### PR TITLE
changing to modern github URI formats 

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -34,7 +34,7 @@ defaultnav:
 #    subdirectory: documentation                    # A subdirectory within the remote repository that contains the documentation files that we'll build and mount at the specified url.
 externalsources:
   /mcollective:
-    repo: git://github.com/puppetlabs/marionette-collective.git
+    repo: git@github.com:choria-legacy/marionette-collective.git
     commit: origin/2.12.x
     subdirectory: website
 

--- a/source/_config_archive.yml
+++ b/source/_config_archive.yml
@@ -39,7 +39,7 @@ defaultnav:
 #    subdirectory: documentation                    # A subdirectory within the remote repository that contains the documentation files that we'll build and mount at the specified url.
 externalsources:
   /mcollective:
-    repo: git://github.com/puppetlabs/marionette-collective.git
+    repo: git@github.com:choria-legacy/marionette-collective.git
     commit: origin/2.12.x
     subdirectory: website
 


### PR DESCRIPTION
The _config.yml and the config_archive.yml reference the Mcollective URLs via the older git:// syntax, and the `bundle exec rake generate` fails. I migrated away from the puppetlabs URL and pointed at the current Mcollective location for these resources. This allows me to move further down the Rakefile to get `bundle exec rake generate` to function as expected.