### PR TITLE
Publish workflow fixup

### DIFF
--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -19,12 +19,18 @@ jobs:
 
   build:
     needs: test
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build.yaml
     with:
       ref: '${{ github.sha }}'
 
   deploy:
     needs: build
+    permissions:
+      id-token: write
+      pages: write
     uses: ./.github/workflows/deploy.yaml
     with:
       tag: '${{ needs.build.outputs.tag }}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: '${{ inputs.ref }}'
           fetch-depth: 1
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Short description

This changeset fixes a couple of issues in the GitHub actions for publishing the docs site. Notably, the `autopublish.yaml` workflow needed to explicitly grant the permissions used by the `build.yaml` and `deploy.yaml` sub-workflows.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
