### PR TITLE
Fix facter CLI doc generation: convert mdoc output via pandoc-ruby

### DIFF
--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -31,8 +31,9 @@ module PuppetReferences
           puts "Encountered an error while building the facter cli docs, will abort: #{err}"
           return
         end
-        content = make_header(header_data) + PREAMBLE +
-                  raw_text.gsub(/SYNOPSIS\n--------\n\s\s(.*?)$/, "SYNOPSIS\n--------\n    \\1")
+        require 'pandoc-ruby'
+        markdown_text = PandocRuby.convert(raw_text, from: :mdoc, to: :commonmark)
+        content = make_header(header_data) + PREAMBLE + markdown_text
         filename = OUTPUT_DIR + 'cli.md'
         filename.open('w') { |f| f.write(content) }
         puts 'CLI documentation is done!'


### PR DESCRIPTION
## Summary

- `facter man` outputs mdoc (BSD man page format), but `build_all` in `facter_cli.rb` was writing the raw troff macros directly into the generated doc, making `/openfact/latest/cli.html` unreadable
- Replace with `PandocRuby.convert(raw_text, from: :mdoc, to: :commonmark)` to produce clean Markdown

## Prerequisite

This PR depends on [OpenVoxProject/openfact#119](https://github.com/OpenVoxProject/openfact/pull/119) being merged first. That fix closes an unclosed `.Bl` list in `man.erb` — without it, `pandoc-ruby`'s strict mdoc parser aborts and CLI doc generation fails entirely.

## Test plan

- [ ] Merge OpenVoxProject/openfact#119 first
- [ ] Run `bundle exec rake references:facter VERSION=<tag>` and verify `references_output/facter/cli.md` contains valid Markdown with proper section headers
- [ ] Copy output to `docs/_openfact_5x/cli.md` and verify page renders correctly at `/openfact/latest/cli.html`

## Linting

```
$ bundle exec rubocop lib/puppet_references/facter/facter_cli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)