### PR TITLE
Cleanup exclude lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,7 @@ AllCops:
     - .vendor/**/*
     - spec/fixtures/**/*
     - externalsources/**/*
-    - output/**/*
-    - _site/vendor/**/*
+    - _site/**/*
 
 Style/StringConcatenation:
   Details: See https://github.com/rubocop/rubocop/issues/9144

--- a/_config.yml
+++ b/_config.yml
@@ -90,4 +90,5 @@ exclude:
   - README.markdown
   - toolchain_walkthrough.markdown
   - util
+  - vendor
   - WORKFLOW.md

--- a/_config.yml
+++ b/_config.yml
@@ -88,7 +88,6 @@ exclude:
   - Rakefile
   - README_WRITING.markdown
   - README.markdown
-  - source
   - toolchain_walkthrough.markdown
   - util
   - WORKFLOW.md


### PR DESCRIPTION
### Short description

This commit cleans up the lists of excluded files for Jekyll in `_config.yml` and Rubocop in `.rubocop.yml` to account for recent removals.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
