### PR TITLE
Fix collection image permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,31 +35,31 @@ collections_dir: docs
 collections:
   openfact_latest:
     output: true
-    permalink: '/openfact/latest/:path.html'
+    permalink: '/openfact/latest/:path:output_ext'
   openfact_5x:
     output: true
-    permalink: '/openfact/5.x/:path.html'
+    permalink: '/openfact/5.x/:path:output_ext'
 
   openvox_latest:
     output: true
-    permalink: '/openvox/latest/:path.html'
+    permalink: '/openvox/latest/:path:output_ext'
   openvox_8x:
     output: true
-    permalink: '/openvox/8.x/:path.html'
+    permalink: '/openvox/8.x/:path:output_ext'
 
   openvox-server_latest:
     output: true
-    permalink: '/openvox-server/latest/:path.html'
+    permalink: '/openvox-server/latest/:path:output_ext'
   openvox-server_8x:
     output: true
-    permalink: '/openvox-server/8.x/:path.html'
+    permalink: '/openvox-server/8.x/:path:output_ext'
 
   openvoxdb_latest:
     output: true
-    permalink: '/openvoxdb/latest/:path.html'
+    permalink: '/openvoxdb/latest/:path:output_ext'
   openvoxdb_8x:
     output: true
-    permalink: '/openvoxdb/8.x/:path.html'
+    permalink: '/openvoxdb/8.x/:path:output_ext'
 
 defaults:
   - scope:


### PR DESCRIPTION
## Summary

- Collection permalinks used a hardcoded `.html` suffix (`:path.html`), which was applied to all files including static assets
- This caused images, GIFs, and SVGs to be output with mangled filenames like `bgtmclassstructure.html.png` instead of `bgtmclassstructure.png`
- Replaced `.html` with `:output_ext` across all 8 collection definitions — Jekyll uses `.html` for rendered documents and preserves the original extension for static files

## Example

On the production site, [bgtm.html](https://docs.openvoxproject.org/openvox/latest/bgtm.html) contains:

```html
<img src="./images/bgtmclassstructure.png" alt="module class structure">
```

The image reference is correct — but Jekyll is outputting the file as `bgtmclassstructure.html.png`, so the browser gets a 404. The markdown never needed fixing; the output filename was wrong.

- **Before:** `_site/openvox/8.x/images/bgtmclassstructure.html.png` (404 on load)
- **After:** `_site/openvox/8.x/images/bgtmclassstructure.png` (correct)

## Affected images (40 total)

- 36 images/GIFs/SVGs under `openvox/8.x/` and `openvox/latest/`
- 2 PNGs under `openvox-server/8.x/` and `openvox-server/latest/`
- 3 PNGs under `openvoxdb/8.x/` and `openvoxdb/latest/`

## Approach note

[`:output_ext`](https://jekyllrb.com/docs/permalinks/#placeholders) is a standard Jekyll permalink placeholder that resolves to the correct output extension for each file type — `.html` for rendered documents, `.png`/`.gif`/`.svg` etc. for static assets. This is the right minimal fix for the bug.

Longer term, moving collection images to a top-level `assets/` directory would be cleaner — static assets don't really belong in collection directories — but that would require updating image references across many markdown files and is a separate concern from this bug.

## Test plan

- [x] Run `bundle exec jekyll build` and verify image files in `_site/` have correct extensions (no `.html.png`)
- [x] Verify HTML pages still render as `.html` (e.g. `_site/openvox/8.x/bgtm.html` exists)
- [x] Check an image-bearing page in browser to confirm images load

🤖 Generated with [Claude Code](https://claude.com/claude-code)