### PR TITLE
Fix facter cli and core_facts generation.

### DIFF
--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -32,7 +32,7 @@ module PuppetReferences
           return
         end
         require 'pandoc-ruby'
-        markdown_text = PandocRuby.convert(raw_text, from: :mdoc, to: :commonmark)
+        markdown_text = PandocRuby.new(raw_text, from: 'man').to_markdown
         content = make_header(header_data) + PREAMBLE + markdown_text
         filename = OUTPUT_DIR + 'cli.md'
         filename.open('w') { |f| f.write(content) }


### PR DESCRIPTION
### Short description

PandocRuby is used, but :mdoc is unknown.

Using man instead

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
