### PR TITLE
Add PDK.markdown stub so PDK links resolve

### DIFF
--- a/PDK.markdown
+++ b/PDK.markdown
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Puppet Development Kit (PDK)
+permalink: /pdk.html
+---
+
+The **Puppet Development Kit (PDK)** is a package of development and testing tools that helps you create, validate, and test Puppet modules.
+
+> **Note:** Puppet (Perforce) ceased open-source maintenance of PDK at version **3.4.0**. Newer versions are distributed from a protected repository requiring either a Puppet Forge API key or a Puppet Enterprise license ID to download; see [Puppet's PDK documentation](https://help.puppet.com/pdk/current/topics/pdk.htm) for details. Documentation for the last open-source release is available in the [pdk repository on GitHub](https://github.com/puppetlabs/pdk/blob/main/docs/pdk.md).
+
+## Overview
+
+PDK provides a standard set of tools and workflows for developing Puppet modules, including:
+
+- Module scaffolding and structure validation
+- Unit testing with rspec-puppet
+- Acceptance testing with Litmus
+- Metadata validation
+
+## Compatibility with OpenVox
+
+OpenVox is compatible with PDK **3.4.0** and earlier for module development workflows. The last open-source release can be found in the [pdk repository on GitHub](https://github.com/puppetlabs/pdk).
+
+## Open source alternatives
+
+The OpenVox community maintains tooling that replaces PDK workflows without requiring a commercial Puppet account:
+
+- **[VoxBox](https://github.com/voxpupuli/container-voxbox)** — A container image maintained by Vox Pupuli that includes rspec-puppet, Litmus, RuboCop, and other testing gems. It is the recommended way to run unit and acceptance tests for OpenVox modules in CI and local development.
+- **[jig](https://github.com/avitacco/jig)** — A Go-based reimplementation of PDK. Ships as a single static binary with no Ruby runtime dependency and supports module scaffolding, building, and releasing.


### PR DESCRIPTION
## Summary

- Five docs pages (`bgtm.md`, `modules_fundamentals.markdown`, `modules_documentation.markdown`, `modules_publishing.markdown`, `modules_installing.markdown`) define `[pdk]: {{pdk}}/pdk.html` as a link reference
- `{{pdk}}` resolves to an empty string, so all these links pointed to `/pdk.html`, which 404'd
- Adds `PDK.markdown` at the repo root with `permalink: /pdk.html`, noting that Puppet/Perforce ceased open-source PDK maintenance at version 3.4.0 and linking to both the OSS docs and Puppet's current (credential-gated) PDK docs

## Test plan

- [x] `bundle exec jekyll build` produces `_site/pdk.html`
- [x] Links in the five affected pages no longer 404
- [x] Stub page renders correctly with the default layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)