### PR TITLE
Add OpenVox 8.26.2 release notes

### DIFF
--- a/docs/_openvox_8x/known_issues.md
+++ b/docs/_openvox_8x/known_issues.md
@@ -1,7 +1,13 @@
 ---
 layout: default
 toc_levels: 1234
-title: "OpenVox 8.25 known issues"
+title: "OpenVox 8 known issues"
 ---
 
-As known issues are discovered in OpenVox 8.25 and its patch releases, they'll be added to the [project's issue tracker](https://github.com/OpenVoxProject/openvox/issues). Once a known issue is resolved, it is listed as a resolved issue in the release notes for that release, and removed from this list.
+As known issues are discovered in OpenVox 8 and its patch releases, they'll be added to the [project's issue tracker](https://github.com/OpenVoxProject/openvox/issues). Once a known issue is resolved, it is listed as a resolved issue in the release notes for that release, and removed from this list.
+
+## OpenVox 8.26.2
+
+### `openvox --version` reports 8.26.1
+
+After installing `openvox-agent` 8.26.2, running `puppet --version` reports `8.26.1` instead of `8.26.2`. The agent itself is at the correct version; only the version string returned by `--version` is incorrect. See [issue #415](https://github.com/OpenVoxProject/openvox/issues/415).

--- a/docs/_openvox_8x/release_notes.markdown
+++ b/docs/_openvox_8x/release_notes.markdown
@@ -18,6 +18,14 @@ Puppet Open Source is no longer actively developed.
 
 You can either upgrade to Puppet 7 and then switch to OpenVox 7 and then upgrade to OpenVox 8, or you can upgrade to Puppet 8 and then migrate to OpenVox 8.
 
+## OpenVox 8.26.2
+
+Released April 18, 2026.
+
+This is a bug-fix and security release of OpenVox.
+
+All bug fixes, new features and other changes are provided on the [project's github release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.26.2).
+
 ## OpenVox 8.26.1
 
 Released April 16, 2026.


### PR DESCRIPTION
Adds release notes entry for OpenVox 8.26.2 (released April 18, 2026), linking to the [GitHub release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.26.2).