### PR TITLE
Restore Hiera intro and config yaml 5 pages from Puppet 5.4 archive

### DIFF
--- a/docs/_openvox_8x/hiera_config_yaml_3.md
+++ b/docs/_openvox_8x/hiera_config_yaml_3.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Hiera: Legacy config file syntax (hiera.yaml v3)"
 ---
 

--- a/docs/_openvox_8x/hiera_config_yaml_4.md
+++ b/docs/_openvox_8x/hiera_config_yaml_4.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Hiera: Legacy config file syntax (hiera.yaml v4)"
 ---
 

--- a/docs/_openvox_8x/hiera_config_yaml_5.md
+++ b/docs/_openvox_8x/hiera_config_yaml_5.md
@@ -1,11 +1,367 @@
 ---
+layout: default
 title: "Configuring Hiera"
 ---
 
+[hierarchy]: ./hiera_intro.html#hiera-hierarchies
+[layers]: ./hiera_intro.html#hieras-three-config-layers
+[confdir]: ./dirs_confdir.html
+[module]: ./modules_fundamentals.html
+[yaml]: http://www.yaml.org/YAML_for_ruby.html
+[variables]: ./hiera_merging.html#interpolating-variables
+[interpolation]: ./hiera_interpolation.html
+[eyaml]: https://github.com/voxpupuli/hiera-eyaml
+[custom puppet function]: ./functions_basics.html
+[backends]: ./hiera_custom_backends.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+The Hiera configuration file is called hiera.yaml. It configures the hierarchy for a given layer of data.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+Related topics: [hierarchy][hierarchy], [layers][layers].
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+## Location of hiera.yaml files
 
+There are several hiera.yaml files in a typical deployment. Hiera uses three layers of configuration, and the module and environment layers typically have multiple instances.
+
+The configuration file locations for each layer:
+
+Layer       | Location                                        | Example
+------------|-------------------------------------------------|--------
+Global      | [`$confdir`][confdir]`/hiera.yaml`              | `/etc/puppetlabs/puppet/hiera.yaml` `C:\ProgramData\PuppetLabs\puppet\etc\hiera.yaml`
+Environment | [`<ENVIRONMENT>`](./environments_about.html)`/hiera.yaml` | `/etc/puppetlabs/code/environments/production/hiera.yaml` `C:\ProgramData\PuppetLabs\code\environments\production\hiera.yaml`
+Module      | [`<MODULE>`][module]`/hiera.yaml`               | `/etc/puppetlabs/code/environments/production/modules/ntp/hiera.yaml` `C:\ProgramData\PuppetLabs\code\environments\production\modules\ntp\hiera.yaml`
+
+> Note: You can change the location for the global layer's hiera.yaml with OpenVox's `hiera_config` setting.
+
+Hiera searches for data in the following order: global → environment → module. For more information, see [Hiera configuration layers][layers].
+
+Related topics: [$confdir][confdir], [`<MODULE>`][module].
+
+## Config file syntax (hiera.yaml v5)
+
+`hiera.yaml` is a YAML file, containing a hash with up to four top-level keys:
+
+-   `version` - Required. Must be the number 5, with no quotes.
+-   `hierarchy` - An array of hashes, which configures the levels of the hierarchy.
+-   `default_hierarchy` - An array of hashes, which sets a default hierarchy to be used only if the normal hierarchy entries do not result in a value. Only allowed in a module's hiera.yaml.
+-   `defaults` - A hash, which can set a default datadir, backend, and options for hierarchy levels.
+
+```yaml
+---
+version: 5
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: "Per-node data"                   # Unique human-readable name.
+    path: "nodes/%{trusted.certname}.yaml"  # File path, relative to datadir.
+                                   # ^^^ IMPORTANT: include the file extension!
+
+  - name: "Per-datacenter business group data" # Uses custom facts.
+    path: "location/%{facts.whereami}/%{facts.group}.yaml"
+
+  - name: "Global business group data"
+    path: "groups/%{facts.group}.yaml"
+
+  - name: "Per-datacenter secret data (encrypted)"
+    lookup_key: eyaml_lookup_key   # Uses non-default backend.
+    path: "secrets/%{facts.whereami}.eyaml"
+    options:
+      pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+      pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+
+  - name: "Per-OS defaults"
+    path: "os/%{facts.os.family}.yaml"
+
+  - name: "Common data"
+    path: "common.yaml"
+```
+
+Related topics: [YAML][yaml]
+
+### The default configuration
+
+If you omit the `hierarchy` or `defaults` keys, Hiera uses the following default values:
+
+```yaml
+---
+version: 5
+hierarchy:
+  - name: Common
+    path: common.yaml
+defaults:
+  data_hash: yaml_data
+  datadir: data
+```
+
+These defaults are only used if the file is present and specifies `version: 5`. If hiera.yaml is absent, it disables Hiera for that layer. If it specifies a different version, different defaults apply.
+
+## The defaults key
+
+The `defaults` key sets default values for the lookup function and `datadir` keys, which lets you omit those keys in your hierarchy levels.
+
+The value of `defaults` must be a hash, which can have up to three keys: `datadir`, `options`, and one of the mutually exclusive lookup function keys.
+
+### datadir
+
+A default value for `datadir`, used for any file-based hierarchy level that doesn't specify its own. If not given, the `datadir` is the directory `data` in the same directory as the `hiera.yaml` configuration file.
+
+### options
+
+A default value for options, used for any hierarchy level that does not specify its own.
+
+### The lookup function keys
+
+Used for any hierarchy level that doesn't specify its own. This must be one of:
+
+-   `data_hash` - produces a hash of key-value pairs (typically from a data file)
+-   `lookup_key` - produces values key by key (typically for a custom data provider)
+-   `data_dig` - produces values key by key (for a more advanced data provider)
+-   `hiera3_backend` - a data provider that calls out to a legacy Hiera 3 backend (global layer only)
+
+For the built-in data providers - YAML, JSON, and HOCON - the key is always `data_hash` and the value is one of `yaml_data`, `json_data`, or `hocon_data`. To set a custom data provider as the default, see the data provider documentation. Whichever key you use, the value must be the name of the custom OpenVox function that implements the lookup function.
+
+Related topics: [custom backends][backends], [custom OpenVox function][custom puppet function].
+
+## The hierarchy key
+
+The `hierarchy` key configures the levels of the hierarchy.
+
+## The default_hierarchy key
+
+The `default_hierarchy` key is a top-level key. It works exactly like the hierarchy key, but its values are used only if the normal hierarchy entries in the same module, or any of the higher precedence layers (environment or global) does not result in a value. Within this default hierarchy, the normal merging rules apply. However, the `default_hierarchy` is not permitted in environment or global layers.
+
+Related topics: [hierarchies][hierarchy].
+
+## The hierarchy key: write an array of hashes
+
+The value of `hierarchy` must be an array of hashes.
+
+1.  Begin each level of the hierarchy with:
+
+    -   Two spaces of indentation.
+    -   A hyphen (`-`).
+    -   Another space after the hyphen.
+    -   The first key of that level's hash.
+
+2.  Indent the rest of the hash's keys by four spaces, so they line up with the first key.
+
+3.  Put an empty line between hashes, to visually distinguish them.
+
+    ```yaml
+    hierarchy:
+      - name: "Per-node data"
+        path: "nodes/%{trusted.certname}.yaml"
+
+      - name: "Per-datacenter business group data"
+        path: "location/%{facts.whereami}/%{facts.group}.yaml"
+    ```
+
+## Configuring a hierarchy level: built-in backends
+
+Hiera has three built-in backends: YAML, JSON, and HOCON. All of these use files as data sources.
+
+You can use any combination of these backends in a hierarchy, and can also combine them with custom backends. But if most of your data is in one file format, set default values for the `datadir` and `data_hash` keys.
+
+Each YAML/JSON/HOCON hierarchy level needs the following keys:
+
+-   `name` — A unique name for this level, shown in debug messages and `--explain` output.
+-   `path`, `paths`, `glob`, `globs`, or `mapped_paths` (choose one) — The data files to use for this hierarchy level.
+    -   These paths are relative to the datadir, they support variable interpolation, and they require a file extension. See "Specifying file paths" for more details.
+-   `data_hash` — Which backend to use. Can be omitted if you set a default. The value must be one of the following:
+    -   `yaml_data` for YAML.
+    -   `json_data` for JSON.
+    -   `hocon_data` for HOCON.
+-   `datadir` — The directory where data files are kept. Can be omitted if you set a default.
+    -   This path is relative to hiera.yaml's directory: if the config file is at `/etc/puppetlabs/code/environments/production/hiera.yaml` and the datadir is set to data, the full path to the data directory is `/etc/puppetlabs/code/environments/production/data`.
+    -   In the global layer, you can optionally set the datadir to an absolute path; in the other layers, it must always be relative.
+
+Related topics: [variable interpolation][variables], [YAML][yaml].
+
+### Specifying file paths
+
+Options for specifying a file path:
+
+Key     | Data type | Expected value
+--------|-----------|---------------
+`path`  | String    | One file path.
+`paths` | Array     | Any number of file paths. This acts like a sub-hierarchy: if multiple files exist, Hiera searches all of them, in the order in which they're written.
+`glob`  | String    | One shell-like glob pattern, which might match any number of files. If multiple files are found, Hiera searches all of them in alphanumerical order.
+`globs` | Array     | Any number of shell-like glob patterns. If multiple files are found, Hiera searches all of them in alphanumerical order (ignoring the order of the globs).
+`mapped_paths` | Array or Hash | A fact that is a collection (array or hash) of values. Hiera expands these values to produce an array of paths.
+
+> Note: You can only use one of these keys in a given hierarchy level.
+
+Explicit file extensions are required, for example, `common.yaml`, not `common`.
+
+File paths are relative to the `datadir`: if the full datadir is `/etc/puppetlabs/code/environments/production/data` and the file path is set to `"nodes/%{trusted.certname}.yaml"`, the full path to the file is `/etc/puppetlabs/code/environments/production/data/nodes/<NODE NAME>.yaml`.
+
+> Note: Hierarchy levels should interpolate variables into the path.
+
+Globs are implemented with Ruby's `Dir.glob` method:
+
+-   One asterisk (`*`) matches a run of characters.
+-   Two asterisks (`**`) matches any depth of nested directories.
+-   A question mark (`?`) matches one character.
+-   Comma-separated lists in curly braces (`{one,two}`) match any option in the list.
+-   Sets of characters in square brackets (`[abcd]`) match any character in the set.
+-   A backslash (`\`) escapes special characters.
+
+Example:
+
+{% raw %}
+
+```yaml
+- name: "Domain or network segment"
+  glob: "network/**/{%{facts.networking.domain},%{facts.networking.interfaces.en0.bindings.0.network}}.yaml"
+```
+
+{% endraw %}
+
+The `mapped_paths` key must contain three string elements, in the following order:
+
+-   A scope variable that points to a collection of strings.
+-   The variable name that will be mapped to each element of the collection.
+-   A template where that variable can be used in interpolation expressions.
+
+For example, a fact named `$services` contains the array `["a", "b", "c"]`. The following configuration has the same results as if paths had been specified to be `[service/a/common.yaml, service/b/common.yaml, service/c/common.yaml]`.
+
+```yaml
+- name: Example
+  mapped_paths: [services, tmp, "service/%{tmp}/common.yaml"]
+```
+
+Related topics: [interpolate][interpolation], [hierarchies][hierarchy].
+
+## Configuring a hierarchy level: hiera-eyaml
+
+Hiera 5 includes a native interface for the Hiera eyaml extension, which keeps data encrypted on disk but lets OpenVox read it during catalog compilation.
+
+To learn how to create keys and edit encrypted files, see the [Hiera eyaml documentation](https://github.com/voxpupuli/hiera-eyaml).
+
+Within `hiera.yaml`, the eyaml backend resembles the standard built-in backends, with a few differences: it uses `lookup_key` instead of `data_hash`, and requires an `options` key to locate decryption keys. Note that the eyaml backend can read regular yaml files as well as yaml files with encrypted data.
+
+> **Important**: To use the eyaml backend, you must have the `hiera-eyaml` gem installed where OpenVox can use it. To enable eyaml on the command line and with `puppet apply`, use `sudo /opt/puppetlabs/puppet/bin/gem install hiera-eyaml`.
+
+Each eyaml hierarchy level needs the following keys:
+
+-   `name` — A unique name for this level, shown in debug messages and `--explain` output.
+-   `lookup_key` — Which backend to use. The value must be `eyaml_lookup_key`. Use this instead of the `data_hash` setting.
+-   `path`, `paths`, `mapped_paths`, `glob`, or `globs` (choose one) — The data files to use for this hierarchy level. These paths are relative to the datadir, they support variable interpolation, and they require a file extension. In this case, you'll usually use `.eyaml`. They work the same way they do for the standard backends.
+-   `datadir` — The directory where data files are kept. Can be omitted if you set a default. Works the same way it does for the standard backends.
+-   `options` — A hash of options specific to `hiera-eyaml`, mostly used to configure decryption. For the default encryption method, this hash must have the following keys:
+    -   `pkcs7_private_key` — The location of the PKCS7 private key to use.
+    -   `pkcs7_public_key` — The location of the PKCS7 public key to use.
+    -   If you use an alternate encryption plugin, its docs should specify which options to set. Set an `encrypt_method` option, plus some plugin-specific options to replace the `pkcs7` ones.
+    -   You can use normal strings as keys in this hash; you don't need to use symbols.
+
+The file path key and the options key both support variable interpolation.
+
+An example hierarchy level:
+
+```yaml
+hierarchy:
+  - name: "Per-datacenter secret data (encrypted)"
+    lookup_key: eyaml_lookup_key
+    path: "secrets/%{facts.whereami}.eyaml"
+    options:
+      pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+      pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+```
+
+Related topics: [Hiera eyaml][eyaml], [variable interpolation][interpolation].
+
+## Configuring a hierarchy level: legacy Hiera 3 backends
+
+> Note: This feature is a temporary measure to let you start using new features while waiting for backend updates.
+
+If you rely on custom data backends designed for Hiera 3, you can use them in your global hierarchy. They are not supported at the environment or module layers.
+
+Each legacy hierarchy level needs the following keys:
+
+-   `name` — A unique name for this level, shown in debug messages and `--explain` output.
+-   `path` or `paths` (choose one) — The data files to use for this hierarchy level.
+    -   For file-based backends, include the file extension, even though you would have omitted it in the v3 hiera.yaml file.
+    -   For non-file backends, don't use a file extension.
+-   `hiera3_backend` — The legacy backend to use. This is the same name you'd use in the v3 config file's `:backends` key.
+-   `datadir` — The directory where data files are kept. Set this only if your backend required a `:datadir` setting in its backend-specific options.
+    -   This path is relative to hiera.yaml's directory: if the config file is at `/etc/puppetlabs/code/environments/production/hiera.yaml` and the datadir is set to `data`, the full path to the data directory is `/etc/puppetlabs/code/environments/production/data`. Note that Hiera v3 uses 'hieradata' instead of 'data'.
+    -   In the global layer, you can optionally set the datadir to an absolute path.
+-   `options` — A hash, with any backend-specific options (other than `datadir`) required by your backend. In the v3 config, this would have been in a top-level key named after the backend.
+
+You can use normal strings as keys. Hiera converts them to symbols for the backend.
+
+The following example shows roughly equivalent v3 and v5 hiera.yaml files using legacy backends:
+
+```yaml
+# hiera.yaml v3
+---
+:backends:
+  - mongodb
+  - xml
+
+:mongodb:
+  :connections:
+    :dbname: hdata
+    :collection: config
+    :host: localhost
+
+:xml:
+  :datadir: /some/other/dir
+
+:hierarchy:
+  - "%{trusted.certname}"
+  - "common"
+
+
+# hiera.yaml v5
+---
+version: 5
+hierarchy:
+  - name: MongoDB
+    hiera3_backend: mongodb
+    paths:
+      - "%{trusted.certname}"
+      - common
+    options:
+      connections:
+        dbname: hdata
+        collection: config
+        host: localhost
+
+  - name: Data in XML
+    hiera3_backend: xml
+    datadir: /some/other/dir
+    paths:
+      - "%{trusted.certname}.xml"
+      - common.xml
+```
+
+## Configuring a hierarchy level: general format
+
+Hiera supports custom backends.
+
+See the backend's documentation for configuring hierarchy levels.
+
+Each hierarchy level is represented by a hash which needs the following keys:
+
+-   `name` — A unique name for this level, shown in debug messages and `--explain` output.
+-   A backend key, which must be one of:
+    -   `data_hash`
+    -   `lookup_key`
+    -   `data_dig` - a more specialized form of `lookup_key`, suitable when the backend is for a database. `data_dig` resolves dot separated keys, whereas `lookup_key` does not.
+    -   `hiera3_backend` (global layer only)
+-   A path or URI key - only if required by the backend. These keys support variable interpolation. The following path/URI keys are available:
+    -   `path`
+    -   `paths`
+    -   `mapped_paths`
+    -   `glob`
+    -   `globs`
+    -   `uri`
+    -   `uris` - these paths or URIs work the same way they do for the built-in backends. Hiera handles the work of locating files, so any backend that supports `path` automatically supports `paths`, `glob`, and `globs`. `uri` (string) and `uris` (array) can represent any kind of data source. Hiera does not ensure URIs are resolvable before calling the backend, and does not need to understand any given URI schema. A backend can omit the path/URI key, and rely wholly on the `options` key to locate its data.
+-   `datadir` — The directory where data files are kept: the path is relative to hiera.yaml's directory. Only required if the backend uses the `path`, `paths`, `glob`, and `globs` keys, and can be omitted if you set a default.
+-   `options` — A hash of extra options for the backend; for example, database credentials or the location of a decryption key. All values in the `options` hash support variable interpolation.
+
+Whichever key you use, the value must be the name of a function that implements the backend API. Note that the choice here is made by the implementer of the particular backend, not the user.
+
+Related topics: [custom OpenVox function][custom puppet function], [custom backends][backends], [variable interpolation][interpolation].

--- a/docs/_openvox_8x/hiera_intro.md
+++ b/docs/_openvox_8x/hiera_intro.md
@@ -1,11 +1,159 @@
 ---
+layout: default
 title: "Hiera"
 ---
 
+[auto_lookup]: ./hiera_automatic.html#class-parameters
+[codedir]: ./dirs_codedir.html
+[confdir]: ./dirs_confdir.html
+[v3]: ./hiera_config_yaml_3.html
+[v4]: ./hiera_config_yaml_4.html
+[v5]: ./hiera_config_yaml_5.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+Hiera is a key/value lookup used for separating data from OpenVox code.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+## About Hiera
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+Hiera is OpenVox's built-in key-value configuration data lookup system.
 
+OpenVox's strength is in reusable code. Code that serves many needs must be configurable: put site-specific information in external configuration data files, rather than in the code itself.
+
+OpenVox uses Hiera to do two things:
+
+* Store the configuration data in key-value pairs
+* Look up what data a particular module needs for a given node during catalog compilation.
+
+This is done via:
+
+* Automatic Parameter Lookup for classes included in the catalog
+* Explicit lookup calls
+
+Hiera's hierarchical lookups follow a "defaults, with overrides" pattern, meaning you specify common data once, and override it in situations where the default won't work. Hiera uses OpenVox's facts to specify data sources, so you can structure your overrides to suit your infrastructure. While using facts for this purpose is common, data-sources may well be defined without the use of facts.
+
+Hiera 5 comes with support for JSON, YAML, and EYAML files.
+
+Related topics: [Automatic Parameter Lookup][auto_lookup]
+
+## Hiera hierarchies
+
+Hiera looks up data by following a hierarchy - an ordered list of data sources.
+
+Hierarchies are configured in a `hiera.yaml` configuration file. Each level of the hierarchy tells Hiera how to access some kind of data source.
+
+### Hierarchies interpolate variables
+
+Most levels of a hierarchy interpolate variables into their configuration:
+
+`path: "os/%{facts.os.family}.yaml"`
+
+* The percent-and-braces `%{variable}` syntax is a Hiera interpolation token. It is similar to the OpenVox language's `${expression}` interpolation tokens. Wherever you use an interpolation token, Hiera determines the variable's value and inserts it into the hierarchy.
+* `facts.os.family` uses the Hiera special `key.subkey` notation for accessing elements of hashes and arrays. It is equivalent to `$facts['os']['family']` in the OpenVox language but the 'dot' notation will produce an empty string instead of raising an error if parts of the data is missing. Make sure that an empty interpolation does not end up matching an unintended path.
+* You can only interpolate values into certain parts of the config file. For more info, see the hiera.yaml format reference.
+* With node-specific variables, each node gets a customized set of paths to data. The hierarchy is always the same.
+
+### Hiera searches the hierarchy in order
+
+Once Hiera replaces the variables to make a list of concrete data sources, it checks those data sources in the order they were written. Generally, if a data source doesn't exist, or doesn't specify a value for the current key, Hiera skips it and moves on to the next source, until it finds one that exists - then it uses it. Note that this is the default merge strategy, but does not always apply, for example, Hiera can use data from all data sources and merge the result.
+
+Earlier data sources have priority over later ones. In the example above, the node-specific data has the highest priority, and can override data from any other level. Business group data is separated into local and global sources, with the local one overriding the global one. Common data used by all nodes always goes last.
+
+That's how Hiera's "defaults, with overrides" approach to data works - you specify common data at lower levels of the hierarchy, and override it at higher levels for groups of nodes with special needs.
+
+### Layered hierarchies
+
+Hiera uses layers of data with a `hiera.yaml` for each layer.
+
+Each layer can configure its own independent hierarchy. Before a lookup, Hiera combines them into a single super-hierarchy: global → environment → module.
+
+> Note: There is a fourth layer - `default_hierarchy` - that can be used in a module's `hiera.yaml`. It only comes into effect when there is no data for a key in any of the other regular hierarchies
+
+Assume the example above is an environment hierarchy (in the production environment). If we also had the following global hierarchy:
+
+```yaml
+version: 5
+hierarchy:
+  - name: "Data exported from our old self-service config tool"
+    path: "selfserve/%{trusted.certname}.json"
+    data_hash: json_data
+    datadir: data
+```
+
+And the NTP module had the following hierarchy for default data:
+
+```yaml
+version: 5
+hierarchy:
+  - name: "OS values"
+    path: "os/%{facts.os.name}.yaml"
+  - name: "Common values"
+    path: "common.yaml"
+defaults:
+  data_hash: yaml_data
+  datadir: data
+```
+
+Then in a lookup for the `ntp::servers` key, `thrush.example.com` would use the following combined hierarchy:
+
+* `<CODEDIR>/data/selfserve/thrush.example.com.json`
+* `<CODEDIR>/environments/production/data/nodes/thrush.example.com.yaml`
+* `<CODEDIR>/environments/production/data/location/belfast/ops.yaml`
+* `<CODEDIR>/environments/production/data/groups/ops.yaml`
+* `<CODEDIR>/environments/production/data/os/Debian.yaml`
+* `<CODEDIR>/environments/production/data/common.yaml`
+* `<CODEDIR>/environments/production/modules/ntp/data/os/Ubuntu.yaml`
+* `<CODEDIR>/environments/production/modules/ntp/data/common.yaml`
+
+The combined hierarchy works the same way as a layer hierarchy. Hiera skips empty data sources, and either returns the first found value or merges all found values.
+
+> Note: By default, datadir refers to the directory named 'data' next to the `hiera.yaml`.
+
+### Tips for making a good hierarchy
+
+* Make a short hierarchy. Data files will be easier to work with.
+* Use the roles and profiles method to manage less data in Hiera. Sorting hundreds of class parameters is easier than sorting thousands.
+* If the built-in facts don't provide an easy way to represent differences in your infrastructure, make custom facts. For example, create a custom datacenter fact that is based on information particular to your network layout so that each datacenter is uniquely identifiable.
+* Give each environment -- production, test, development -- its own hierarchy.
+
+Related topics: [codedir][codedir], [confdir][confdir], [hiera.yaml][v5]
+
+## Hiera's three config layers
+
+Hiera uses three independent layers of configuration. Each layer has its own hierarchy, and they're linked into one super-hierarchy before doing a lookup.
+
+The three layers are searched in the following order: global → environment → module. Hiera searches every data source in the global layer's hierarchy before checking any source in the environment layer.
+
+### The global layer
+
+* The configuration file for the global layer is located, by default, in `$confdir/hiera.yaml`. You can change the location by changing the `hiera_config` setting in `puppet.conf`.
+* Hiera has one global hierarchy. Since it goes before the environment layer, it's useful for temporary overrides, for example, when your ops team needs to bypass its normal change processes.
+* The global layer is the only place where legacy Hiera 3 backends can be used - it's an important piece of the transition period when you migrate your backends to support Hiera 5.
+* The global layer supports the following config formats: hiera.yaml v5, hiera.yaml v3 (deprecated).
+* Other than the above use cases, try to avoid the global layer. All normal data should be specified in the environment layer.
+
+### The environment layer
+
+* The configuration file for the environment layer is located, by default, at `<ENVIRONMENT DIR>/hiera.yaml`.
+* The environment layer is where most of your Hiera data hierarchy definition happens.
+* Every OpenVox environment has its own hierarchy configuration, which applies to nodes in that environment.
+* Supported config formats: hiera.yaml v5, hiera.yaml v3 (deprecated).
+
+### The module layer
+
+* The configuration file for a module layer is located, by default, in a module's `<MODULE>/hiera.yaml`.
+* The module layer sets default values and merge behavior for a module's class parameters. It is a convenient alternative to the `params.pp` pattern.
+  * Note that to get the exact same behaviour as params.pp, the default_hierarchy should be used, as those bindings are excluded from merges. When placed in the regular hierarchy in the module's hierarchy the bindings will be merged when a merge lookup is performed.
+* The module layer comes last in Hiera's lookup order, so environment data set by a user overrides the default data set by the module's author.
+* Every module can have its own hierarchy configuration. You can only bind data for keys in the module's namespace. For example:
+
+| Lookup key        | Relevant module hierarchy |
+| ----------------- |:-------------------------:|
+| `ntp::servers`    | `ntp`                     |
+| `jenkins::port`   | `jenkins`                 |
+| `secure_server`   | `(none)`                  |
+
+* Hiera uses the `ntp` module's hierarchy when looking up `ntp::servers`, but uses the `jenkins` module's hierarchy when looking up `jenkins::port`. Hiera never checks the `ntp` module for a key beginning with `jenkins::`.
+* When you use the lookup function for keys that don't have a namespace (for example, `secure_server`), the module layer is not consulted.
+
+The three-layer system means that each environment has its own hierarchy, and so do modules. You can make hierarchy changes on an environment-by-environment basis. Module data is also customizable.
+
+Related topics: [version 3][v3], [version 4][v4], [version 5][v5]


### PR DESCRIPTION
## Summary

Several Hiera pages were reduced to placeholder stubs in the original Puppet docs repo. This PR restores them to a functional baseline using content from puppetlabs/docs-archive (puppet/5.4), with minimal changes to adapt them for OpenVox.

**Scope:** This is a baseline restoration only — the goal is to get real content on the page rather than a stub. Accuracy review, technical updates, and deeper content work are out of scope for this PR.

Changes made:

- Restore `hiera_intro.md` and `hiera_config_yaml_5.md` from stub placeholders to full content
- Add `layout: default` to `hiera_config_yaml_3.md` and `hiera_config_yaml_4.md` so they render with the site theme
- Replace Puppet product name references with OpenVox
- Remove `{:.concept}`, `{:.reference}`, and `{:.task}` markers
- Fix broken `{{facter}}` variable references and `puppet.com` external links to local pages
- Fix Liquid syntax error in glob example

## Test plan

- [x] Pages render with full theme and sidebar
- [x] Site builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)