### PR TITLE
Restore remaining Hiera 5 pages from Puppet 5.4 archive

### DIFF
--- a/docs/_openvox_8x/hiera_automatic.md
+++ b/docs/_openvox_8x/hiera_automatic.md
@@ -1,11 +1,246 @@
 ---
+layout: default
 title: "Looking up data with Hiera"
 ---
 
+[data_type]: ./lang_data_type.html
+[editing_data]: ./hiera_merging.html
+[merging]: ./hiera_merging.html#merge-behaviors
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+## Class parameters
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+OpenVox looks up the values for class parameters in Hiera, using the fully-qualified name of the parameter (`myclass::parameter_one`) as a lookup key.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+Most classes need configuration, and you can specify them as parameters to a class. This will look up the needed data if not directly given when the class is included in a catalog.
+There are several ways OpenVox sets values for class parameters, in this order:
 
+1. If you're doing a resource-like declaration, OpenVox uses parameters that are explicitly set (if explicitly setting `undef`, a looked-up value or default will be used).
+
+2. OpenVox uses Hiera, using `<CLASS NAME>::<PARAMETER NAME>` as the lookup key. For example, it looks up `ntp::servers` for the `ntp` class's `$servers` parameter.
+
+3. If a parameter still has no value, OpenVox uses the default value from the parameter's default value expression in the class's definition.
+
+4. If any parameters have no value and no default, OpenVox fails compilation with an error.
+
+For example, you can set servers for the `NTP` class like this:
+
+```yaml
+# /etc/puppetlabs/code/production/data/nodes/web01.example.com.yaml
+---
+ntp::servers:
+  - time.example.com
+  - 0.pool.ntp.org
+```
+
+> Note: The best way to manage this is to use the roles and profiles method, which allows you to store a smaller amount of more meaningful data in Hiera.
+
+## Puppet lookup
+
+The `lookup` function uses Hiera to retrieve a value for a given key.
+
+By default, the lookup function returns the first value found and fails compilation if no values are available. You can also configure the lookup function to merge multiple values into one.
+
+When looking up a key, Hiera searches up to four hierarchy layers of data, in the following order:
+
+1. Global hierarchy.
+2. The current environment's hierarchy.
+3. The indicated module's hierarchy, if the key is of the form `<MODULE NAME>::<SOMETHING>`.
+4. If not found and the module's hierarchy has a `default_hierarchy` entry in its `hiera.yaml` — the lookup is repeated if steps 1–3 did not produce a value.
+
+> Note: Hiera checks the global layer before the environment layer. If no global `hiera.yaml` file has been configured, Hiera defaults are used.
+> If you do not want it to use the defaults, you can create an empty `hiera.yaml` file in `/etc/puppetlabs/puppet/hiera.yaml`.
+
+### Arguments
+
+You must provide the name of a key to look up, and can optionally provide other arguments. You can combine these arguments in the following ways:
+
+- `lookup( <NAME>, [<VALUE TYPE>], [<MERGE BEHAVIOR>], [<DEFAULT VALUE>] )`
+- `lookup( [<NAME>], <OPTIONS HASH> )`
+- `lookup( as above ) |$key| { <VALUE> }` — lambda returns a default value
+
+Arguments in `[square brackets]` are optional.
+
+> Note: Giving a hash of options containing `default_value` at the same time as giving a lambda means that the lambda will win.
+> A `default_values_hash` wins over the lambda if it has a value for the looked-up key.
+
+### Merge behaviors
+
+Hiera uses a hierarchy of data sources, and a given key can have values in multiple sources.
+By default (unless you use one of the merge strategies) it is priority/"first found wins", in which case the search ends as soon as a value is found.
+
+> Note: Data sources can use the `lookup_options` metadata key to request a specific merge behavior for a key. The lookup function will use that requested behavior unless you specify one.
+
+### Examples
+
+Look up a key and return the first value found:
+
+```puppet
+lookup('ntp::service_name')
+```
+
+A unique merge lookup of class names, then adding all of those classes to the catalog:
+
+```puppet
+lookup('classes', Array[String], 'unique').include
+```
+
+A deep hash merge lookup of user data, letting higher priority sources remove values by prefixing them with `--`:
+
+```puppet
+lookup( { 'name'  => 'users',
+          'merge' => {
+            'strategy'        => 'deep',
+            'knockout_prefix' => '--',
+          },
+})
+```
+
+## Arguments accepted by lookup
+
+You must provide the key's name. The other arguments are optional.
+
+- `<NAME>` (String or Array) — The name of the key to look up. This can also be an array of keys.
+  If Hiera doesn't find anything for the first key, it tries with the subsequent ones, only resorting to a default value if none of them succeed.
+- `<VALUE TYPE>` (data Type) — A data type that must match the retrieved value; if not, the lookup (and catalog compilation) will fail. Defaults to `Data` which accepts any normal value.
+- `<MERGE BEHAVIOR>` (String or Hash; see [Merge behaviors][merging]) — Whether and how to combine multiple values. If present, this overrides any merge behavior specified in the data sources.
+  Defaults to no value; Hiera will use merge behavior from the data sources if present, and will otherwise do a first-found lookup.
+- `<DEFAULT VALUE>` (any normal value) — If present, lookup returns this when it can't find a normal value. Default values are never merged with found values.
+  Like a normal value, the default must match the value type.
+  Defaults to no value; if Hiera can't find a normal value, the lookup (and compilation) will fail.
+- `<OPTIONS HASH>` (Hash) — Alternate way to set the arguments above, plus some less common additional options.
+  If you pass an options hash, you can't combine it with any regular arguments (except `<NAME>`). An options hash can have the following keys:
+  - `'name'` — Same as `<NAME>` (argument 1). You can pass this as an argument or in the hash, but not both.
+  - `'value_type'` — Same as `<VALUE TYPE>`.
+  - `'merge'` — Same as `<MERGE BEHAVIOR>`.
+  - `'default_value'` — Same as `<DEFAULT VALUE>`.
+  - `'default_values_hash'` (Hash) — A hash of lookup keys and default values. If Hiera can't find a normal value, it will check this hash for the requested key before giving up.
+    You can combine this with `default_value` or a lambda, which will be used if the key isn't present in this hash. Defaults to an empty hash.
+  - `'override'` (Hash) — A hash of lookup keys and override values. OpenVox will check for the requested key in the overrides hash first.
+    If found, it returns that value as the final value, ignoring merge behavior. Defaults to an empty hash.
+  - `lookup` can take a lambda, which must accept a single parameter. This is yet another way to set a default value for the lookup;
+    if no results are found, OpenVox will pass the requested key to the lambda and use its result as the default value.
+
+Related topics: [Data type][data_type].
+
+## Using puppet lookup
+
+The `puppet lookup` command is the command line interface (CLI) for the lookup function.
+
+The `puppet lookup` command lets you do Hiera lookups from the command line. It needs to be run on a node that has a copy of your Hiera data.
+You can log into an OpenVox server node and run `puppet lookup` with sudo.
+
+The most common version of this command is:
+
+```sh
+puppet lookup <KEY> --node <NAME> --environment <ENV> --explain
+```
+
+The `puppet lookup` command searches your Hiera data and returns a value for the requested lookup key, so you can test and explore your data.
+It replaces the `hiera` command. Hiera relies on a node's facts to locate the relevant data sources.
+By default, `puppet lookup` uses facts from the node you run the command on, but you can get data for any other node with the `--node NAME` option.
+If possible, the lookup command will use the requested node's most recent stored facts from PuppetDB.
+If PuppetDB is not configured or you want to provide other fact values, pass facts from a JSON or YAML file with the `--facts FILE` option.
+
+### Usage
+
+```sh
+puppet lookup [--help] [--type <TYPESTRING>] [--merge first|unique|hash|deep]
+              [--knock-out-prefix <PREFIX-STRING>] [--sort-merged-arrays]
+              [--merge-hash-arrays] [--explain] [--environment <ENV>]
+              [--default <VALUE>] [--node <NODE-NAME>] [--facts <FILE>]
+              [--compile] [--render-as s|json|yaml|binary|msgpack] keys
+```
+
+### Command examples
+
+To look up `key_name` using the local node's facts:
+
+```sh
+puppet lookup key_name
+```
+
+To look up `key_name` with agent.local's facts:
+
+```sh
+puppet lookup --node agent.local key_name
+```
+
+To get the first value found for `key_name_one` and `key_name_two` with agent.local's facts while merging values and knocking out the prefix `foo`:
+
+```sh
+puppet lookup --node agent.local --merge deep --knock-out-prefix foo key_name_one key_name_two
+```
+
+To look up `key_name` with agent.local's facts, and return a default value of `bar` if nothing was found:
+
+```sh
+puppet lookup --node agent.local --default bar key_name
+```
+
+To see an explanation of how the value for `key_name` would be found, using agent.local's facts:
+
+```sh
+puppet lookup --node agent.local --explain key_name
+```
+
+## Puppet lookup command options
+
+The `puppet lookup` command has the following options:
+
+- `--help` — Print a usage message.
+- `--explain` — Explain the details of how the lookup was performed and where the final value came from, or the reason no value was found.
+  Useful when debugging Hiera data. If `--explain` isn't specified, lookup exits with 0 if a value was found and 1 if not. With `--explain`, lookup always exits with 0 unless there is a major error.
+- `--node <NODE-NAME>` — Specify which node to look up data for; defaults to the node where the command is run.
+  If the node where you're running this command is configured to talk to PuppetDB, the command will use the requested node's most recent facts. Otherwise, override facts with the `--facts` option.
+- `--facts <FILE>` — Specify a JSON or YAML file that contains key-value mappings to override the facts for this lookup. Any facts not specified in this file maintain their original value.
+- `--environment <ENV>` — Specify an environment. Different environments can have different Hiera data.
+- `--merge first/unique/hash/deep` — Specify the merge behavior, overriding any merge behavior from the data's `lookup_options`.
+- `--knock-out-prefix <PREFIX-STRING>` — Used with `deep` merge. Specifies a prefix to indicate a value should be removed from the final result.
+- `--sort-merged-arrays` — Used with `deep` merge. When this flag is used, all merged arrays are sorted.
+- `--merge-hash-arrays` — Used with the `deep` merge strategy. When this flag is used, hashes within arrays are deep-merged with their counterparts by position.
+- `--explain-options` — Explain whether a `lookup_options` hash affects this lookup, and how that hash was assembled.
+- `--default <VALUE>` — A value to return if Hiera can't find a value in data. Useful for emulating a call to the `lookup` function that includes a default.
+- `--type <TYPESTRING>` — Assert that the value has the specified type.
+- `--compile` — Perform a full catalog compilation prior to the lookup. If your hierarchy and data only use the `$facts`, `$trusted`, and `$server_facts` variables, you don't need this option.
+  If your Hiera configuration uses arbitrary variables set by a Puppet manifest, you need this to get accurate data.
+- `--render-as s/json/yaml/binary/msgpack` — Specify the output format of the results; `s` means plain text. The default when producing a value is `yaml` and the default when producing an explanation is `s`.
+
+Related topics: [Creating and editing data with Hiera][editing_data].
+
+## Access hash and array elements using a key.subkey notation
+
+Access hash and array members in Hiera using a `key.subkey` notation.
+
+You can access hash and array elements when doing the following things:
+
+- Interpolating variables into `hiera.yaml` or a data file. Many of the most commonly used variables, for example `facts` and `trusted`, are deeply nested data structures.
+- Using the `lookup` function or the `puppet lookup` command. If the value of `lookup('some_key')` is a hash or array, look up a single member of it by using `lookup('some_key.subkey')`.
+- Using interpolation functions that do Hiera lookups, for example `lookup` and `alias`.
+
+To access a single member of an array or hash:
+
+1. Use the name of the value followed by a period (`.`) and a subkey.
+   - If the value is an array, the subkey must be an integer, for example: `users.0` returns the first entry in the `users` array.
+   - If the value is a hash, the subkey must be the name of a key in that hash, for example, `facts.os`.
+   - To access values in nested data structures, you can chain subkeys together. For example, since the value of `facts.system_uptime` is a hash, you can access its `hours` key with `facts.system_uptime.hours`.
+
+## Hiera dotted notation
+
+The Hiera dotted notation does not support arbitrary expressions for subkeys; only literal keys are valid.
+
+A hash can include literal dots in the text of a key. For example, the value of `$trusted['extensions']` is a hash containing any certificate extensions for a node,
+but some of its keys can be raw OID strings like `1.3.6.1.4.1.34380.1.2.1`. You can access those values in Hiera with the `key.subkey` notation,
+but you must put quotation marks — single or double — around the affected subkey.
+If the entire compound key is quoted (for example, as required by the lookup interpolation function), use the other kind of quote for the subkey,
+and escape quotes (as needed by your data file format) to ensure that you don't prematurely terminate the whole string.
+
+For example:
+
+```yaml
+aliased_key: "%{lookup('other_key.\"dotted.subkey\"')}"
+# Or:
+aliased_key: "%{lookup(\"other_key.'dotted.subkey'\")}"
+```
+
+> Note: Using extra quotes prevents digging into dotted keys. For example, if the lookup key contains a dot (`.`) then the entire key must be enclosed within single quotes within double quotes,
+> for example, `lookup("'has.dot'")`.

--- a/docs/_openvox_8x/hiera_custom_backends.md
+++ b/docs/_openvox_8x/hiera_custom_backends.md
@@ -1,11 +1,390 @@
 ---
+layout: default
 title: "Writing new data backends"
 ---
 
+[yaml_data]: https://github.com/OpenVoxProject/openvox/blob/main/lib/puppet/functions/yaml_data.rb
+[json_data]: https://github.com/OpenVoxProject/openvox/blob/main/lib/puppet/functions/json_data.rb
+[hocon_data]: https://github.com/OpenVoxProject/openvox/blob/main/lib/puppet/functions/hocon_data.rb
+[merging]: ./hiera_merging.html
+[interpolation]: ./lang_data_string.html#interpolation
+[automatic]: ./hiera_automatic.html#access-hash-and-array-elements-using-a-keysubkey-notation
+[eyaml_lookup_key]: https://github.com/voxpupuli/hiera-eyaml
+[puppet_functions]: ./lang_write_functions_in_puppet.html
+[ruby_functions]: ./functions_ruby_overview.html
+[hiera_yaml]: ./hiera_config_yaml_5.html
+[struct]: ./lang_data_abstract.html#struct
+[functions]: ./lang_functions.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+You can extend Hiera to look up values in data stores, for example, a PostgreSQL database table, a custom web app, or a new kind of structured data file.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+To teach Hiera how to talk to other data sources, write a custom backend.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+> **Important**: Writing a custom backend is an advanced topic. Before proceeding, make sure you really need it.
+> It is also worth asking the community whether there is one you can re-use, rather than starting from scratch.
 
+## Custom backends overview
+
+A backend is a custom Puppet function that accepts a particular set of arguments and whose return value obeys a particular format. The function can do whatever is necessary to locate its data.
+
+A backend function uses the modern Ruby functions API or the Puppet language.
+This means you can use different versions of a Hiera backend in different environments, and you can distribute Hiera backends in OpenVox modules.
+
+Different types of data have different performance characteristics.
+To make sure Hiera performs well with every type of data source, it supports three types of backends: `data_hash`, `lookup_key` and `data_dig`.
+
+### data_hash
+
+For data sources where it's inexpensive, performance-wise, to read the entire contents at once, like simple files on disk. Use the `data_hash` backend type if:
+
+* The cache is alive for the duration of one compilation.
+* The data is small.
+* The data can be retrieved all at once.
+* Most of the data gets used.
+* The data is static.
+
+### lookup_key
+
+For data sources where looking up a key is relatively expensive, performance-wise, like an HTTPS API. Use the `lookup_key` backend type if:
+
+* The data set is big, but only a small portion is used.
+* The result can vary during the compilation.
+
+The `hiera-eyaml` backend is a `lookup_key` function, because decryption tends to affect performance; as a given node uses only a subset of the available secrets, it makes sense to decrypt only on-demand.
+
+### data_dig
+
+For data sources that can access arbitrary elements of hash or array values before passing anything back to Hiera, like a database.
+
+#### The `RichDataKey` and `RichData` types
+
+To simplify backend function signatures, you can use two extra data type aliases: `RichDataKey` and `RichData`.
+These are only available to backend functions called by Hiera; normal functions and Puppet code cannot use them.
+
+Related topics: [custom Puppet function][puppet_functions], [the modern Ruby functions API][ruby_functions].
+
+## data_hash backends
+
+A `data_hash` backend function reads an entire data source at once, and returns its contents as a hash.
+
+The built-in YAML, JSON, and HOCON backends are all `data_hash` functions. You can view their source on GitHub:
+
+* [`yaml_data.rb`][yaml_data]
+* [`json_data.rb`][json_data]
+* [`hocon_data.rb`][hocon_data]
+
+### data_hash arguments
+
+Hiera calls a `data_hash` function with two arguments:
+
+* A hash of options. The options hash will contain a `path` when the entry in `hiera.yaml` is using `path`/`paths`, `glob`/`globs`, or `mapped_paths`,
+  and the backend will receive one call per path to an existing file.
+  When the entry in `hiera.yaml` is using `uri`/`uris`, the options hash will have a `uri` key, and the backend function is called once per given URI.
+  When `uri`/`uris` are used, Hiera does not perform an existence check. It is up to the function to type the options parameter as wanted.
+* A `Puppet::LookupContext` object.
+
+### data_hash return type
+
+The function must either call the context object's `not_found` method, or return a hash of lookup keys and their associated values. The hash can be empty.
+
+Puppet language example signature:
+
+```puppet
+function mymodule::hiera_backend(
+  Hash                  $options,
+  Puppet::LookupContext $context,
+)
+```
+
+Ruby example signature:
+
+```ruby
+dispatch :hiera_backend do
+  param 'Hash', :options
+  param 'Puppet::LookupContext', :context
+end
+```
+
+The returned hash can include the `lookup_options` key to configure merge behavior for other keys. See [Configuring merge behavior in Hiera data][merging] for more information.
+Values in the returned hash can include Hiera interpolation tokens like `%{variable}` or `%{lookup('key')}`; Hiera interpolates values as needed.
+This is a significant difference between `data_hash` and the other two backend types; `lookup_key` and `data_dig` functions have to explicitly handle interpolation.
+
+## lookup_key backends
+
+A `lookup_key` backend function looks up a single key and returns its value.
+
+The built-in `hiera_eyaml` backend is a `lookup_key` function. You can view its source at the [hiera-eyaml GitHub repository][eyaml_lookup_key].
+
+### lookup_key arguments
+
+Hiera calls a `lookup_key` function with three arguments:
+
+1. A key to look up.
+2. A hash of options.
+3. A `Puppet::LookupContext` object.
+
+### lookup_key return type
+
+The function must either call the context object's `not_found` method, or return a value for the requested key. It may return `undef` as a value.
+
+Puppet language example signature:
+
+```puppet
+function mymodule::hiera_backend(
+  Variant[String, Numeric] $key,
+  Hash                     $options,
+  Puppet::LookupContext    $context,
+)
+```
+
+Ruby example signature:
+
+```ruby
+dispatch :hiera_backend do
+  param 'Variant[String, Numeric]', :key
+  param 'Hash', :options
+  param 'Puppet::LookupContext', :context
+end
+```
+
+A `lookup_key` function can return a hash for the `lookup_options` key to configure merge behavior for other keys. See [Configuring merge behavior in Hiera data][merging] for more information.
+To support Hiera interpolation tokens, for example `%{variable}` or `%{lookup('key')}` in your data, call `context.interpolate` on your values before returning them.
+
+Related topics: [interpolation][interpolation].
+
+## data_dig backends
+
+A `data_dig` backend function is similar to a `lookup_key` function, but instead of looking up a single key, it looks up a single sequence of keys and subkeys.
+
+Hiera lets you look up individual members of hash and array values using `key.subkey` notation. Use `data_dig` types in cases where:
+
+* Lookups are relatively expensive.
+* The data source knows how to extract elements from hash and array values.
+* Users are likely to pass `key.subkey` requests to the `lookup` function to access subsets of large data structures.
+
+### data_dig arguments
+
+Hiera calls a `data_dig` function with three arguments:
+
+1. An array of lookup key segments, made by splitting the requested lookup key on the dot (`.`) subkey separator. For example, a lookup for `users.dbadmin.uid` results in `['users', 'dbadmin', 'uid']`.
+   Positive base-10 integer subkeys (for accessing array members) are converted to Integer objects, but other number subkeys remain as strings.
+2. A hash of options.
+3. A `Puppet::LookupContext` object.
+
+### data_dig return type
+
+The function must either call the context object's `not_found` method, or return a value for the requested sequence of key segments.
+Note that returning `undef` (`nil` in Ruby) means that the key was found but that the value for that key was specified to be `undef`.
+
+Puppet language example signature:
+
+```puppet
+function mymodule::hiera_backend(
+  Array[Variant[String, Numeric]] $segments,
+  Hash                            $options,
+  Puppet::LookupContext           $context,
+)
+```
+
+Ruby example signature:
+
+```ruby
+dispatch :hiera_backend do
+  param 'Array[Variant[String, Numeric]]', :segments
+  param 'Hash', :options
+  param 'Puppet::LookupContext', :context
+end
+```
+
+A `data_dig` function can return a hash for the `lookup_options` key to configure merge behavior for other keys.
+
+To support Hiera interpolation tokens like `%{variable}` or `%{lookup('key')}` in your data, call `context.interpolate` on your values before returning them.
+
+Related topics: [key.subkey notation][automatic], [Configuring merge behavior in Hiera data][merging].
+
+## Hiera calling conventions for backend functions
+
+Hiera uses the following conventions when calling backend functions:
+
+* Hiera calls `data_hash` once per data source.
+* Hiera calls `lookup_key` functions once per data source for every unique key lookup.
+* Hiera calls `data_dig` functions once per data source for every unique sequence of key segments.
+
+However, a given hierarchy level can refer to multiple data sources with the `path`, `uri`, and `glob` settings. Hiera handles each hierarchy level as follows:
+
+* If the `path` or `glob` settings are used, Hiera determines which files exist and calls the function once for each. If no files were found, the function will not be called.
+* If the `uri` settings are used, Hiera calls the function once per URI.
+* If none of those settings are used, Hiera calls the function once.
+
+Hiera can call a function again for a given data source if the inputs change. For example, if `hiera.yaml` interpolates a local variable in a file path,
+Hiera calls the function again for scopes where that variable has a different value.
+This has a significant performance impact, so you should interpolate only facts, trusted facts, and server facts in the hierarchy.
+
+## The options hash
+
+Hierarchy levels are configured in the `hiera.yaml` file. When calling a backend function, Hiera passes a modified version of that configuration as a hash.
+
+The options hash may contain the following keys (depending on whether `path`/`glob`/`uri`/`mapped_paths` have been set):
+
+* `path` — The absolute path to a file on disk. It is present only if `path`, `paths`, `glob`, `globs`, or `mapped_paths` is present in the hierarchy.
+  Hiera will never call the function unless the file is present.
+* `uri` — A URI that your function can use to locate a data source. It is present only if `uri` or `uris` is present in the hierarchy. Hiera does not verify the URI before passing it to the function.
+* Every key from the hierarchy level's `options` setting. List any options your backend requires or accepts. The `path` and `uri` keys are reserved.
+
+> Note: If your backend uses data files, use the context object's `cached_file_data` method to read them.
+
+For example, the following hierarchy level in `hiera.yaml` results in several different options hashes, depending on the current node's facts and whether the files exist:
+
+```yaml
+- name: "Secret data: per-node, per-datacenter, common"
+  lookup_key: eyaml_lookup_key
+  datadir: data
+  paths:
+    - "secrets/nodes/%{trusted.certname}.eyaml"
+    - "secrets/location/%{facts.whereami}.eyaml"
+    - "common.eyaml"
+  options:
+    pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+    pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+```
+
+The various hashes would all be similar to this:
+
+```ruby
+{
+  'path' => '/etc/puppetlabs/code/environments/production/data/secrets/nodes/web01.example.com.eyaml',
+  'pkcs7_private_key' => '/etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem',
+  'pkcs7_public_key' => '/etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem'
+}
+```
+
+In your function's signature, you can validate the options hash by using the `Struct` data type to restrict its contents.
+In particular, you can disable all of the `path` and `glob` settings for your backend by disallowing the `path` key in the options hash.
+
+Related topics: [Configuring merge behavior in Hiera data][merging], [Hiera interpolation tokens][interpolation], [hiera.yaml][hiera_yaml], [the Struct data type][struct].
+
+## The Puppet::LookupContext object and methods
+
+To support caching and other backend needs, Hiera provides a `Puppet::LookupContext` object.
+
+In Ruby functions, the context object is a normal Ruby object of class `Puppet::LookupContext`, and you can call methods with standard Ruby syntax, for example `context.not_found`.
+
+In Puppet language functions, the context object appears as the special data type `Puppet::LookupContext` with methods attached.
+You can call the context's methods using Puppet's chained function call syntax, for example, `$context.not_found`.
+For methods that take a block, use Puppet's lambda syntax (parameters outside block) instead of Ruby's block syntax (parameters inside block).
+
+### not_found()
+
+Tells Hiera to halt this lookup and move on to the next data source. Call this method when your function cannot find a matching key or a given lookup. This method returns no value.
+
+For `data_hash` backends, return an empty hash. The empty hash will result in `not_found` and will prevent further calls to the provider.
+For `lookup_key` and `data_dig` backends, use `not_found` when a requested key is not present in the data source or the data source does not exist.
+Do not return `undef` or `nil` for missing keys, as these are legal values that can be set in data.
+
+### interpolate(value)
+
+Returns the provided value, but with any Hiera interpolation tokens (`%{variable}` or `%{lookup('key')}`) replaced by their value.
+This lets you opt-in to allowing Hiera-style interpolation in your backend's data sources. It works recursively on arrays and hashes. Hashes can interpolate into both keys and values.
+
+In `data_hash` backends, support for interpolation is built in, and you do not need to call this method.
+
+In `lookup_key` and `data_dig` backends, call this method if you want to support interpolation.
+
+### environment_name()
+
+Returns the name of the environment, regardless of layer.
+
+### module_name()
+
+Returns the name of the module whose `hiera.yaml` called the function. Returns `undef` (in Puppet) or `nil` (in Ruby) if the function was called by the global or environment layer.
+
+### cache(key, value)
+
+Caches a value in a per-data-source private cache. It also returns the cached value.
+
+On future lookups in this data source, you can retrieve values by calling `cached_value(key)`. Cached values are immutable, but you can replace the value for an existing key.
+Cache keys can be anything valid as a key for a Ruby hash, including `nil`.
+
+For example, on its first invocation for a given YAML file, the built-in `eyaml_lookup_key` backend reads the whole file and caches it, then decrypts only the specific value that was requested.
+On subsequent lookups into that file, it gets the encrypted value from the cache instead of reading the file from disk again.
+
+The cache is useful for storing session keys or connection objects for backends that access a network service.
+
+Each `Puppet::LookupContext` cache lasts for the duration of the current catalog compilation. A node can't access values cached for a previous node.
+
+Hiera creates a separate cache for each combination of inputs for a function call. Each hierarchy level has its own cache, and hierarchy levels that use multiple paths have a separate cache for each path.
+
+### cache_all(hash)
+
+Caches all the key-value pairs from a given hash. Returns `undef` (in Puppet) or `nil` (in Ruby).
+
+### cached_value(key)
+
+Returns a previously cached value from the per-data-source private cache. Returns `undef` or `nil` if no value with this name has been cached.
+
+### cache_has_key(key)
+
+Checks whether the cache has a value for a given key yet. Returns `true` or `false`.
+
+### cached_entries()
+
+Returns everything in the per-data-source cache as an iterable object. The returned object is not a hash.
+If you want a hash, use `Hash($context.all_cached())` in the Puppet language or `Hash[context.all_cached()]` in Ruby.
+
+### cached_file_data(path)
+
+Puppet syntax:
+
+```puppet
+cached_file_data(path) |content| { ... }
+```
+
+Ruby syntax:
+
+```ruby
+cached_file_data(path) {|content| ...}
+```
+
+For best performance, use this method to read files in Hiera backends.
+
+Returns the content of the specified file as a string. If an optional block is provided, it passes the content to the block and returns the block's return value.
+For example, the built-in JSON backend uses a block to parse JSON and return a hash:
+
+```ruby
+context.cached_file_data(path) do |content|
+  begin
+    JSON.parse(content)
+  rescue JSON::ParserError => ex
+    raise Puppet::DataBinding::LookupError, "Unable to parse (#{path}): #{ex.message}"
+  end
+end
+```
+
+On repeated access to a given file, Hiera checks whether the file has changed on disk. If it hasn't, Hiera uses cached data instead of reading and parsing the file again.
+
+This method does not use the same per-data-source caches as `cache(key, value)` and similar methods.
+It uses a separate cache that lasts across multiple catalog compilations, tied to the server's environment cache.
+
+Since the cache can outlive a given node's catalog compilation, do not do any node-specific pre-processing (like calling `context.interpolate`) in this method's block.
+
+### explain() { 'message' }
+
+Puppet syntax:
+
+```puppet
+explain() || { 'message' }
+```
+
+Ruby syntax:
+
+```ruby
+explain() { 'message' }
+```
+
+In both Puppet and Ruby, the provided block must take zero arguments.
+
+Adds a message which appears in debug messages or when using `puppet lookup --explain`. The block provided to this function must return a string.
+
+The `explain` method is useful for complex lookups where a function tries several different things before arriving at the value. Hiera never executes the explain block unless explain is enabled.
+
+Related topics: [Ruby functions][ruby_functions], [Puppet language functions][puppet_functions], [chained function call syntax][functions].

--- a/docs/_openvox_8x/hiera_merging.md
+++ b/docs/_openvox_8x/hiera_merging.md
@@ -1,11 +1,395 @@
 ---
+layout: default
 title: "Creating and editing data"
 ---
 
+[lookup_command]: ./man/lookup.html
+[automatic]: ./hiera_automatic.html
+[data types]: ./lang_data.html
+[interpolation_puppet]: ./lang_data_string.html#interpolation
+[facts_hash]: ./lang_facts_and_builtin_vars.html#the-factsfactname-hash
+[trusted]: ./lang_facts_and_builtin_vars.html#trusted-facts
+[server_facts]: ./lang_facts_and_builtin_vars.html#serverfacts-variable
+[environment]: ./environments_about.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+## Setting the merge behavior for a lookup
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+When you look up a key in Hiera, it is common for multiple data sources to have different values for it.
+By default, Hiera returns the first value it finds, but it can also continue searching and merge all the found values together.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+You can set the merge behavior for a lookup in two ways:
 
+* At lookup time. This works with the `lookup` function, but does not support automatic class parameter lookup.
+* In Hiera data, with the `lookup_options` key. This works for both manual and automatic lookups. It also lets module authors set default behavior that users can override.
+
+With both of these methods, specify a merge behavior as either a string (for example, `'first'`) or a hash (for example `{'strategy' => 'first'}`).
+The hash syntax is useful for `deep` merges where extra options are available, but it also works with the other merge types.
+
+Related topics: [lookup][lookup_command], [automatic class parameter lookup][automatic].
+
+## Merge behaviors
+
+There are four merge behaviors to choose from: `first`, `unique`, `hash`, and `deep`.
+When specifying a merge behavior, use one of the following identifiers:
+
+* `'first'`, `{'strategy' => 'first'}`, or nothing.
+* `'unique'` or `{'strategy' => 'unique'}`.
+* `'hash'` or `{'strategy' => 'hash'}`.
+* `'deep'` or `{'strategy' => 'deep', <OPTION> => <VALUE>, ...}`. Valid options:
+  * `'knockout_prefix'` — string or undef; default is `undef`
+  * `'sort_merged_arrays'` — Boolean; default is `false`
+  * `'merge_hash_arrays'` — boolean; default is `false`
+
+### First
+
+A first-found lookup doesn't merge anything: it returns the first value found, and ignores the rest. This is Hiera's default behavior.
+
+Specify this merge behavior with one of these:
+
+* `'first'`
+* `{'strategy' => 'first'}`
+* Nothing (since it's the default)
+
+### Unique
+
+A unique merge (also called an array merge) combines any number of array and scalar (string, number, boolean) values to return a merged, flattened array with all duplicate values removed.
+The lookup fails if any of the values are hashes. The result is ordered from highest priority to lowest.
+
+Specify this merge behavior with one of these:
+
+* `'unique'`
+* `{'strategy' => 'unique'}`
+
+### Hash
+
+A hash merge combines the keys and values of any number of hashes to return a merged hash. The lookup fails if any of the values aren't hashes.
+
+If multiple source hashes have a given key, Hiera uses the value from the highest priority data source: it won't recursively merge the values.
+
+Hashes in Puppet preserve the order in which their keys are written. When merging hashes, Hiera starts with the lowest priority data source.
+For each higher priority source, it appends new keys at the end of the hash and updates existing keys in place.
+
+For example:
+
+```yaml
+# web01.example.com.yaml
+mykey:
+  d: "per-node value"
+  b: "per-node override"
+# common.yaml
+mykey:
+  a: "common value"
+  b: "default value"
+  c: "other common value"
+```
+
+```puppet
+lookup('mykey', {merge => 'hash'})
+```
+
+Returns the following:
+
+```puppet
+{
+  a => "common value",
+  b => "per-node override", # Using value from the higher-priority source, but
+                            # preserving the order of the lower-priority source.
+  c => "other common value",
+  d => "per-node value",
+}
+```
+
+Specify this merge behavior with one of these:
+
+* `'hash'`
+* `{'strategy' => 'hash'}`
+
+### Deep
+
+A deep merge combines the keys and values of any number of hashes to return a merged hash. If the same key exists in multiple source hashes, Hiera recursively merges them:
+
+* Hash values are merged with another deep merge.
+* Array values are merged. This differs from the unique merge. The result is ordered from lowest priority to highest, which is the reverse of the unique merge's ordering.
+  The result isn't flattened, so it can contain nested arrays. The `merge_hash_arrays` and `sort_merged_arrays` options can make further changes to the result.
+* Scalar (String, Number, Boolean) values use the highest priority value, like in a first-found lookup.
+
+Specify this merge behavior with one of these:
+
+* `'deep'`
+* `{'strategy' => 'deep', <OPTION> => <VALUE>, ...}` — Adjust the merge behavior with these additional options:
+  * `'knockout_prefix'` (String or Undef) — A string prefix to indicate a value should be removed from the final result. Defaults to `undef`, which turns off this option.
+  * `'sort_merged_arrays'` (Boolean) — Whether to sort all arrays that are merged together. Defaults to `false`.
+  * `'merge_hash_arrays'` (Boolean) — Whether to deep-merge hashes within arrays, by position.
+    For example, `[ {a => high}, {b => high} ]` and `[ {c => low}, {d => low} ]` would be merged as `[ {c => low, a => high}, {d => low, b => high} ]`. Defaults to `false`.
+
+> Note: Unlike a hash merge, a deep merge can also accept arrays as the root values. It merges them with its normal array merging behavior, which differs from a unique merge as described above.
+
+## Set merge behavior at lookup time
+
+Use merge behavior at lookup time to override preconfigured merge behavior for a key.
+
+Use the `lookup` function or the `puppet lookup` command to provide a merge behavior as an argument or flag.
+
+Function example:
+
+```puppet
+# Merge several arrays of class names into one array:
+lookup('classes', {merge => 'unique'})
+```
+
+Command line example:
+
+```sh
+puppet lookup classes --merge unique --environment production --explain
+```
+
+> Note that each of the deprecated `hiera_*` functions is locked to one particular merge behavior. (`hiera` only does first-found, `hiera_array` only does unique merge, etc.)
+
+Related topics: [lookup][lookup_command], [puppet lookup][automatic].
+
+## Configure merge behavior in Hiera data
+
+Hiera uses a key's configured merge behavior in any lookup that doesn't explicitly override it.
+
+In any Hiera data source, including module data, use the `lookup_options` key to configure merge behavior.
+
+For example:
+
+```yaml
+# <ENVIRONMENT>/data/common.yaml
+lookup_options:
+  ntp::servers:     # Name of key
+    merge: unique   # Merge behavior as a string
+  "^profile::(.*)::users$": # Regexp: `$users` parameter of any profile class
+    merge:          # Merge behavior as a hash
+      strategy: deep
+      merge_hash_arrays: true
+```
+
+Hiera uses the configured merge behaviors for these keys.
+
+> Note: the `hiera_*` functions always override configured merge behavior.
+
+## `lookup_options` format
+
+The value of `lookup_options` is a hash with the following format:
+
+```yaml
+lookup_options:
+  <NAME or REGEXP>:
+    merge: <MERGE BEHAVIOR>
+```
+
+Each key is either the full name of a lookup key (like `ntp::servers`) or a regular expression (like `'^profile::(.*)::users$'`).
+In a module's data, you can configure lookup keys only within that module's namespace: the `ntp` module can set options for `ntp::servers`, but the `apache` module can't.
+
+Each value is a hash with a `merge` key. A merge behavior can be a string or a hash.
+
+`lookup_options` is a reserved key — you can't put other kinds of data in it, and you can't look it up directly. This is the only reserved key in Hiera.
+
+### Overriding merge behavior
+
+Any data source overrides individual `lookup_options` from a lower priority source.
+As Hiera uses a hash merge on the `lookup_options` values, module authors can configure a default merge behavior for a given key and end users can override it.
+
+When you specify a merge behavior as an argument to the `lookup` function, it overrides the configured merge behavior.
+
+## Use a regular expression in `lookup_options`
+
+You can use regular expressions in `lookup_options` to configure merge behavior for many lookup keys at once.
+
+A regular expression key such as `'^profile::(.*)::users$'` sets the merge behavior for `profile::server::users`, `profile::postgresql::users`, `profile::jenkins::master::users`.
+Regular expression lookup options use Puppet's regular expression support, which is based on Ruby's regular expressions.
+
+To use a regular expression in `lookup_options`:
+
+1. Write the pattern as a quoted string. Do not use the Puppet language's forward-slash (`/.../`) regular expression delimiters.
+2. Begin the pattern with the start-of-line metacharacter (`^`, also called a caret). If `^` isn't the first character, Hiera treats it as a literal key name instead of a regular expression.
+3. If this data source is in a module, follow `^` with the module's namespace: its full name, plus the `::` namespace separator.
+   For example, all regular expression lookup options in the `ntp` module must start with `^ntp::`. Starting with anything else results in an error.
+
+The merge behavior you set for that pattern applies to all lookup keys that match it. In cases where multiple lookup options could apply to the same key, Hiera resolves the conflict.
+If there's a literal (not regular expression) option available, Hiera uses it.
+Otherwise, Hiera uses the first regular expression that matches the lookup key, using the order in which they appear in the module code.
+
+> Note: `lookup_options` are assembled with a hash merge, which puts keys from lower priority data sources before those from higher priority sources.
+> To override a module's regular expression configured merge behavior, use the exact same regular expression string in your environment data, so that it replaces the module's value.
+> A slightly different regular expression won't work because the lower-priority regular expression goes first.
+
+## Interpolation
+
+In Hiera you can insert, or interpolate, the value of a variable into a string, using the syntax `%{variable}`.
+
+Hiera uses interpolation in two places:
+
+* Hierarchies: you can interpolate variables into the `path`, `glob`, `uri`, `datadir`, `mapped_paths` and `options` of a hierarchy level. This lets each node get a customized version of the hierarchy.
+* Data: you can use interpolation to avoid repetition. This takes one of two forms:
+  * If some value always involves the value of a fact (for example, if you need to specify a mail server and you have one predictably-named mail server per domain),
+    reference the fact directly instead of manually transcribing it.
+  * If multiple keys need to share the same value, write it out for one of them and reuse it for the rest with the `lookup` or `alias` interpolation functions.
+    This makes it easier to keep data up to date, as you only need to change a given value in one place.
+
+## Interpolation token syntax
+
+Interpolation tokens consist of:
+
+* A percent sign (`%`).
+* An opening curly brace (`{`).
+* One of:
+  * A variable name, optionally using key.subkey notation to access a specific member of a hash or array.
+  * An interpolation function and its argument.
+* A closing curly brace (`}`).
+
+For example, `%{trusted.certname}` or `%{alias("users")}`.
+
+Hiera interpolates values of Puppet data types and converts them to strings. Note that the exception to this is when using an alias. If the alias is the only thing present, then its value is not converted.
+
+In YAML files, any string containing an interpolation token must be enclosed in quotation marks.
+
+> Note: Unlike the Puppet interpolation tokens, you can't interpolate an arbitrary expression.
+
+Related topics: [Puppet's data types][data types], [Puppet's rules for interpolating non-string values][interpolation_puppet].
+
+## Interpolate a Puppet variable
+
+The most common thing to interpolate is the value of a top-scope variable.
+
+Use the name of the variable, omitting the leading dollar sign (`$`). Use the Hiera key.subkey notation to access a member of a data structure.
+For example, to interpolate the value of `$facts['networking']['domain']` write:
+
+```yaml
+smtpserver: "mail.%{facts.networking.domain}"
+```
+
+## Interpolating variables
+
+The `facts` hash, `trusted` hash, and `server_facts` hash are the most useful variables to Hiera and behave predictably.
+
+> Note: If you have a hierarchy level that needs to reference the name of a node, get the node's name by using `trusted.certname`. To reference a node's environment, use `server_facts.environment`.
+
+Avoid using local variables, namespaced variables from classes (unless the class has already been evaluated), and Hiera-specific pseudo-variables (pseudo-variables are not supported in Hiera 5).
+
+### Classic `::<fact_name>` facts
+
+OpenVox makes facts available in two ways: grouped together in the `facts` hash (`$facts['networking']`), and individually as top-scope variables (`$networking`).
+
+When you use individual fact variables, specify the (empty) top-scope namespace for them, like this:
+
+* `%{::networking}`
+
+Not like this:
+
+* `%{networking}`
+
+> Note: The individual fact names aren't protected the way `$facts` is, and local scopes can set unrelated variables with the same names.
+> In most of the Puppet language, you don't have to worry about unknown scopes overriding your variables, but in Hiera you do.
+
+Related topics: [facts][facts_hash], [trusted][trusted], [server_facts][server_facts], [environment][environment].
+
+## Interpolation functions
+
+In Hiera data sources, you can use interpolation functions to insert non-variable values. These aren't the same as Puppet functions; they're only available in Hiera interpolation tokens.
+
+> Note: You cannot use interpolation functions in `hiera.yaml`. They're only for use in data sources.
+
+There are five interpolation functions:
+
+* `lookup` — looks up a key using Hiera, and interpolates the value into a string.
+* `hiera` — a synonym for `lookup`.
+* `alias` — looks up a key using Hiera, and uses the value as a replacement for the enclosing string.
+  The result has the same data type as what the aliased key has — no conversion to string takes place if the value is exactly one alias.
+* `literal` — a way to write a literal percent sign (`%`) without accidentally interpolating something.
+* `scope` — an alternate way to interpolate a variable. Not generally useful.
+
+### `lookup` and `hiera`
+
+The `lookup` and `hiera` interpolation functions look up a key and return the resulting value. The result of the lookup must be a string; any other result causes an error.
+
+This is useful in the Hiera data sources. If you need to use the same value for multiple keys, you can assign the literal value to one key, then call lookup to reuse the value elsewhere.
+You can edit the value once to change it everywhere it's used.
+
+For example, suppose your WordPress profile needs a database server, and you're already configuring that hostname in data because the MySQL profile needs it. You could write:
+
+```yaml
+# in location/pdx.yaml:
+profile::mysql::public_hostname: db-server-01.pdx.example.com
+
+# in location/bfs.yaml:
+profile::mysql::public_hostname: db-server-06.belfast.example.com
+
+# in common.yaml:
+profile::wordpress::database_server: "%{lookup('profile::mysql::public_hostname')}"
+```
+
+The value of `profile::wordpress::database_server` is always the same as `profile::mysql::public_hostname`.
+Even though you wrote the WordPress parameter in the `common.yaml` data, it's location-specific, as the value it references was set in your per-location data files.
+
+The value referenced by the lookup function can contain another call to lookup; if you accidentally make an infinite loop, Hiera detects it and fails.
+
+> Note: The lookup and hiera interpolation functions aren't the same as the Puppet functions of the same names. They only take a single argument.
+
+### `alias`
+
+The `alias` function lets you reuse Hash, Array, or Boolean values. When you interpolate `alias` in a string, Hiera replaces that entire string with the aliased value, using its original data type. For example:
+
+```yaml
+original:
+  - 'one'
+  - 'two'
+aliased: "%{alias('original')}"
+```
+
+A lookup of `original` and a lookup of `aliased` would both return the value `['one', 'two']`.
+
+When you use the `alias` function, its interpolation token must be the only text in that string. For example, the following would be an error:
+
+```yaml
+aliased: "%{alias('original')} - 'three'"
+```
+
+> Note: A lookup resulting in an interpolation of `alias` referencing a non-existent key will return an empty string, not a Hiera "not found" condition.
+
+### `literal`
+
+The `literal` interpolation function lets you escape a literal percent sign (`%`) in Hiera data, to avoid triggering interpolation where it isn't wanted.
+This is useful when dealing with Apache config files, for example, which might include text such as `%{SERVER_NAME}`.
+
+For example:
+
+```yaml
+server_name_string: "%{literal('%')}{SERVER_NAME}"
+```
+
+The value of `server_name_string` would be `%{SERVER_NAME}`, and Hiera would not attempt to interpolate a variable named `SERVER_NAME`.
+
+The only legal argument for `literal` is a single `%` sign.
+
+### `scope`
+
+The `scope` interpolation function interpolates variables. It works identically to variable interpolation. The function's argument is the name of a variable.
+
+The following two values would be identical:
+
+```yaml
+smtpserver: "mail.%{facts.domain}"
+smtpserver: "mail.%{scope('facts.domain')}"
+```
+
+Related topics: [lookup][lookup_command].
+
+## Use interpolation functions
+
+To use an interpolation function, write:
+
+1. The name of the function.
+2. An opening parenthesis.
+3. One argument to the function, enclosed in single or double quotation marks. Use the opposite of what the enclosing string uses: if it uses single quotation marks, use double quotation marks.
+4. A closing parenthesis.
+
+For example:
+
+```yaml
+wordpress::database_server: "%{lookup('instances::mysql::public_hostname')}"
+```
+
+> Note: There must be no spaces between these elements.

--- a/docs/_openvox_8x/hiera_migrate.md
+++ b/docs/_openvox_8x/hiera_migrate.md
@@ -1,11 +1,507 @@
 ---
+layout: default
 title: "Upgrading to Hiera 5"
 ---
 
+[layers]: ./hiera_intro.html#hieras-three-config-layers
+[backends]: ./hiera_custom_backends.html
+[puppet_conf]: ./config_file_main.html
+[automatic]: ./hiera_automatic.html
+[legacy_backend]: ./hiera_config_yaml_5.html#configuring-a-hierarchy-level-legacy-hiera-3-backends
+[v3]: ./hiera_config_yaml_3.html
+[v4]: ./hiera_config_yaml_4.html
+[v5]: ./hiera_config_yaml_5.html
+[merging]: ./hiera_merging.html
+[v5_defaults]: ./hiera_config_yaml_5.html#the-defaults-key
+[v5_builtin]: ./hiera_config_yaml_5.html#configuring-a-hierarchy-level-built-in-backends
+[eyaml_v5]: ./hiera_config_yaml_5.html#configuring-a-hierarchy-level-hiera-eyaml
+[hash_merge_operator]: ./lang_expressions.html#merging
+[class_inheritance]: ./lang_classes.html#inheritance
+[conditional_logic]: ./lang_conditional.html
+[custom_backend_system]: ./hiera_custom_backends.html
+[functions_puppet]: ./lang_write_functions_in_puppet.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+Upgrading to Hiera 5 offers some major advantages. A real environment data layer means changes to your hierarchy are now routine and testable,
+using multiple backends in your hierarchy is easier and you can make a custom backend.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+> Note: If you're already a Hiera user, you can use your current code with Hiera 5 without any changes to it.
+> Hiera 5 is fully backwards-compatible with Hiera 3, and legacy features will not be removed until a future major version.
+> You can even start using some Hiera 5 features — like module data — without upgrading anything.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+Hiera 5 uses the same built-in data formats as Hiera 3. You don't need to do mass edits of any data files.
 
+Updating your code to take advantage of Hiera 5 features involves the following tasks:
+
+Task | Benefit
+---- | -------
+Enable the environment layer, by giving each environment its own `hiera.yaml` file. | Future hierarchy changes are cheap and testable. The legacy `hiera()`, `hiera_array()`, etc. functions gain full Hiera 5 powers in any migrated environment, only if there is a `hiera.yaml` in the environment root.
+Convert your global `hiera.yaml` file to the version 5 format. | You can use new Hiera 5 backends at the global layer.
+Convert any experimental (version 4) `hiera.yaml` files to version 5. | Future-proof any environments or modules where you used the experimental version of Puppet lookup.
+In Puppet code, replace `hiera()`/`hiera_array()`/etc. with `lookup()`. | Future-proof your Puppet code.
+Use Hiera for default data in modules. | Simplify your modules with an elegant alternative to the "params.pp" pattern.
+
+> Note: Enabling the environment layer takes the most work, but yields the biggest benefits. Focus on that first, then do the rest at your own pace.
+
+## Use cases for upgrading to Hiera 5
+
+- **hiera-eyaml users** — Upgrade now. OpenVox includes a built-in hiera-eyaml backend for Hiera 5. (It still requires that the `hiera-eyaml` gem be installed.)
+  See the [usage instructions in the hiera.yaml (v5) syntax reference][eyaml_v5].
+  This means you can move your existing encrypted YAML data into the environment layer at the same time you move your other data.
+
+- **Custom backend users** — Wait for updated backends. You can keep using custom Hiera 3 backends with Hiera 5, but they'll make upgrading more complex,
+  because you can't move legacy data to the environment layer until there's a Hiera 5 backend for it.
+  If an updated version of the backend is coming out soon, wait. If you're using an off-the-shelf custom backend, check its website or contact its developer.
+  If you developed your backend in-house, read the [documentation about writing Hiera 5 backends][backends].
+
+- **Custom `data_binding_terminus` users** — Upgrade now, and replace it with a Hiera 5 backend as soon as possible.
+  There's a deprecated `data_binding_terminus` setting in `puppet.conf` which changes the behavior of automatic class parameter lookup.
+  It can be set to `hiera` (normal), `none` (deprecated; disables auto-lookup), or the name of a custom plugin.
+  Once you have a Hiera 5 backend, integrate it into your hierarchies and delete the `data_binding_terminus` setting.
+
+Related topics: [environment data layer][layers], [hiera.yaml (v5) eyaml usage][eyaml_v5], [writing Hiera 5 backends][backends], [puppet.conf][puppet_conf], [automatic class parameter lookup][automatic].
+
+## Enable the environment layer for existing Hiera data
+
+A key feature in Hiera 5 is per-environment hierarchy configuration. Because you probably store data in each environment, local `hiera.yaml` files are more logical and convenient than a single global hierarchy.
+
+You can enable the environment layer gradually. In migrated environments, the legacy Hiera functions switch to Hiera 5 mode — they can access environment and module data without requiring any code changes.
+
+> Note: Before migrating environment data to Hiera 5, be aware that if you rely on custom Hiera 3 backends, you should upgrade them for Hiera 5 or prepare for some extra work during migration.
+> If your only custom backend is hiera-eyaml, continue upgrading — OpenVox includes a Hiera 5 eyaml backend.
+
+The process of enabling the environment layer involves the following steps. In each environment, you will:
+
+1. Check your code for Hiera function calls with "hierarchy override arguments", which will cause errors in Hiera 5.
+   A quick way to find instances of using this argument is to search for calls with two or more commas using the following regular expression:
+
+   ```regexp
+   hiera(_array|_hash|_include)?\(([^,\)]*,){2,}[^\)]*\)
+   ```
+
+2. Choose a new data directory name. The default data directory name in Hiera 3 was `<ENVIRONMENT>/hieradata`, and the default in Hiera 5 is `<ENVIRONMENT>/data`.
+   If you used the old default, use the new default.
+
+3. Add a Hiera 5 `hiera.yaml` file to the environment. Each environment needs a Hiera config file that works with its existing data.
+   See [converting a version 3 hiera.yaml to version 5](#convert-a-version-3-hierayaml-to-version-5). Make sure to reference the new `datadir` name. Save the resulting file as `<ENVIRONMENT>/hiera.yaml`.
+
+4. If any of your data relies on custom backends that have been ported to Hiera 5, install them in the environment.
+   Hiera 5 backends are distributed as OpenVox modules, so each environment can use its own version of them.
+
+5. Move the environment's data directory by renaming it from its old name (`hieradata`) to its new name (`data`).
+   If you use custom file-based Hiera 3 backends, the global layer still needs access to their data, so you need to sort the files:
+   Hiera 5 data moves to the new data directory, and Hiera 3 data stays in the old data directory.
+
+6. Repeat these steps for each environment.
+
+7. After you have migrated the environments that have active node populations, delete the parts of your global hierarchy that you transferred into environment hierarchies.
+
+> **Important**: The environment layer does not support Hiera 3 backends.
+> If any of your data uses a custom backend that has not been ported to Hiera 5, omit those hierarchy levels from the environment config and continue to use the global layer for that data.
+
+Related topics: [per-environment hierarchy configuration][layers], [legacy backends][legacy_backend], [hiera.yaml (v5)][eyaml_v5], [custom backends][backends].
+
+## Convert a version 3 hiera.yaml to version 5
+
+Hiera 5 supports three versions of the `hiera.yaml` file: version 3, version 4, and version 5. If you've been using Hiera 3, your existing configuration is a version 3 `hiera.yaml` file at the global layer.
+
+Consider this example `hiera.yaml` version 3 file:
+
+```yaml
+:backends:
+  - mongodb
+  - eyaml
+  - yaml
+:yaml:
+  :datadir: "/etc/puppetlabs/code/environments/%{environment}/hieradata"
+:mongodb:
+  :connections:
+    :dbname: hdata
+    :collection: config
+    :host: localhost
+:eyaml:
+  :datadir: "/etc/puppetlabs/code/environments/%{environment}/hieradata"
+  :pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+  :pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+:hierarchy:
+  - "nodes/%{trusted.certname}"
+  - "location/%{facts.whereami}/%{facts.group}"
+  - "groups/%{facts.group}"
+  - "os/%{facts.os.family}"
+  - "common"
+:logger: console
+:merge_behavior: native
+:deep_merge_options: {}
+```
+
+To convert this version 3 file to version 5:
+
+1. **Use strings instead of symbols for keys.** Remove the leading colons on keys.
+
+2. **Remove settings that aren't used anymore.** Delete the following settings completely:
+   - `:logger`
+   - `:merge_behavior`
+   - `:deep_merge_options`
+
+   Paste the following settings into a temporary file for reference, then delete them from `hiera.yaml`:
+   - `:backends`
+   - Any backend-specific setting sections, like `:yaml` or `:mongodb`
+
+3. **Add a `version` key** with a value of `5`:
+
+   ```yaml
+   version: 5
+   hierarchy:
+     # ...
+   ```
+
+4. **Set a default backend and data directory.** If you use one backend for the majority of your data, set a `defaults` key with values for `datadir` and one of the backend keys.
+   The names of the backends have changed for Hiera 5:
+
+   Hiera 3 backend | Hiera 5 backend setting
+   ----------------|------------------------
+   `yaml`          | `data_hash: yaml_data`
+   `json`          | `data_hash: json_data`
+   `eyaml`         | `lookup_key: eyaml_lookup_key`
+
+5. **Translate the hierarchy.** In version 5, each hierarchy level has one designated backend.
+   Consult the previous values for the `:backends` key and any backend-specific settings to determine how to split your existing hierarchy levels across backends.
+
+6. **Remove hierarchy levels** that use `calling_module`, `calling_class`, and `calling_class_path`. These pseudo-variables are not supported in `hiera.yaml` version 5.
+
+7. **Translate built-in backends** to the version 5 config:
+
+   ```yaml
+   version: 5
+   defaults:
+     datadir: data
+     data_hash: yaml_data
+   hierarchy:
+     - name: "Per-node data (yaml version)"
+       path: "nodes/%{trusted.certname}.yaml"
+
+     - name: "Other YAML hierarchy levels"
+       paths:
+         - "location/%{facts.whereami}/%{facts.group}.yaml"
+         - "groups/%{facts.group}.yaml"
+         - "os/%{facts.os.family}.yaml"
+         - "common.yaml"
+   ```
+
+8. **Translate hiera-eyaml backends:**
+
+   ```yaml
+   - name: "Per-group secrets"
+     path: "groups/%{facts.group}.eyaml"
+     lookup_key: eyaml_lookup_key
+     options:
+       pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+       pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+   ```
+
+9. **Translate custom Hiera 3 backends.** Check if the backend's author has published a Hiera 5 update.
+   If there is no update, use the version 3 backend in a version 5 hierarchy at the global layer — it will not work in the environment layer.
+   See [Configuring a hierarchy level (legacy Hiera 3 backends)][legacy_backend] for details.
+
+After following these steps, the example configuration becomes:
+
+```yaml
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "Per-node data (yaml version)"
+    path: "nodes/%{trusted.certname}.yaml"
+
+  - name: "Per-node data (MongoDB version)"
+    path: "nodes/%{trusted.certname}"
+    hiera3_backend: mongodb
+    options:
+      connections:
+        dbname: hdata
+        collection: config
+        host: localhost
+
+  - name: "Per-group secrets"
+    path: "groups/%{facts.group}.eyaml"
+    lookup_key: eyaml_lookup_key
+    options:
+      pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
+      pkcs7_public_key:  /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
+
+  - name: "Other YAML hierarchy levels"
+    paths:
+      - "location/%{facts.whereami}/%{facts.group}.yaml"
+      - "groups/%{facts.group}.yaml"
+      - "os/%{facts.os.family}.yaml"
+      - "common.yaml"
+```
+
+Related topics: [version 3][v3], [version 4][v4], [version 5][v5], [global layer][layers], [Merging data from multiple sources][merging], [set a defaults key][v5_defaults],
+[Configuring a hierarchy level (built-in backends)][v5_builtin], [Hiera 5 backends][backends], [eyaml usage instructions][eyaml_v5].
+
+## Convert an experimental (version 4) hiera.yaml to version 5
+
+If you used the experimental version of Puppet lookup (Hiera 5's predecessor), you might have some version 4 `hiera.yaml` files in your environments and modules.
+Hiera 5 can use these, but you will need to convert them, especially if you want to use any backends other than YAML or JSON.
+
+Consider this example of a version 4 `hiera.yaml` file:
+
+```yaml
+# /etc/puppetlabs/code/environments/production/hiera.yaml
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "Nodes"
+    backend: yaml
+    path: "nodes/%{trusted.certname}"
+
+  - name: "Exported JSON nodes"
+    backend: json
+    paths:
+      - "nodes/%{trusted.certname}"
+      - "insecure_nodes/%{facts.networking.fqdn}"
+
+  - name: "virtual/%{facts.virtual}"
+    backend: yaml
+
+  - name: "common"
+    backend: yaml
+```
+
+To convert to version 5:
+
+1. Change the value of the `version` key to `5`.
+
+2. Add a file extension to every file path — use `"common.yaml"`, not `"common"`.
+
+3. If any hierarchy levels are missing a `path`, add one. In version 5, `path` no longer defaults to the value of `name`.
+
+4. If there is a top-level `datadir` key, change it to a `defaults` key and set a default backend:
+
+   ```yaml
+   defaults:
+     datadir: data
+     data_hash: yaml_data
+   ```
+
+5. In each hierarchy level, delete the `backend` key and replace it with a `data_hash` key:
+
+   v4 backend      | v5 equivalent
+   ----------------|--------------
+   `backend: yaml` | `data_hash: yaml_data`
+   `backend: json` | `data_hash: json_data`
+
+6. Delete the `environment_data_provider` and `data_provider` settings, which enabled Puppet lookup for an environment or module.
+   You'll find these in `puppet.conf`, `environment.conf`, and a module's `metadata.json`.
+
+After being converted to version 5, the example looks like this:
+
+```yaml
+# /etc/puppetlabs/code/environments/production/hiera.yaml
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "Nodes"
+    path: "nodes/%{trusted.certname}.yaml"
+
+  - name: "Exported JSON nodes"
+    data_hash: json_data
+    paths:
+      - "nodes/%{trusted.certname}.json"
+      - "insecure_nodes/%{facts.networking.fqdn}.json"
+
+  - name: "Virtualization platform"
+    path: "virtual/%{facts.virtual}.yaml"
+
+  - name: "common"
+    path: "common.yaml"
+```
+
+Related topics: [defaults key][v5_defaults], [the hiera.yaml version 5 reference][v5], [backends][backends].
+
+## Convert experimental data provider functions to a Hiera 5 `data_hash` backend
+
+Puppet lookup had experimental custom backend support, where you could set `data_provider = function` and create a function with a name that returned a hash.
+You can convert such a function to a Hiera 5 `data_hash` backend:
+
+1. Change the function's signature to accept two arguments: a `Hash` and a `Puppet::LookupContext` object. You do not have to do anything with these — just add them to the signature.
+
+2. Delete the `data_provider` setting from the module's `metadata.json`.
+
+3. Create a version 5 `hiera.yaml` file for the affected environment or module, and add a hierarchy level as follows:
+
+   ```yaml
+   - name: <ARBITRARY NAME>
+     data_hash: <NAME OF YOUR FUNCTION>
+   ```
+
+   It does not need a `path`, `datadir`, or any other options.
+
+## Updated classic Hiera function calls
+
+The `hiera`, `hiera_array`, `hiera_hash`, and `hiera_include` functions are all deprecated. The `lookup` function is a complete replacement for all of these.
+
+Hiera function                | Equivalent `lookup` call
+------------------------------|-------------------------
+`hiera('secure_server')`      | `lookup('secure_server')`
+`hiera_array('ntp::servers')` | `lookup('ntp::servers', {merge => unique})`
+`hiera_hash('users')`         | `lookup('users', {merge => hash})` or `lookup('users', {merge => deep})`
+`hiera_include('classes')`    | `lookup('classes', {merge => unique}).include`
+
+To prepare for deprecations in future OpenVox versions, it's best to revise your modules to replace the `hiera_*` functions with `lookup`.
+While revising, consider refactoring code to use automatic class parameter lookup instead of manual lookup calls.
+Because automatic lookups can now do unique and hash merges, the use of `hiera_array` and `hiera_hash` are not as important as they used to be.
+
+Related topics: [automatic class parameter lookup][automatic], [unique and hash merges][merging].
+
+## Adding Hiera data to a module
+
+Modules need default values for their class parameters. Before, the preferred way to do this was the "params.pp" pattern. With Hiera 5, you can use the "data in modules" approach instead.
+
+> Note: The "params.pp" pattern is still valid. But if you want to use Hiera data instead, you now have that option.
+
+### Module data with the "params.pp" pattern
+
+The "params.pp" pattern takes advantage of Puppet class inheritance behavior:
+
+- One class in your module sets variables for the other classes: `<MODULE>::params`.
+- This class uses Puppet code to construct values using conditional logic based on the target operating system.
+- The rest of the classes in the module inherit from the params class, using its variables as default parameter values.
+- When using the "params.pp" pattern, the values set in `params.pp` cannot be used in lookup merges — they are only used for defaults when no values are found in Hiera.
+
+An example params class:
+
+```puppet
+# ntp/manifests/params.pp
+class ntp::params {
+  $autoupdate = false,
+  $default_service_name = 'ntpd',
+
+  case $facts['os']['family'] {
+    'AIX': {
+      $service_name = 'xntpd'
+    }
+    'Debian': {
+      $service_name = 'ntp'
+    }
+    'RedHat': {
+      $service_name = $default_service_name
+    }
+  }
+}
+```
+
+A class that inherits from the params class:
+
+```puppet
+# ntp/manifests/init.pp
+class ntp (
+  $autoupdate   = $ntp::params::autoupdate,
+  $service_name = $ntp::params::service_name,
+) inherits ntp::params {
+ ...
+}
+```
+
+### Module data with a one-off custom Hiera backend
+
+With Hiera 5's custom backend system, you can convert an existing params class to a hash-based Hiera backend. Create a function written in the Puppet language that returns a hash:
+
+```puppet
+# ntp/functions/params.pp
+function ntp::params(
+  Hash                  $options,
+  Puppet::LookupContext $context,
+) {
+  $base_params = {
+    'ntp::autoupdate'   => false,
+    'ntp::service_name' => 'ntpd',
+  }
+
+  $os_params = case $facts['os']['family'] {
+    'AIX': {
+      { 'ntp::service_name' => 'xntpd' }
+    }
+    'Debian': {
+      { 'ntp::service_name' => 'ntp' }
+    }
+    default: {
+      {}
+    }
+  }
+
+  $base_params + $os_params
+}
+```
+
+Tell Hiera to use it by adding it to the module layer `hiera.yaml`.
+Add it to the `default_hierarchy` for exact "params.pp" behavior (only used as defaults, not merged), or to the regular `hierarchy` if you want values to be merged:
+
+```yaml
+# ntp/hiera.yaml
+---
+version: 5
+hierarchy:
+  - name: "NTP class parameter defaults"
+    data_hash: "ntp::params"
+```
+
+With Hiera-based defaults, you can simplify your module's main classes — they do not need to inherit from any other class, and you do not need to explicitly set default values:
+
+```puppet
+# ntp/manifests/init.pp
+class ntp (
+  $autoupdate,
+  $service_name,
+) {
+ ...
+}
+```
+
+### Module data with YAML data files
+
+You can also manage your module's default data with basic Hiera YAML files:
+
+```yaml
+# ntp/hiera.yaml
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS family"
+    path: "os/%{facts.os.family}.yaml"
+
+  - name: "common"
+    path: "common.yaml"
+```
+
+Then put the necessary data files in the data directory:
+
+```yaml
+# ntp/data/common.yaml
+---
+ntp::autoupdate: false
+ntp::service_name: ntpd
+```
+
+```yaml
+# ntp/data/os/AIX.yaml
+---
+ntp::service_name: xntpd
+```
+
+```yaml
+# ntp/data/os/Debian.yaml
+---
+ntp::service_name: ntp
+```
+
+Related topics: [class inheritance][class_inheritance], [conditional logic][conditional_logic], [custom backend system][custom_backend_system],
+[write functions in the Puppet language][functions_puppet], [hash merge operator][hash_merge_operator], [module layer][layers], [automatic class parameter lookup][automatic].

--- a/docs/_openvox_8x/hiera_quick.md
+++ b/docs/_openvox_8x/hiera_quick.md
@@ -1,11 +1,216 @@
 ---
+layout: default
 title: "Getting started with Hiera"
 ---
 
+[layers]: ./hiera_intro.html#hieras-three-config-layers
+[merging]: ./hiera_merging.html#merge-behaviors
+[v5]: ./hiera_config_yaml_5.html
+[yaml]: https://yaml.org/spec/1.2/spec.html
+[hierarchies]: ./hiera_intro.html#hiera-hierarchies
+[variables]: ./hiera_merging.html#interpolating-variables
+[automatic]: ./hiera_automatic.html
+[certname]: ./lang_facts_and_builtin_vars.html#trusted-facts
+[cli]: ./man/lookup.html
+[confdir]: ./dirs_confdir.html
+[codedir]: ./dirs_codedir.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+This page introduces the basic concepts and tasks to get you started with Hiera, including how to create a hiera.yaml config file and write data.
+It is the foundation for understanding the more advanced topics described in the rest of the Hiera documentation.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+Related topics: [global layer and module layer][layers], [hash and array merging][merging].
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+## Create a hiera.yaml config file
 
+The Hiera config file is called `hiera.yaml`. Each environment should have its own `hiera.yaml` file.
+
+1. In the main directory of one of your environments, create a new file called `hiera.yaml`. Paste the following contents into it:
+
+   ```yaml
+   # <ENVIRONMENT>/hiera.yaml
+   ---
+   version: 5
+
+   hierarchy:
+     - name: "Per-node data"                   # Human-readable name.
+       path: "nodes/%{trusted.certname}.yaml"  # File path, relative to datadir.
+                                      # ^^^ IMPORTANT: include the file extension!
+
+     - name: "Per-OS defaults"
+       path: "os/%{facts.os.family}.yaml"
+
+     - name: "Common data"
+       path: "common.yaml"
+   ```
+
+   This file is in a format called YAML, which is used extensively throughout Hiera.
+
+Related topics: [The hiera.yaml (v5) reference][v5], [YAML specification][yaml].
+
+## The hierarchy
+
+The `hiera.yaml` file configures a hierarchy: an ordered list of data sources.
+
+Hiera searches these data sources in the order they are written. Higher-priority sources override lower-priority ones.
+Most hierarchy levels use variables to locate a data source, so that different nodes get different data.
+
+This is the core concept of Hiera: a defaults-with-overrides pattern for data lookup, using a node-specific list of data sources.
+
+Related topics: [hierarchies][hierarchies], [variables][variables].
+
+## Write data: Create a test class
+
+A test class writes the data it receives to a temporary file on the agent when applying the catalog.
+
+Hiera is used with OpenVox code, so the first step is to create an OpenVox class for testing.
+
+1. If you do not already use the roles and profiles method, create a module named `profile`. Profiles are wrapper classes that use multiple component modules to configure a layered technology stack.
+
+2. Create a class called `hiera_test.pp` in your `profile` module.
+
+3. Add the following code to your `hiera_test.pp` file:
+
+   ```puppet
+   # /etc/puppetlabs/code/environments/production/modules/profile/manifests/hiera_test.pp
+   class profile::hiera_test (
+     Boolean             $ssl,
+     Boolean             $backups_enabled,
+     Optional[String[1]] $site_alias = undef,
+   ) {
+     file { '/tmp/hiera_test.txt':
+       ensure  => file,
+       content => @("END"),
+                  Data from profile::hiera_test
+                  -----
+                  profile::hiera_test::ssl: ${ssl}
+                  profile::hiera_test::backups_enabled: ${backups_enabled}
+                  profile::hiera_test::site_alias: ${site_alias}
+                  |END
+       owner   => root,
+       mode    => '0644',
+     }
+   }
+   ```
+
+   The test class uses class parameters to request configuration data. OpenVox looks up class parameters in Hiera, using `<CLASS NAME>::<PARAMETER NAME>` as the lookup key.
+
+4. Make a manifest that includes the class:
+
+   ```puppet
+   # site.pp
+   include profile::hiera_test
+   ```
+
+5. Compile the catalog and observe that this fails because there are required values.
+
+6. To provide values for the missing class parameters, set the following keys in your Hiera data:
+
+   Parameter          | Hiera key
+   -------------------|---------------------------------------
+   `$ssl`             | `profile::hiera_test::ssl`
+   `$backups_enabled` | `profile::hiera_test::backups_enabled`
+   `$site_alias`      | `profile::hiera_test::site_alias`
+
+7. Compile again and observe that the parameters are now automatically looked up.
+
+Related topics: [Automatic class parameter lookup][automatic].
+
+## Write data: Set values in common data
+
+Set values in your common data — the level at the bottom of your hierarchy.
+
+This hierarchy level uses the YAML backend for data, which means the data goes into a YAML file. To know where to put that file, combine the following pieces of information:
+
+* The current environment's directory.
+* The data directory, which is a subdirectory of the environment. By default, it's `<ENVIRONMENT>/data`.
+* The file path specified by the hierarchy level.
+
+In this case, `/etc/puppetlabs/code/environments/production/` + `data/` + `common.yaml`.
+
+1. Open that YAML file in an editor, and set values for two of the class's parameters.
+
+   ```yaml
+   # /etc/puppetlabs/code/environments/production/data/common.yaml
+   ---
+   profile::hiera_test::ssl: false
+   profile::hiera_test::backups_enabled: true
+   ```
+
+   The third parameter, `$site_alias`, has a default value defined in code, so you can omit it from the data.
+
+## Write data: Set per-operating system data
+
+The second level of the hierarchy uses the `os` fact to locate its data file. This means it can use different data files depending on the operating system of the current node.
+
+For this example, suppose that your developers use MacBook laptops, which have an OS family of `Darwin`.
+If a developer is running an app instance on their laptop, it should not send data to your production backup server, so set `$backups_enabled` to `false`.
+
+If you do not run OpenVox on any Mac laptops, choose an OS family that is meaningful to your infrastructure.
+
+1. Locate the data file by replacing `%{facts.os.family}` with the value you are targeting:
+
+   `/etc/puppetlabs/code/environments/production/data/` + `os/` + `Darwin` + `.yaml`
+
+2. Add the following contents:
+
+   ```yaml
+   # /etc/puppetlabs/code/environments/production/data/os/Darwin.yaml
+   ---
+   profile::hiera_test::backups_enabled: false
+   ```
+
+3. Compile to observe that the override takes effect.
+
+## Write data: Set per-node data
+
+The highest level of the example hierarchy uses the value of `$trusted['certname']` to locate its data file, so you can set data by name for each individual node.
+
+This example supposes you have a server named `jenkins-prod-03.example.com`, and configures it to use SSL and to serve this application at the hostname `ci.example.com`.
+To try this out, choose the name of a real server that you can run OpenVox on.
+
+1. To locate the data file, replace `%{trusted.certname}` with the node name you're targeting:
+
+   `/etc/puppetlabs/code/environments/production/data/` + `nodes/` + `jenkins-prod-03.example.com` + `.yaml`
+
+2. Open that file in an editor and add the following contents:
+
+   ```yaml
+   # /etc/puppetlabs/code/environments/production/data/nodes/jenkins-prod-03.example.com.yaml
+   ---
+   profile::hiera_test::ssl: true
+   profile::hiera_test::site_alias: ci.example.com
+   ```
+
+3. Compile to observe that the override takes effect.
+
+Related topics: [$trusted['certname']][certname].
+
+## Testing Hiera data on the command line
+
+As you set Hiera data or rearrange your hierarchy, it is important to double-check the data a node will receive.
+
+The `puppet lookup` command helps test data interactively. For example:
+
+```sh
+puppet lookup profile::hiera_test::backups_enabled --environment production --node jenkins-prod-03.example.com
+```
+
+This returns the following value:
+
+```yaml
+--- true
+```
+
+To use the `puppet lookup` command effectively:
+
+* Run the command on an OpenVox server node, or on another node that has access to a full copy of your OpenVox code and configuration.
+* The node you are testing against should have contacted the server at least once, as this makes the facts for that node available to the lookup command
+  (otherwise you will need to supply the facts yourself on the command line).
+* Make sure the command uses the global `confdir` and `codedir`, so it has access to your live data. If you're not running `puppet lookup` as root user, specify `--codedir` and `--confdir` on the command line.
+* If you use PuppetDB, you can use any node's facts in a lookup by specifying `--node <NAME>`. Hiera can automatically get that node's real facts and use them to resolve data.
+* If you do not use PuppetDB, or if you want to test for a set of facts that don't exist, provide facts in a YAML or JSON file and specify that file as part of the command with `--facts <FILE>`.
+  To get a file full of facts, rather than creating one from scratch, run `facter -p --json > facts.json` on a node that is similar to the node you want to examine,
+  copy the `facts.json` file to your OpenVox server node, and edit it as needed.
+* If you are not getting the values you expect, try re-running the command with `--explain`. The `--explain` flag makes Hiera output a full explanation of which data sources it searched and what it found in them.
+
+Related topics: [The puppet lookup command][cli], [confdir][confdir], [codedir][codedir].


### PR DESCRIPTION
## Summary

Several Hiera pages were still placeholder stubs after PR #74. This PR restores the remaining five pages to full content using the puppetlabs/docs-archive (puppet/5.4) as source material, with minimal changes to adapt them for OpenVox.

**Scope:** This is a baseline restoration only — the goal is to get real content on the page rather than a stub. Accuracy review, technical updates, and deeper content work are out of scope for this PR.

Changes made:

- Restore `hiera_quick.md`, `hiera_merging.md`, `hiera_automatic.md`, `hiera_custom_backends.md`, and `hiera_migrate.md` from stub placeholders to full content
- Replace Puppet product name references with OpenVox
- Add `layout: default` frontmatter to all five files
- Fix broken `environments.html` → `environments_about.html` internal link
- Fix stale YAML Cookbook external link (replaced with YAML 1.2 specification)
- Pre-emptively wrap long prose lines to satisfy the 210-character MD013 limit from PR #30
- Fix fenced code blocks to include language tags (MD040)

## Test plan

- [x] Site builds without errors
- [x] All internal links resolve (verified against built `_site/`)
- [x] All external links return HTTP 200
- [x] No MD013 prose line-length violations above 210 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)