### PR TITLE
Fix and update Ruby functions API docs

### DIFF
--- a/docs/_openvox_8x/_naming_functions.md
+++ b/docs/_openvox_8x/_naming_functions.md
@@ -1,10 +1,13 @@
+<!-- markdownlint-disable MD041 -->
 Function names generally resemble these examples:
 
 * `num2bool` (a function that could come from anywhere)
 * `postgresql::acls_to_resource_hash` (a function in the `postgresql` module)
 * `environment::hash_from_api_call` (a function in an environment)
 
-Function names are almost the same as [class names](./lang_reserved.html#classes-and-defined-resource-types). They consist of one or more segments; each segment must start with a lowercase letter, and can include:
+Function names are almost the same as
+[class names](./lang_reserved.html#classes-and-defined-resource-types).
+They consist of one or more segments; each segment must start with a lowercase letter, and can include:
 
 * Lowercase letters.
 * Numbers.
@@ -24,10 +27,10 @@ Function names can be either _global_ or _namespaced._
 
 * Global names have only one segment (like `str2bool`), and can be used in any module or environment.
 
-    Global names are shorter, but they're not guaranteed to be unique --- two modules might use the same function name, in which case Puppet won't necessarily load the one you want.
+    Global names are shorter, but they're not guaranteed to be unique --- two modules might use the same function name, in which case OpenVox won't necessarily load the one you want.
 * Namespaced names have multiple segments (like `stdlib::str2bool`), and are guaranteed to be unique. The first segment is dictated by the function's location:
-    * In an environment, it must be the literal word `environment` (like `environment::str2bool`).
-    * In a module, it must be the module's name (like `stdlib::str2bool`, for a function stored in the `stdlib` module).
+  * In an environment, it must be the literal word `environment` (like `environment::str2bool`).
+  * In a module, it must be the module's name (like `stdlib::str2bool`, for a function stored in the `stdlib` module).
 
     Functions usually only have two name segments, although it's legal to use more.
 

--- a/docs/_openvox_8x/functions_ruby_documenting.md
+++ b/docs/_openvox_8x/functions_ruby_documenting.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Writing functions in Ruby: Documenting Ruby functions"
 ---
 
@@ -6,13 +7,15 @@ title: "Writing functions in Ruby: Documenting Ruby functions"
 [overview]: ./functions_ruby_overview.html
 [signatures]: ./functions_ruby_signatures.html
 
-[Puppet Strings][], a free documentation tool for Puppet, can extract code details and specially-formatted comments to build documentation pages for functions. This page describes the proper formatting to make your comments work well with Strings.
+[Puppet Strings][], a free documentation tool for OpenVox, can extract code details and specially-formatted comments to build
+documentation pages for functions. This page describes the proper formatting to make your comments work well with Strings.
 
 > **Note:** This is one of several pages describing the Ruby functions API. Before reading it, make sure you understand the [overview of this API][overview] and how to [define function signatures][signatures].
 
 ## Examples
 
-Full content for this page is coming soon. In the meantime, the following examples show how to format comments in two situations: a function with two explicit signatures, and a function with an automatic signature.
+Full content for this page is coming soon. In the meantime, the following examples show how to format comments in two situations:
+a function with two explicit signatures, and a function with an automatic signature.
 
 ``` ruby
 # Subtracts two things.

--- a/docs/_openvox_8x/functions_ruby_implementation.md
+++ b/docs/_openvox_8x/functions_ruby_implementation.md
@@ -1,11 +1,12 @@
 ---
+layout: default
 title: "Writing functions in Ruby: Using special features in implementation methods"
 ---
 
 [overview]: ./functions_ruby_overview.html
 [signatures]: ./functions_ruby_signatures.html
 [documenting]: ./functions_ruby_documenting.html
-[parser scope]: ./yard/Puppet/Parser/Scope.html
+[parser scope]: https://www.rubydoc.info/gems/puppet/Puppet/Parser/Scope
 [variables]: ./lang_variables.html
 [facts]: ./lang_facts_and_builtin_vars.html
 [trusted data]: ./lang_facts_and_builtin_vars.html#trusted-facts
@@ -13,14 +14,15 @@ title: "Writing functions in Ruby: Using special features in implementation meth
 [lambdas]: ./lang_lambdas.html
 [proc]: https://ruby-doc.org/core/Proc.html
 
-For the most part, implementation methods are normal Ruby. However, there are some special features available for accessing Puppet variables, working with provided blocks of Puppet code, and calling other functions.
+For the most part, implementation methods are normal Ruby. However, there are some special features available for accessing
+OpenVox variables, working with provided blocks of Puppet code, and calling other functions.
 
 > **Note:** This is one of several pages describing the Ruby functions API. Before reading it, make sure you understand the [overview of this API][overview] and how to [define function signatures][signatures].
 
+## Accessing OpenVox variables
 
-## Accessing Puppet variables
-
-Most functions should only use the arguments they are passed. However, you also have the option of accessing globally-reachable [Puppet variables][variables]. The main use case for this is accessing [facts][], [trusted data][], or [server data][].
+Most functions should only use the arguments they are passed. However, you also have the option of accessing
+globally-reachable [OpenVox variables][variables]. The main use case for this is accessing [facts][], [trusted data][], or [server data][].
 
 > **Note:** Functions cannot access **local** variables in the scope from which they were called. They can only access global variables or fully-qualified class variables.
 
@@ -58,13 +60,15 @@ If your signature specified an optional code block, your implementation method c
 
 When you know a block was provided, you can execute it any number of times with the `yield()` method.
 
-The arguments to `yield` will be passed as arguments to the lambda; since your signature probably specified the number and type of arguments the lambda should expect, you should be able to call it with confidence.
+The arguments to `yield` will be passed as arguments to the lambda; since your signature probably specified the number and
+type of arguments the lambda should expect, you should be able to call it with confidence.
 
 The return value of the `yield` call will be the return value of the provided lambda.
 
 ### Capturing a block as a Proc
 
-If you need to introspect a provided lambda, or pass it on to some other method, an implementation method can capture it as a [Proc][] by specifying an extra argument with an ampersand (`&`) flag. This works the same way as capturing a Ruby block as a Proc.
+If you need to introspect a provided lambda, or pass it on to some other method, an implementation method can capture it as a
+[Proc][] by specifying an extra argument with an ampersand (`&`) flag. This works the same way as capturing a Ruby block as a Proc.
 
 Once you've captured the block, you can execute it with `#call` instead of `yield`. You can also use any other Proc instance methods to examine it.
 
@@ -106,4 +110,6 @@ end
 
 To make this API reference easier to use, we've split some of its larger topics into separate pages. Please read the following pages to learn the remainder of the Ruby functions API:
 
-* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for Puppet, can extract documentation from functions and display it to your module's users. This page describes how to format your code comments to work well with Strings.
+* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for OpenVox, can extract
+  documentation from functions and display it to your module's users. This page describes how to format your code
+  comments to work well with Strings.

--- a/docs/_openvox_8x/functions_ruby_overview.md
+++ b/docs/_openvox_8x/functions_ruby_overview.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Writing functions in Ruby: Overview and examples"
 ---
 
@@ -8,11 +9,11 @@ title: "Writing functions in Ruby: Overview and examples"
 [func_puppet]: ./lang_write_functions_in_puppet.html
 [func_legacy]: ./functions_legacy.html
 [module]: ./modules_fundamentals.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [symbol]: https://ruby-doc.org/core/Symbol.html
 [data types]: ./lang_data_type.html
 
-Puppet includes two Ruby APIs for writing custom functions. This page is about the modern API, which uses the `Puppet::Functions` namespace.
+OpenVox includes two Ruby APIs for writing custom functions. This page is about the modern API, which uses the `Puppet::Functions` namespace.
 
 * If you want an easier way to write functions, try [writing them in the Puppet language.][func_puppet]
 * If you absolutely must support Puppet 3, you can use [the legacy Ruby functions API.][func_legacy]
@@ -32,14 +33,15 @@ Puppet::Functions.create_function(:'mymodule::upcase') do
 end
 ```
 
-To write a new function in Ruby, use the `Puppet::Functions.create_function` method. You don't need to `require` any Puppet libraries to make it available; Puppet handles that automatically when it loads the function file.
+To write a new function in Ruby, use the `Puppet::Functions.create_function` method. You don't need to `require` any Puppet
+libraries to make it available; OpenVox handles that automatically when it loads the function file.
 
 The `create_function` method requires:
 
 * A function name.
 * A block of code (which takes no arguments). This block should contain:
-    * One or more signatures, to configure the function's arguments. To build signatures, use the `dispatch` method and the parameter methods. [Signatures are fully described in a separate page.][signatures]
-    * An implementation method for each signature. The return value of the implementation method will be the return value of the function.
+  * One or more signatures, to configure the function's arguments. To build signatures, use the `dispatch` method and the parameter methods. [Signatures are fully described in a separate page.][signatures]
+  * An implementation method for each signature. The return value of the implementation method will be the return value of the function.
 
 In summary, with the pieces labled:
 
@@ -60,7 +62,8 @@ end
 
 A Ruby function must be placed in its own file, in the `lib/puppet/functions` directory of either a [module][] or an [environment][].
 
-The filename must match the name of the function, and have the `.rb` extension. For namespaced functions, each segment prior to the final one must be a subdirectory of `functions`, and the final segment must be the filename.
+The filename must match the name of the function, and have the `.rb` extension. For namespaced functions, each segment prior
+to the final one must be a subdirectory of `functions`, and the final segment must be the filename.
 
 Examples:
 
@@ -73,7 +76,9 @@ Function name         | File location
 
 ## Function names
 
+<!-- markdownlint-disable MD037 -->
 {% include_relative _naming_functions.md %}
+<!-- markdownlint-enable MD037 -->
 
 ### Pass names to `create_function` as symbols
 
@@ -86,25 +91,34 @@ To turn a function name into a symbol:
 
 ## Behavior of Ruby functions
 
-Ruby functions can have multiple signatures. When a function is called, Puppet checks each signature in order, comparing the allowed arguments to the arguments that were actually passed. Arguments are checked using Puppet's [data type system][data types], the same way class parameters are checked.
+Ruby functions can have multiple signatures. When a function is called, OpenVox checks each signature in order, comparing
+the allowed arguments to the arguments that were actually passed. Arguments are checked using OpenVox's
+[data type system][data types], the same way class parameters are checked.
 
-As soon as Puppet finds a signature that can accept the provided arguments, it calls the associated implementation method, passing the arguments to that method. When the method finishes running and returns a value, Puppet uses that as the function's return value.
+As soon as OpenVox finds a signature that can accept the provided arguments, it calls the associated implementation method,
+passing the arguments to that method. When the method finishes running and returns a value, OpenVox uses that as the
+function's return value.
 
-If none of the function's signatures match the provided arguments, Puppet fails compilation and logs an error message describing the mismatch between the provided and expected arguments.
+If none of the function's signatures match the provided arguments, OpenVox fails compilation and logs an error message describing the mismatch between the provided and expected arguments.
 
 ### Conversion of Puppet and Ruby data types
 
 When function arguments are passed to a Ruby method, they're converted to Ruby objects. Similarly, the method's return value is converted to a Puppet data type when the Puppet manifest regains control.
 
-Puppet converts data types between the Puppet language and Ruby as follows:
+OpenVox converts data types between the Puppet language and Ruby as follows:
 
+<!-- markdownlint-disable MD037 -->
 {% include_relative _puppet_types_to_ruby_types.md %}
-
+<!-- markdownlint-enable MD037 -->
 
 ## Next pages
 
 To make this API reference easier to use, we've split some of its larger topics into separate pages. Please read the following pages to learn the remainder of the Ruby functions API:
 
 * [Defining function signatures][signatures]. This page describes the `dispatch` method and the parameter methods.
-* [Using special features in implementation methods][implementation]. For the most part, implementation methods are basic Ruby. However, there are some special features available for accessing Puppet variables, working with provided blocks of Puppet code, and calling other functions.
-* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for Puppet, can extract documentation from functions and display it to your module's users. This page describes how to format your code comments to work well with Strings.
+* [Using special features in implementation methods][implementation]. For the most part, implementation methods are basic
+  Ruby. However, there are some special features available for accessing OpenVox variables, working with provided blocks
+  of Puppet code, and calling other functions.
+* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for OpenVox, can extract
+  documentation from functions and display it to your module's users. This page describes how to format your code
+  comments to work well with Strings.

--- a/docs/_openvox_8x/functions_ruby_signatures.md
+++ b/docs/_openvox_8x/functions_ruby_signatures.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Writing functions in Ruby: Defining function signatures"
 ---
 
@@ -9,25 +10,26 @@ title: "Writing functions in Ruby: Defining function signatures"
 [lambda]: ./lang_lambdas.html
 [call]: ./lang_functions.html
 [callable]: ./lang_data_abstract.html#callable
-[variant]: lang_data_abstract.html#variant
+[variant]: ./lang_data_abstract.html#variant
+[abstract data types]: ./lang_data_abstract.html
 [implementation]: ./functions_ruby_implementation.html
 [documenting]: ./functions_ruby_documenting.html
 
-
 Functions can specify how many arguments they expect, and can specify a data type for each argument. The rule set for a function's arguments is called a **signature.**
 
-Since Puppet functions support more advanced argument checking than Ruby does, the functions API uses a lightweight domain-specific language (DSL) to specify signatures.
+Since functions support more advanced argument checking than Ruby does, the functions API uses a lightweight domain-specific language (DSL) to specify signatures.
 
 > **Note:** This is one of several pages describing the Ruby functions API. Before reading it, make sure you understand the [overview of this API.][overview]
-
 
 ## Number of signatures
 
 A function written in Ruby can have more than one signature.
 
-Using multiple signatures is an easy way to have a function behave differently when passed different types or quantities of arguments --- instead of writing complex logic to decide what to do, you can write separate implementations and let Puppet figure out which one to use.
+Using multiple signatures is an easy way to have a function behave differently when passed different types or quantities of
+arguments --- instead of writing complex logic to decide what to do, you can write separate implementations and let OpenVox
+figure out which one to use.
 
-If a function has multiple signatures, Puppet checks them in the order they're written and uses the first one to match the provided arguments.
+If a function has multiple signatures, OpenVox checks them in the order they're written and uses the first one to match the provided arguments.
 
 ## Using automatic signatures
 
@@ -48,7 +50,11 @@ In this case, since the last segment of `stdlib::camelcase` is `camelcase`, we m
 
 ### Drawbacks of automatic signatures
 
-Although functions with automatic signatures are simpler to write, they give worse error messages when called incorrectly. Users will get a useful error if they call the function with a wrong number of arguments, but if they give the wrong _type_ of argument, they'll get something unhelpful. (For example, if you pass the function above a number instead of a string, it reports `Error: Evaluation Error: Error while evaluating a Function Call, undefined method 'split' for 5:Fixnum at /Users/nick/Desktop/test2.pp:7:8 on node magpie.lan`.)
+Although functions with automatic signatures are simpler to write, they give worse error messages when called incorrectly.
+Users will get a useful error if they call the function with a wrong number of arguments, but if they give the wrong _type_
+of argument, they'll get something unhelpful. (For example, if you pass the function above a number instead of a string,
+it reports `Error: Evaluation Error: Error while evaluating a Function Call, undefined method 'split' for 5:Fixnum`
+at the call site.)
 
 If your function might be used by anyone other than yourself, you should support your users by writing a signature with `dispatch`.
 
@@ -67,18 +73,17 @@ To write a signature, use the `dispatch` method.
 `dispatch` takes:
 
 * The name of an implementation method, provided as a Ruby [symbol][].
-    * The corresponding method must be defined somewhere in the `create_function` block, usually after all the signatures.
+  * The corresponding method must be defined somewhere in the `create_function` block, usually after all the signatures.
 * A block of code, which should only contain calls to the parameter and return methods (described below).
-
 
 ## Parameter methods
 
 In the code block of a `dispatch` statement, you can specify arguments with special parameter methods. All of these methods take two arguments:
 
 * The allowed data type for the argument, as a [string][ruby_string].
-    * Types are specified using Puppet's [data type syntax][data type].
+  * Types are specified using OpenVox's [data type syntax][data type].
 * A user-facing name for the argument, as a [symbol][].
-    * This name is only used in documentation and error messages; it doesn't have to match the argument names in the implementation method.
+  * This name is only used in documentation and error messages; it doesn't have to match the argument names in the implementation method.
 
 The order in which you call these methods is important: the function's first argument should go first, the second one second, etc.
 
@@ -98,7 +103,9 @@ Method name                                   | Description
 When specifying a repeatable argument, note that:
 
 * In your implementation method, the repeatable argument appears as an array, which contains all the provided values that weren't assigned to earlier, non-repeatable arguments.
-* The specified data type is matched against _each value_ for the repeatable argument, not the repeatable argument as a whole. For example, if you want to accept any number of numbers, you should specify `repeated_param 'Numeric', :values_to_average`, not `repeated_param 'Array[Numeric]', :values_to_average`.
+* The specified data type is matched against _each value_ for the repeatable argument, not the repeatable argument as a
+  whole. For example, if you want to accept any number of numbers, you should specify
+  `repeated_param 'Numeric', :values_to_average`, not `repeated_param 'Array[Numeric]', :values_to_average`.
 
 ### More about blocks of code
 
@@ -106,7 +113,9 @@ Functions can receive blocks of Puppet code, as described in [the docs on callin
 
 The data type for a block argument should always be [`Callable`][callable], or a [`Variant`][variant] that only contains `Callable`s.
 
-The `Callable` type can optionally specify the type and quantity of parameters that the lambda should accept; for example, `Callable[String, String]` matches any lambda that can be called with a pair of strings. For more details, [see the docs on the `Callable` type.][callable]
+The `Callable` type can optionally specify the type and quantity of parameters that the lambda should accept; for example,
+`Callable[String, String]` matches any lambda that can be called with a pair of strings. For more details,
+[see the docs on the `Callable` type.][callable]
 
 For details on how to execute a provided block in your implementation method, see [Using special features in implementation methods.][implementation]
 
@@ -147,9 +156,8 @@ Most notably, this means:
 
 ## The `return_type` method
 
-> **Note:** `return_type` only works with Puppet 4.7 and later. In earlier versions of Puppet, it will cause an evaluation error.
-
-After specifying a signature's arguments, you can use the `return_type` method to specify the data type of its return value. This method takes one argument: a [Puppet data type][data type], specified as a string.
+After specifying a signature's arguments, you can use the `return_type` method to specify the data type of its return value.
+This method takes one argument: a [Puppet data type][data type], specified as a string.
 
 ``` ruby
 dispatch :camelcase do
@@ -160,24 +168,24 @@ end
 
 The return type serves two purposes: documentation, and insurance.
 
-* Puppet Strings can include information about the return value of a function.
-* If something goes wrong and your function returns the wrong type (like `nil` when a string is expected), it will fail early with an informative error instead of allowing compilation to continue with an incorrect value.
+* Puppet Strings can include information about the return value of a function in generated docs.
+* If something goes wrong and your function returns the wrong type (like `nil` when a string is expected), it will fail
+  early with an informative error instead of allowing compilation to continue with an incorrect value.
 
 ## Specifying local type aliases
 
-> **Note:** Local type aliases only work with Puppet 4.5 and later. In earlier versions of Puppet, they will cause an evaluation error.
-
 If you are using complicated [abstract data types][] to validate arguments, and if you need to use these types in multiple signatures, they can sometimes become difficult to work with.
 
-In these cases, you can specify short aliases for your complex types and use the short names in your signatures. Centralizing the complex part like this can make your function more maintainable by reducing copy-pasted code.
+In these cases, you can specify short aliases for your complex types and use the short names in your signatures.
+Centralizing the complex part like this can make your function more maintainable by reducing copy-pasted code.
 
 To specify aliases, use the `local_types` method.
 
 * You must call `local_types` only once, _before_ any signatures.
 * `local_types` takes a block, which should only contain calls to the `type` method.
-* The `type` method takes a single [string][] argument, of the form `'<NAME> = <TYPE>'`.
-    * The name should be a capitalized, CamelCase word, similar to a Ruby class name or the existing [Puppet data types][data type].
-    * The type should be a valid [Puppet data type][data type].
+* The `type` method takes a single [string][ruby_string] argument, of the form `'<NAME> = <TYPE>'`.
+  * The name should be a capitalized, CamelCase word, similar to a Ruby class name or the existing [Puppet data types][data type].
+  * The type should be a valid [Puppet data type][data type].
 
 Example:
 
@@ -201,5 +209,9 @@ end
 
 To make this API reference easier to use, we've split some of its larger topics into separate pages. Please read the following pages to learn the remainder of the Ruby functions API:
 
-* [Using special features in implementation methods][implementation]. For the most part, implementation methods are basic Ruby. However, there are some special features available for accessing Puppet variables, working with provided blocks of Puppet code, and calling other functions.
-* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for Puppet, can extract documentation from functions and display it to your module's users. This page describes how to format your code comments to work well with Strings.
+* [Using special features in implementation methods][implementation]. For the most part, implementation methods are basic
+  Ruby. However, there are some special features available for accessing OpenVox variables, working with provided blocks
+  of Puppet code, and calling other functions.
+* [Documenting Ruby functions][documenting]. Puppet Strings, a free documentation tool for OpenVox, can extract
+  documentation from functions and display it to your module's users. This page describes how to format your code
+  comments to work well with Strings.


### PR DESCRIPTION
## Scope

Updates the four `functions_ruby_*` pages and two include files under `docs/_openvox_8x/`.

## Changes

- **Layout:** Add missing `layout: default` frontmatter to all four pages so they render with the correct theme
- **Broken links fixed:**
  - `functions_ruby_implementation.md`: `[parser scope]` was pointing to a local YARD path (`./yard/Puppet/Parser/Scope.html`) that doesn't exist → replaced with the live rubydoc.info URL
  - `functions_ruby_signatures.md`: `[variant]` was missing the `./` prefix; `[abstract data types]` reference was undefined → added both definitions
  - `functions_ruby_signatures.md`: `[string][]` was referencing an undefined label → changed to `[ruby_string][]`
- **Outdated content removed:** Two notes saying features "only work with Puppet 4.x" removed from `return_type` and `local_types` sections
- **OpenVox naming:** Updated prose references from "Puppet" to "OpenVox" where describing the product's behavior (checking signatures, failing compilation, converting data types, etc.). Code identifiers (`Puppet::Functions`, `Puppet::Parser::Scope`), language constructs ("Puppet language", "Puppet data type"), and tool names ("Puppet Strings") are unchanged
- **Linting (MD007/MD012/MD013):** Fixed 4-space sub-list indents → 2-space; removed multiple consecutive blank lines; wrapped long lines. Also added inline `markdownlint-disable` comments for known false positives on Liquid `{% include_relative %}` tags and include files without top-level headings. These changes are made in anticipation of [#30](https://github.com/OpenVoxProject/openvox-docs/pull/30) being merged — this PR will be clean against that config when it lands.

## Test plan

- [x] `bundle exec jekyll build` succeeds with no errors
- [x] All internal relative links in the four pages resolve to files in `_site/`
- [x] `markdownlint-cli2` reports 0 errors against the project's planned 210-char line-length config

🤖 Generated with [Claude Code](https://claude.com/claude-code)