### PR TITLE
Restore environment documentation from Puppet 5.4 archive

### DIFF
--- a/docs/_openvox_8x/environment_isolation.md
+++ b/docs/_openvox_8x/environment_isolation.md
@@ -1,14 +1,93 @@
 ---
 layout: default
 title: "Environment Isolation"
-canonical: "/puppet/latest/environment_isolation.html"
-description: "Generating metadata to isolate resources in environments in Puppet"
+description: "Generating metadata to isolate resources in environments in OpenVox"
 ---
 
+## Environment isolation
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+Environment isolation prevents resource types from leaking between your various environments.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+If you use multiple environments with OpenVox, you might encounter issues with multiple versions of the same
+resource type leaking between your various environments on the server. This doesn't happen with OpenVox's
+built-in resource types, but it can happen with any other resource types.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+This problem occurs because Ruby resource type bindings are global in the Ruby runtime. The first loaded
+version of a Ruby resource type takes priority, and subsequent requests to compile in other environments get
+that first-loaded version. Environment isolation solves this issue by generating and using metadata that
+describes the resource type implementation, instead of using the Ruby resource type implementation, when
+compiling catalogs.
 
+> **Note:** Other environment isolation problems, such as external helper logic issues or varying versions of
+> required gems, are not solved by the generated metadata approach. This fixes only resource type leaking.
+> Resource type leaking is a problem that affects only servers, not agents.
+
+## Enable environment isolation
+
+To use environment isolation, generate metadata files that OpenVox can use instead of the default Ruby
+resource type implementations.
+
+1. On the command line, run `puppet generate types --environment <ENV_NAME>` for each of your environments.
+   For example, to generate metadata for your production environment, run:
+
+   ``` bash
+   puppet generate types --environment production
+   ```
+
+2. Whenever you deploy a new version of OpenVox, overwrite previously generated metadata by running:
+
+   ``` bash
+   puppet generate types --environment <ENV_NAME> --force
+   ```
+
+## Enable environment isolation with r10k
+
+To use environment isolation with r10k, generate types for each environment every time r10k deploys new code.
+
+1. Use one of the following methods:
+   * Modify your existing r10k hook to run the `generate types` command after code deployment.
+   * Create a script that first runs r10k for an environment, then runs `generate types` as a post-run
+     command.
+2. If you have enabled environment-level purging in r10k, whitelist the `resource_types` folder so that
+   r10k doesn't purge it.
+
+## Troubleshooting environment isolation
+
+If the `generate types` command cannot generate certain types, if the generated type has missing or
+inaccurate information, or if generation itself has errors or fails, you will get a catalog compilation error
+of "type not found" or "attribute not found."
+
+To fix these errors:
+
+1. Ensure that your OpenVox resource types are correctly implemented. Refactor any problem resource types.
+2. Regenerate the metadata by removing the environment's `.resource_types` directory and running
+   `generate types` again.
+3. If you continue to get catalog compilation errors, disable environment isolation to help isolate the error.
+
+To disable environment isolation:
+
+1. Remove the `generate types` command from any r10k hooks.
+2. Remove the `.resource_types` directory.
+
+## The `generate types` command
+
+When you run `puppet generate types`, it scans the entire environment for resource type implementations,
+excluding core OpenVox resource types.
+
+The command accepts the following options:
+
+Option                     | Description
+---------------------------|------------
+`--environment <ENV_NAME>` | The environment for which to generate metadata. Defaults to `production`.
+`--force`                  | Overwrite all previously generated metadata.
+
+For each resource type implementation it finds, the command generates a corresponding metadata file in the
+`<env-root>/.resource_types` directory. It also syncs the directory so that:
+
+* Types removed from modules are removed from `resource_types`.
+* Types added to modules are added to `resource_types`.
+* Types that have not changed (based on timestamp) are kept as-is.
+* Types that have changed (based on timestamp) are overwritten with freshly generated metadata.
+
+The generated metadata files have a `.pp` extension and are read-only. Do not delete them, modify them, or
+use expressions from them in manifests.

--- a/docs/_openvox_8x/environments_about.markdown
+++ b/docs/_openvox_8x/environments_about.markdown
@@ -3,11 +3,80 @@ layout: default
 title: "About environments"
 ---
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+[modulepath]: ./dirs_modulepath.html
+[main manifest]: ./dirs_manifest.html
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+## Environments
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+Environments are isolated groups of OpenVox agent nodes.
 
+An OpenVox server serves each environment with its own main manifest and module path. This lets you use different versions
+of the same modules for different groups of nodes, which is useful for testing changes to your Puppet code before
+implementing them on production machines.
 
+Related topics: [main manifests][main manifest] and [module paths][modulepath].
 
+## Access environment name in Puppet manifests
+
+If you want to share code across environments, you can use the `$environment` variable in your Puppet manifests.
+
+To get the name of the current environment, use the `$environment` variable, which is set by the OpenVox server.
+
+## Environments scenarios
+
+The main uses for environments fall into three categories: permanent test environments, temporary test environments,
+and divided infrastructure.
+
+### Permanent test environments
+
+In a permanent test environment, there is a stable group of test nodes where all changes must succeed before they can
+be merged into the production code. The test nodes are a smaller version of the whole production infrastructure. They
+are either short-lived cloud instances or longer-lived virtual machines (VMs) in a private cloud. These nodes stay in
+the test environment for their whole lifespan.
+
+### Temporary test environments
+
+In a temporary test environment, you can test a single change or group of changes by checking the changes out of
+version control into the `$codedir/environments` directory, where it will be detected as a new environment. A temporary
+test environment can either have a descriptive name or use the commit ID from the version that it is based on. Temporary
+environments are good for testing individual changes, especially if you need to iterate quickly while developing them.
+Once you're done with a temporary environment, you can delete it. The nodes in a temporary environment are short-lived
+cloud instances or VMs, which are destroyed when the environment ends.
+
+### Divided infrastructure
+
+If parts of your infrastructure are managed by different teams that don't need to coordinate their code, you can split
+them into environments.
+
+## Environments limitations
+
+Environments have limitations, including leakage and conflicts with exported resources.
+
+### Plugins can leak between environments
+
+Environment leakage occurs when different versions of Ruby files, such as resource types, exist in multiple
+environments. When these files are loaded on the server, the first version loaded is treated as global. Subsequent
+requests in other environments get that first loaded version. Environment leakage does not affect the agent, as agents
+are only in one environment at any given time.
+
+### Exported resources can conflict or cross over
+
+Nodes in one environment can collect resources that were exported from another environment, which causes problems ---
+either a compilation error due to identically titled resources, or creation and management of unintended resources.
+The solution is to run separate OpenVox servers for each environment if you use exported resources.
+
+## Troubleshooting environment leaks
+
+Use one of the following methods to avoid environment leaks:
+
+* For resource types, you can avoid environment leaks with the `puppet generate types` command as described in the
+  environment isolation documentation. This command generates resource type metadata files to ensure that each
+  environment uses the right version of each type.
+
+* The leakage issue occurs only with the `Puppet::Parser::Functions` API. To fix this, rewrite functions with the
+  modern functions API, which is not affected by environment leakage. You can include helper code in the function
+  definition, but if helper code is more complex, it should be packaged as a gem and installed for all environments.
+
+* Report processors and indirector termini are still affected by this problem, so put them in your global Ruby
+  directories rather than in your environments. If they are in your environments, you must ensure they all have the
+  same content.

--- a/docs/_openvox_8x/environments_creating.markdown
+++ b/docs/_openvox_8x/environments_creating.markdown
@@ -3,9 +3,202 @@ layout: default
 title: "Creating Environments"
 ---
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+[environment.conf]: ./config_file_environment.html
+[modulepath]: ./dirs_modulepath.html
+[manifest_dir]: ./dirs_manifest.html
+[hiera.yaml]: ./hiera_config_yaml_5.html
+[default_manifest]: ./configuration.html#defaultmanifest
+[puppet.conf]: ./config_file_main.html
+[writingenc]: ./nodes_external.html
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+## Environment structure
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+An environment is a branch that gets turned into a directory on your OpenVox server. They follow several conventions.
 
+When you create an environment, give it the following structure:
+
+* It contains a `modules` directory, which becomes part of the environment's default module path.
+* It contains a `manifests` directory, which will be the environment's default main manifest.
+* It can optionally contain a `hiera.yaml` file.
+* It can optionally contain an `environment.conf` file, which can locally override configuration settings,
+  including `modulepath` and `manifest`.
+
+> **Note:** Environment names can contain lowercase letters, numbers, and underscores. They must match the
+> following regular expression: `\A[a-z0-9_]+\Z`
+
+Related topics: [environment.conf][environment.conf]
+
+## Environment resources
+
+An environment specifies resources that the OpenVox server will use when compiling catalogs for agent nodes.
+The `modulepath`, the main manifest, Hiera data, and the config version script can all be specified in
+`environment.conf`.
+
+### The `modulepath`
+
+* The `modulepath` is the list of directories OpenVox will load modules from.
+* By default, OpenVox will load modules first from the environment's `modules` directory, and second from the
+  server's `puppet.conf` file's `basemodulepath` setting, which can be multiple directories.
+* If the `modules` directory is empty or absent, OpenVox will only use modules from directories in the
+  `basemodulepath`.
+
+Related topics: [The modulepath (default config)][modulepath]
+
+### The main manifest
+
+* The main manifest is OpenVox's starting point for compiling a catalog.
+* Unless you specify otherwise in `environment.conf`, an environment will use OpenVox's global
+  `default_manifest` setting to determine its main manifest.
+* The value of this setting can be an absolute path to a manifest that all environments will share, or a
+  relative path to a file or directory inside each environment.
+* The default value of `default_manifest` is `./manifests` — the environment's own manifests directory.
+* If the file or directory specified by `default_manifest` is empty or absent, OpenVox will not fall back to
+  any other manifest. Instead, it behaves as if it is using a blank main manifest.
+
+Related topics: [main manifest][manifest_dir], [environment.conf][environment.conf],
+[default_manifest setting][default_manifest], [puppet.conf][puppet.conf].
+
+### Hiera data
+
+Each environment can use its own Hiera hierarchy and provide its own data.
+
+Related topics: [Hiera: Config file syntax][hiera.yaml].
+
+### The config version script
+
+OpenVox automatically adds a config version to every catalog it compiles, as well as to messages in reports.
+The version is an arbitrary piece of data that can be used to identify catalogs and events. By default, the
+config version will be the time at which the catalog was compiled (as the number of seconds since January 1,
+1970).
+
+### The environment.conf file
+
+An environment can contain an `environment.conf` file, which can override values for certain settings:
+
+* `modulepath`
+* `manifest`
+* `config_version`
+* `environment_timeout`
+
+Related topics: [environment.conf][environment.conf]
+
+## Create an environment
+
+Environments are turned on by default. Create an environment by adding a new directory of configuration data.
+
+1. Inside your code directory, create a directory called `environments`.
+2. Inside the `environments` directory, create a directory with the name of your new environment:
+   `$codedir/environments/<ENV_NAME>`
+3. Create a `modules` directory and a `manifests` directory inside the environment directory. These two
+   directories will contain your Puppet code.
+
+### Configure a modulepath
+
+1. Set `modulepath` in the environment's `environment.conf` file. If you set a value for this setting, the
+   global `modulepath` setting from `puppet.conf` will not be used by the environment.
+2. Check the `modulepath` by specifying the environment when requesting the setting value:
+
+   ``` bash
+   sudo puppet config print modulepath --section server --environment test
+   ```
+
+### Configure a main manifest
+
+1. Set `manifest` in the environment's `environment.conf` file. As with the global `default_manifest`
+   setting, you can specify a relative path (resolved within the environment's directory) or an absolute path.
+2. To lock all environments to a single global manifest, use the `disable_per_environment_manifest` setting,
+   which prevents any environment from setting its own main manifest.
+
+### Configure a config version script
+
+1. Specify a path to the script in the `config_version` setting in `environment.conf`. OpenVox runs this
+   script when compiling a catalog for a node in the environment, and uses its output as the config version.
+
+> **Note:** If you're using a system binary like `git rev-parse`, specify the absolute path to it. If
+> `config_version` is set to a relative path, OpenVox will look for the binary in the environment, not in
+> the system's PATH.
+
+## Assign nodes to environments via an ENC
+
+You can assign agent nodes to environments by using an external node classifier (ENC). By default, all nodes
+are assigned to a default environment named `production`.
+
+1. Ensure that the `environment` key is set in the YAML output that the ENC returns. If the `environment` key
+   isn't set, the OpenVox server will use the environment requested by the agent.
+
+> **Note:** The value from the ENC is authoritative if it exists. If the ENC doesn't specify an environment,
+> the node's config value is used.
+
+Related topics: [Writing ENCs][writingenc]
+
+## Assign nodes to environments via the agent's config file
+
+You can assign agent nodes to environments by editing the agent's `puppet.conf` file. By default, all nodes
+are assigned to a default environment named `production`.
+
+1. Open the agent's `puppet.conf` file in an editor.
+2. Find the `environment` setting in either the `agent` or `main` section.
+3. Set the value of the `environment` setting to the name of the desired environment.
+
+When that node requests a catalog from the OpenVox server, it will request that environment. If you are
+using an ENC and it specifies an environment for that node, the ENC value will override the config file.
+
+> **Note:** Nodes can't be assigned to unconfigured environments. If a node is assigned to an environment
+> that doesn't exist, the OpenVox server will fail to compile its catalog. The one exception is if the
+> default `production` environment doesn't exist — in that case, the agent will successfully retrieve an
+> empty catalog.
+
+## Global settings for configuring environments
+
+The settings in the server's `puppet.conf` file configure how OpenVox finds and uses environments.
+
+### `environmentpath`
+
+* `environmentpath` is the list of directories where OpenVox will look for environments. The default value
+  is `$codedir/environments`.
+* If you have more than one directory, separate them by colons and put them in order of precedence:
+  `$codedir/temp_environments:$codedir/environments`
+* If environments with the same name exist in both paths, OpenVox uses the first one it encounters.
+* Put the `environmentpath` setting in the `main` section of `puppet.conf`.
+
+### `basemodulepath`
+
+* `basemodulepath` lists directories of global modules that all environments can access by default.
+* The default includes `$codedir/modules` for user-accessible modules.
+* Add additional directories of global modules by setting your own value for `basemodulepath`.
+
+Related topics: [modulepath][modulepath].
+
+### `default_manifest`
+
+* `default_manifest` specifies the main manifest for any environment that doesn't set a `manifest` value in
+  `environment.conf`.
+* The default value is `./manifests` — the environment's own manifests directory.
+* The value can be an absolute path to one manifest shared by all environments, or a relative path to a file
+  or directory inside each environment's directory.
+
+Related topics: [default_manifest setting][default_manifest].
+
+### `disable_per_environment_manifest`
+
+* When set to `true`, OpenVox uses the same global manifest for every environment.
+* If an environment specifies a different manifest in `environment.conf`, OpenVox will not compile catalogs
+  for nodes in that environment.
+* If this setting is `true`, the `default_manifest` value must be an absolute path.
+
+### `environment_timeout`
+
+* `environment_timeout` sets how often the OpenVox server refreshes information about environments. It can
+  be overridden per-environment.
+* This setting defaults to `0` (caching disabled), which lowers performance but makes it easy for new users
+  to deploy updated Puppet code.
+* Once your code deployment process is mature, change this setting to `unlimited`.
+
+To configure `environment_timeout`:
+
+1. Set `environment_timeout = unlimited` in `puppet.conf`.
+2. Change your code deployment process to refresh the OpenVox server whenever you deploy updated code.
+
+> **Note:** Only use the value `0` or `unlimited`. Most OpenVox servers use a pool of Ruby interpreters,
+> which all have their own cache timers. When these timers are out of sync, agents can be served inconsistent
+> catalogs. To avoid that inconsistency, refresh the server when deploying.


### PR DESCRIPTION
## Scope

Restores three stub environment pages under `docs/_openvox_8x/` with full content from the
[puppetlabs/docs-archive](https://github.com/puppetlabs/docs-archive) (puppet/5.4).

## Changes

- **`environments_about.markdown`**: Restored concepts, main use cases (permanent/temporary test
  environments, divided infrastructure), limitations (plugin leakage, exported resource conflicts),
  and troubleshooting guidance
- **`environments_creating.markdown`**: Restored environment structure, resources (modulepath, main
  manifest, Hiera data, config version script, environment.conf), creation steps, node assignment via
  ENC and config file, and global `puppet.conf` settings
- **`environment_isolation.md`**: Restored generate types command usage, r10k integration, and
  troubleshooting steps

**Adaptations from the archive source:**

- Puppet master/server references → OpenVox server
- Prose "Puppet" → "OpenVox" where referring to the product
- Removed Kramdown class tags (`{:.concept}`, `{:.task}`, `{:.reference}`) not used in this theme
- Removed Puppet Enterprise-specific content and PE-only links
- Removed unused link reference definitions (MD053)
- Added language specifiers to fenced code blocks (MD040)
- Aligned table columns (MD060)

## Test plan

- [x] `bundle exec jekyll build` succeeds with no errors
- [x] `markdownlint-cli2` reports 0 errors against the project's planned 210-char line-length config
  (see [#30](https://github.com/OpenVoxProject/openvox-docs/pull/30))

🤖 Generated with [Claude Code](https://claude.com/claude-code)