### PR TITLE
[codex] Fix search index generation

### DIFF
--- a/search.json
+++ b/search.json
@@ -1,0 +1,43 @@
+---
+layout: null
+permalink: /search.json
+---
+[
+{% assign first = true %}
+{% assign home_page = site.pages | where: "url", "/" | first %}
+{% if home_page %}
+  {% assign excerpt = home_page.content | markdownify | strip_html | strip_newlines | replace: "  ", " " | strip | truncate: 2400, "" %}
+  {
+    "title": {{ home_page.title | default: site.title | strip_html | strip | jsonify }},
+    "url": {{ home_page.url | relative_url | jsonify }},
+    "content": {{ excerpt | jsonify }}
+  }
+  {% assign first = false %}
+{% endif %}
+{% assign static_pages = site.pages | sort: "url" %}
+{% for page in static_pages %}
+  {% if page.title and page.url and page.url != "/" and page.url != "/search.json" %}
+    {% unless first %},{% endunless %}
+    {% assign excerpt = page.content | markdownify | strip_html | strip_newlines | replace: "  ", " " | strip | truncate: 2400, "" %}
+    {
+      "title": {{ page.title | strip_html | strip | jsonify }},
+      "url": {{ page.url | relative_url | jsonify }},
+      "content": {{ excerpt | jsonify }}
+    }
+    {% assign first = false %}
+  {% endif %}
+{% endfor %}
+{% assign documents = site.documents | sort: "url" %}
+{% for doc in documents %}
+  {% if doc.output and doc.title and doc.url %}
+    {% unless first %},{% endunless %}
+    {% assign excerpt = doc.content | markdownify | strip_html | strip_newlines | replace: "  ", " " | strip | truncate: 2400, "" %}
+    {
+      "title": {{ doc.title | strip_html | strip | jsonify }},
+      "url": {{ doc.url | relative_url | jsonify }},
+      "content": {{ excerpt | jsonify }}
+    }
+    {% assign first = false %}
+  {% endif %}
+{% endfor %}
+]


### PR DESCRIPTION
## Summary
Add a repo-level `search.json` so local site search indexes the actual documentation pages instead of only the homepage.

## Root cause
`jekyll-vitepress-theme` generates `/search.json` from `site.data.sidebar`, but this repo does not define `_data/sidebar.*`.

This docs site uses `_data/nav/*.yml` and collection defaults in `_config.yml`, so the theme's generated search index never iterates the documentation collections.

## What changed
- Added a custom root `search.json`
- Indexed the homepage, regular titled pages, and output collection documents from `site.documents`
- Overrode the theme's broken default index generation for this repo structure

## Validation
- Ran `bundle exec jekyll build`
- Verified `_site/search.json` contains 881 entries after the change
- Verified OpenVox docs pages are present in the generated index

Closes #80