### PR TITLE
Restore lang_defaults from Puppet 5.4 archive

### DIFF
--- a/docs/_openvox_8x/lang_defaults.markdown
+++ b/docs/_openvox_8x/lang_defaults.markdown
@@ -3,10 +3,55 @@ layout: default
 title: "Language: Resource default statements"
 ---
 
+[definedtypes]: ./lang_defined_types.html
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+Resource default statements let you set default attribute values for a given resource type. Any resource
+declaration within the area of effect that omits those attributes will inherit the default values.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+## Syntax
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+``` puppet
+Exec {
+  path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+  environment => 'RUBYLIB=/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/',
+  logoutput   => true,
+  timeout     => 180,
+}
+```
 
+The general form of resource defaults is:
+
+* The resource type, capitalized. (If the resource type has a namespace separator (`::`) in its name, every
+  segment must be capitalized. E.g., `Concat::Fragment`.)
+* An opening curly brace.
+* Any number of attribute and value pairs.
+* A closing curly brace.
+
+You can specify defaults for any resource type in OpenVox, including [defined types][definedtypes].
+
+## Behavior
+
+Within the [area of effect](#area-of-effect), every resource of the specified type that omits a given
+attribute will use that attribute's default value.
+
+Attributes that are set explicitly in a resource declaration will always override any default value.
+
+Resource defaults are **evaluation-order independent** --- that is, a default will affect resource
+declarations written both above and below it.
+
+### Area of effect
+
+OpenVox uses dynamic scoping for resource defaults, even though it no longer uses dynamic variable lookup.
+This means that if you use a resource default statement in a class, it has the potential to affect any
+classes or defined types that class declares.
+
+Because of this, resource defaults should not be set outside of `site.pp`. You should
+[use per-resource default attributes](./lang_resources_advanced.html#per-expression-default-attributes)
+when possible.
+
+### Overriding defaults from parent scopes
+
+Resource defaults declared in the local scope override any defaults received from parent scopes.
+
+Overriding of resource defaults is **per attribute,** not per block of attributes --- this means local and
+parent resource defaults that don't conflict with each other are merged together.


### PR DESCRIPTION
## Scope

Restores `docs/_openvox_8x/lang_defaults.markdown` from the
[puppetlabs/docs-archive](https://github.com/puppetlabs/docs-archive) (puppet/5.4).

## Changes

Full content restored covering:

- **Syntax** — capitalized resource type, attribute/value pairs, example `Exec` defaults block
- **Behavior** — evaluation-order independence, area of effect (dynamic scoping caveat), overriding
  defaults from parent scopes (per-attribute merging)

**Adaptations from archive source:**

- Prose Puppet → OpenVox where describing runtime behavior
- Removed Kramdown class tags (`{:.concept}`, `{:.section}`)
- Removed unused link definitions (MD053)
- Lines wrapped to 210 chars (MD013)

## Test plan

- [x] `bundle exec jekyll build` succeeds with no errors
- [x] `markdownlint-cli2` reports 0 errors against the project's planned 210-char config
  (see [#30](https://github.com/OpenVoxProject/openvox-docs/pull/30))

🤖 Generated with [Claude Code](https://claude.com/claude-code)