### PR TITLE
Restore lang_virtual and lang_exported from Puppet 5.4 archive

### DIFF
--- a/docs/_openvox_8x/lang_exported.markdown
+++ b/docs/_openvox_8x/lang_exported.markdown
@@ -3,10 +3,162 @@ layout: default
 title: "Language: Exported resources"
 ---
 
+[resources]: ./lang_resources.html
+[tags]: ./lang_tags.html
+[facts]: ./lang_variables.html#facts
+[exported_collector]: ./lang_collectors.html#exported-resource-collectors
+[search]: ./lang_collectors.html#search-expressions
+[title]: ./lang_resources.html#title
+[namevar]: ./lang_resources.html#namenamevar
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+> **Note:** Exported resources require PuppetDB to be installed and connected to your OpenVox server to
+> enable catalog storage and searching.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+An **exported resource declaration** specifies a desired state for a resource, **does not** manage the
+resource on the target system, and publishes the resource for use by **other nodes.** Any node (including
+the node that exported it) can then **collect** the exported resource and manage its own copy of it.
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+## Purpose
 
+Exported resources allow the OpenVox compiler to share information among nodes by combining information
+from multiple nodes' catalogs. This helps you manage things that rely on nodes knowing the states or
+activity of other nodes.
+
+> **Note:** Exported resources rely on the compiler having access to the information, and cannot use
+> information that's never sent to the compiler, such as the contents of arbitrary files on a node.
+
+The most common use cases are monitoring and backups. A class that manages a service like PostgreSQL can
+export a `nagios_service` resource describing how to monitor the service, including information like its
+hostname and port. The Nagios server can then collect every `nagios_service` resource, and will
+automatically start monitoring the Postgres server.
+
+## Syntax
+
+Using exported resources requires two steps: declaring and collecting. In the following example, every
+node with the `ssh` class exports its own SSH host key and then collects the SSH host key of every node
+(including its own). This causes every node in the site to trust SSH connections from every other node.
+
+``` puppet
+class ssh {
+  # Declare:
+  @@sshkey { $::hostname:
+    type => dsa,
+    key  => $::sshdsakey,
+  }
+  # Collect:
+  Sshkey <<| |>>
+}
+```
+
+### Declaring an exported resource
+
+To declare an exported resource, prepend `@@` (a double "at" sign) to the **resource type** of a standard
+[resource declaration][resources]:
+
+``` puppet
+@@nagios_service { "check_zfs${::hostname}":
+  use                 => 'generic-service',
+  host_name           => $::fqdn,
+  check_command       => 'check_nrpe_1arg!check_zfs',
+  service_description => "check_zfs${::hostname}",
+  target              => '/etc/nagios3/conf.d/nagios_service.cfg',
+  notify              => Service[$nagios::params::nagios_service],
+}
+```
+
+### Collecting exported resources
+
+To collect exported resources use an [exported resource collector][exported_collector]:
+
+``` puppet
+Nagios_service <<| |>>  # Collect all exported nagios_service resources
+
+# Collect exported file fragments for building a config file:
+Concat::Fragment <<| tag == "bacula-storage-dir-${bacula_director}" |>>
+```
+
+Since any node could be exporting a resource, it is difficult to predict what the title of an exported
+resource will be. As such, it's usually best to [search][search] on a more general attribute. This is one
+of the main use cases for [tags][].
+
+See [Exported Resource Collectors][exported_collector] for more detail on the collector syntax and search
+expressions.
+
+## Behavior
+
+When catalog storage and searching are enabled, the OpenVox server will send a copy of every
+[catalog][] it compiles to PuppetDB. PuppetDB retains the most recent catalog for every node and provides
+the OpenVox server with a search interface to those catalogs.
+
+[catalog]: ./lang_summary.html#compilation-and-catalogs
+
+Declaring an exported resource causes that resource to be added to the catalog and marked with an
+"exported" flag, which prevents the OpenVox agent from managing the resource (unless it was collected).
+When PuppetDB receives the catalog, it also takes note of this flag.
+
+Collecting an exported resource causes the OpenVox server to send a search query to PuppetDB. PuppetDB
+will respond with every exported resource that matches the [search expression][search], and the OpenVox
+server will add those resources to the catalog.
+
+### Timing
+
+An exported resource becomes available to other nodes as soon as PuppetDB finishes storing the catalog
+that contains it. This is a multi-step process and might not happen immediately:
+
+* The OpenVox server must have compiled a given node's catalog at least once before its resources become
+  available.
+* When the OpenVox server submits a catalog to PuppetDB, it is added to a queue and stored as soon as
+  possible. Depending on the PuppetDB server's workload, there might be a slight delay between a node's
+  catalog being compiled and its resources becoming available.
+
+### Uniqueness
+
+Every exported resource must be **globally unique** across every single node. If two nodes export
+resources with the same [title][] or same [name/namevar][namevar] and you attempt to collect both,
+**the compilation will fail.**
+
+To ensure uniqueness, every resource you export should include a substring unique to the node exporting
+it into its title and name/namevar. The most expedient way is to use the `hostname` or `fqdn` [facts][].
+
+### Exported resource collectors
+
+Exported resource collectors do not collect normal or virtual resources. In particular, they cannot
+retrieve non-exported resources from other nodes' catalogs.
+
+### Example: Exported resources with Nagios
+
+The following example uses Puppet native types for managing Nagios configuration files. These types become
+very powerful when exported and collected. Here a class adds service definitions on a Nagios host,
+automatically monitoring an Apache web server:
+
+``` puppet
+# /etc/puppetlabs/puppet/modules/nagios/manifests/target/apache.pp
+class nagios::target::apache {
+  @@nagios_host { $::fqdn:
+    ensure  => present,
+    alias   => $::hostname,
+    address => $::ipaddress,
+    use     => 'generic-host',
+  }
+  @@nagios_service { "check_ping_${::hostname}":
+    check_command       => 'check_ping!100.0,20%!500.0,60%',
+    use                 => 'generic-service',
+    host_name           => $::fqdn,
+    notification_period => '24x7',
+    service_description => "${::hostname}_check_ping",
+  }
+}
+
+# /etc/puppetlabs/puppet/modules/nagios/manifests/monitor.pp
+class nagios::monitor {
+  package { [ 'nagios', 'nagios-plugins' ]: ensure => installed, }
+  service { 'nagios':
+    ensure  => running,
+    enable  => true,
+    require => Package['nagios'],
+  }
+  # collect resources and populate /etc/nagios/nagios_*.cfg
+  Nagios_host <<||>>
+  Nagios_service <<||>>
+}
+```

--- a/docs/_openvox_8x/lang_virtual.markdown
+++ b/docs/_openvox_8x/lang_virtual.markdown
@@ -3,10 +3,144 @@ layout: default
 title: "Language: Virtual resources"
 ---
 
+[resources]: ./lang_resources.html
+[references]: ./lang_data_resource_reference.html
+[classes]: ./lang_classes.html
+[realize_function]: ./function.html#realize
+[include]: ./lang_classes.html#using-include
+[collectors]: ./lang_collectors.html
+[search_expression]: ./lang_collectors.html#search-expressions
+[override]: ./lang_resources_advanced.html#amending-attributes-with-a-collector
+[chaining]: ./lang_relationships.html#syntax-chaining-arrows
+[catalog]: ./lang_summary.html#compilation-and-catalogs
 
-This page is no longer maintained in Github. Contributions from the Puppet community are still very welcome.
+A **virtual resource declaration** specifies a desired state for a resource without necessarily enforcing
+that state. You can then tell OpenVox to manage the resource by **realizing** it elsewhere in your
+manifests. This splits the work done by a normal [resource declaration][resources] into two steps.
 
- - Open a Jira ticket in the DOCUMENT project here: https://tickets.puppetlabs.com/projects/DOCUMENT/ Let us know the URL of the page, and describe the changes you think it needs.
+Although virtual resources can only be _declared_ once, they can be _realized_ any number of times (much
+as a class can be [`included`][include] multiple times).
 
- - Email docs@puppet.com  if you have questions about contributing to the documentation.
+## Purpose
 
+Virtual resources are useful for:
+
+* Resources whose management depends on at least one of multiple conditions being met.
+* Overlapping sets of resources which might be needed by any number of classes.
+* Resources which should only be managed if multiple cross-class conditions are met.
+
+Virtual resources can be used in some of the same situations as [classes][], since they both offer a safe
+way to add a resource to the catalog in more than one place. The features that distinguish virtual
+resources are:
+
+* **Searchability** via [resource collectors][collectors], which lets you realize overlapping clumps of
+  virtual resources.
+* **Flatness,** such that you can declare a virtual resource and realize it a few lines later without
+  having to clutter your modules with many single-resource classes.
+
+## Syntax
+
+Virtual resources are used in two steps: declaring and realizing. In the following example, the `apache`
+class declares a virtual resource, and both the `wordpress` and `freight` classes realize it. The resource
+is managed on any node that has the `wordpress` and/or `freight` classes applied to it.
+
+``` puppet
+# modules/apache/manifests/init.pp
+# Declare:
+@a2mod { 'rewrite':
+  ensure => present,
+}
+
+# modules/wordpress/manifests/init.pp
+# Realize:
+realize A2mod['rewrite']
+
+# modules/freight/manifests/init.pp
+# Realize again:
+realize A2mod['rewrite']
+```
+
+### Declaring a virtual resource
+
+To declare a virtual resource, prepend `@` (the "at" sign) to the **resource type** of a normal
+[resource declaration][resources]:
+
+``` puppet
+@user {'deploy':
+  uid     => 2004,
+  comment => 'Deployment User',
+  group   => 'www-data',
+  groups  => ["enterprise"],
+  tag     => [deploy, web],
+}
+```
+
+### Realizing with the `realize` function
+
+To realize one or more virtual resources **by title,** use the [`realize`][realize_function] function,
+which accepts one or more [resource references][references]:
+
+``` puppet
+realize(User['deploy'], User['zleslie'])
+```
+
+The `realize` function can be used multiple times on the same virtual resource and the resource is only
+managed once.
+
+### Realizing with a collector
+
+A [resource collector][collectors] realizes any virtual resources that match its
+[search expression][search_expression]:
+
+``` puppet
+User <| tag == web |>
+```
+
+If multiple resource collectors match a given virtual resource, OpenVox will only manage that resource
+once.
+
+Note that a collector also collects and realizes any exported resources from the current node. If you use
+exported resources that you don't want realized, take care to exclude them from the collector's search
+expression.
+
+Note also that a collector used in an [override block][override] or a [chaining statement][chaining] will
+also realize any matching virtual resources.
+
+## Behavior
+
+By itself, a virtual resource declaration does not manage the state of a resource. Instead, it makes a
+virtual resource available to resource collectors and the `realize` function. If that resource is realized,
+OpenVox will manage its state.
+
+Unrealized virtual resources are included in the [catalog][], but they are marked as inactive.
+
+### Evaluation-order independence
+
+Virtual resources do not depend on evaluation order. You can realize a virtual resource before the
+resource has been declared.
+
+### Collectors vs. the `realize` function
+
+The `realize` function causes a compilation failure if you attempt to realize a virtual resource that has
+not been declared. Resource collectors fail silently if they do not match any resources.
+
+### Virtual resources in classes
+
+If a virtual resource is contained in a class, it cannot be realized unless the class is declared at some
+point during the compilation. A common pattern is to declare a class full of virtual resources and then
+use a collector to choose the set of resources you need:
+
+``` puppet
+include virtual::users
+User <| groups == admin or group == wheel |>
+```
+
+### Defined resource types
+
+You can declare virtual resources of defined resource types. This causes every resource contained in the
+defined resource to behave virtually --- they are not managed unless their virtual container is realized.
+
+### Run stages
+
+Virtual resources are evaluated in the [run stage](./lang_run_stages.html) in which they are **declared,**
+not the run stage in which they are **realized.**


### PR DESCRIPTION
## Scope

Restores two related stub pages from the
[puppetlabs/docs-archive](https://github.com/puppetlabs/docs-archive) (puppet/5.4).

## Changes

**`lang_virtual.markdown`** — full content restored covering:

- Purpose (searchability, flatness vs. classes)
- Syntax: declaring with `@`, realizing with `realize` function or resource collector
- Behavior: eval-order independence, virtual resources in classes, defined types, run stages

**`lang_exported.markdown`** — full content restored covering:

- Purpose (cross-node catalog sharing, monitoring/backups use case)
- Syntax: declaring with `@@`, collecting with `<<| |>>`
- Behavior: timing, uniqueness requirements, collector scope, Nagios example

**Adaptations from archive source:**

- Prose Puppet → OpenVox where describing runtime behavior (compiler, server, agent)
- Removed Kramdown class tags (`{:.concept}`, `{:.task}`, `{:.section}`)
- Removed PE-specific PuppetDB install/connect links; kept general PuppetDB requirement note
- Removed unused link definitions (MD053)
- Lines wrapped to 210 chars (MD013)

## Test plan

- [x] `bundle exec jekyll build` succeeds with no errors
- [x] `markdownlint-cli2` reports 0 errors against the project's planned 210-char config
  (see [#30](https://github.com/OpenVoxProject/openvox-docs/pull/30))

🤖 Generated with [Claude Code](https://claude.com/claude-code)