### PR TITLE
Add missing layout: default to openvox_8x pages

### DIFF
--- a/docs/_openvox_8x/file_serving.markdown
+++ b/docs/_openvox_8x/file_serving.markdown
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Adding file server mount points"
 ---
 

--- a/docs/_openvox_8x/functions_basics.md
+++ b/docs/_openvox_8x/functions_basics.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Writing custom functions: Introduction"
 ---
 

--- a/docs/_openvox_8x/functions_legacy.md
+++ b/docs/_openvox_8x/functions_legacy.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "The legacy Ruby functions API"
 ---
 

--- a/docs/_openvox_8x/nodes_external.md
+++ b/docs/_openvox_8x/nodes_external.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Writing external node classifiers"
 ---
 

--- a/docs/_openvox_8x/nodes_ldap.md
+++ b/docs/_openvox_8x/nodes_ldap.md
@@ -1,5 +1,6 @@
 ---
-title: The LDAP Node Classifier
+layout: default
+title: "The LDAP Node Classifier"
 ---
 
 [class parameters]: ./lang_classes.html#class-parameters-and-variables

--- a/docs/_openvox_8x/resources_augeas.md
+++ b/docs/_openvox_8x/resources_augeas.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Resource tips and examples: Augeas"
 ---
 


### PR DESCRIPTION
## Summary

Six pages in the `_openvox_8x` collection had front matter but were missing
the required `layout: default` key, causing them to render without the site
theme.

## Pages fixed

- `file_serving.markdown`
- `functions_basics.md`
- `functions_legacy.md`
- `nodes_external.md`
- `nodes_ldap.md`
- `resources_augeas.md`

## Test plan

- [x] `bundle exec jekyll build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)