### PR TITLE
feat: lint only changed markdown files in CI

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,7 +1,4 @@
 ---
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 name: Markdown Lint
 
 on:
@@ -19,7 +16,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DavidAnson/markdownlint-cli2-action@v22
         with:
-          globs: '**/*.{md,markdown}'
-        continue-on-error: true # Allow this job to fail for now
+          fetch-depth: 0  # required to resolve base.sha for PR diff comparison
+      - name: Find changed Markdown files
+        id: changed-markdown
+        shell: bash
+        run: |
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              base_sha="${{ github.event.pull_request.base.sha }}"
+              head_sha="${GITHUB_SHA}"
+              ;;
+            push)
+              base_sha="${{ github.event.before }}"
+              head_sha="${GITHUB_SHA}"
+              ;;
+            *)
+              # workflow_dispatch: lints only files changed in the most recent commit, not the full branch
+              # || true handles initial commits with no parent
+              base_sha="$(git rev-parse "${GITHUB_SHA}^" 2>/dev/null || true)"
+              head_sha="${GITHUB_SHA}"
+              ;;
+          esac
+
+          if [[ -z "${base_sha}" || "${base_sha}" =~ ^0+$ ]]; then
+            base_sha="$(git rev-list --max-parents=0 "${head_sha}")"
+          fi
+
+          git diff --name-only --diff-filter=ACMRT "${base_sha}" "${head_sha}" -- '*.md' '*.markdown' > changed-markdown-files.txt
+
+          if [[ -s changed-markdown-files.txt ]]; then
+            echo "has_files=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo 'files<<EOF'
+              cat changed-markdown-files.txt
+              echo 'EOF'
+            } >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_files=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: No changed Markdown files
+        if: steps.changed-markdown.outputs.has_files != 'true'
+        run: echo "No changed Markdown files to lint."
+      - uses: DavidAnson/markdownlint-cli2-action@v22
+        if: steps.changed-markdown.outputs.has_files == 'true'
+        with:
+          globs: ${{ steps.changed-markdown.outputs.files }}

--- a/test-markdownlint.md
+++ b/test-markdownlint.md
@@ -1,1 +1,0 @@
-this line has no heading and is also extremely long to trigger MD013 line length violation intentionally for CI testing purposes only do not merge

--- a/test-markdownlint.md
+++ b/test-markdownlint.md
@@ -1,0 +1,1 @@
+this line has no heading and is also extremely long to trigger MD013 line length violation intentionally for CI testing purposes only do not merge


### PR DESCRIPTION
## Summary

The previous workflow linted all markdown files on every PR. With 38,441 existing lint errors across the repo (see [run #24909439672](https://github.com/OpenVoxProject/openvox-docs/actions/runs/24909439672)), this made the job permanently red and effectively useless — PRs couldn't be blocked on it so `continue-on-error: true` was set. This replaces it with a diff-aware approach that lints only files changed in the PR or push, making the job actionable from day one without requiring a bulk fix of the existing codebase first.

- Replaces blanket `**/*.{md,markdown}` glob with a step that computes the diff and lints only changed `.md`/`.markdown` files
- Skips linting entirely if no markdown files changed
- Removes `continue-on-error: true` — linting now fails the job on violations
- Removes the modulesync-managed header since this file is now maintained directly

## Test plan

- [x] Open a PR with a changed `.md` file — markdownlint should run on that file only
- [x] Open a PR with no `.md` changes — job should skip linting and print "No changed Markdown files to lint."
- [x] Introduce a markdown lint violation in a changed file — job should fail