### PR TITLE
Fix #50: remove markdown formatting from nav text and page titles

### DIFF
--- a/_data/nav/openvox_8x.yml
+++ b/_data/nav/openvox_8x.yml
@@ -7,7 +7,7 @@
     link: "known_issues.html"
   - text: System requirements
     link: "system_requirements.html"
-  - text: About `openvox-agent`
+  - text: About openvox-agent
     link: "about_agent.html"
 - text: Quick start guides
   items:

--- a/docs/_openvox_8x/about_agent.md
+++ b/docs/_openvox_8x/about_agent.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "About `openvox-agent`"
+title: "About openvox-agent"
 ---
 
 [release_notes]: ./release_notes.html


### PR DESCRIPTION
## Summary

- Removes backtick formatting from the `About openvox-agent` nav entry in `_data/nav/openvox_8x.yml`
- Removes backtick formatting from the `about_agent.md` front matter title

## Note

Page titles (front matter `title:`) and nav `text:` fields are plain text contexts — the Jekyll template outputs them directly without Markdown processing, so backtick characters render literally rather than as `<code>` elements. Titles and nav entries should not contain Markdown formatting.

Fixes #50