### PR TITLE
cleanup markdownlint on openfacts path

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,4 @@
 ---
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 default: true
 
 line-length:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,3 +12,7 @@ no-inline-html:
     - br
 
 descriptive-link-text: false
+
+table:
+  style: 'compact'
+  aligned_delimiter: true

--- a/docs/_openfact_5x/configuring_openfact.md
+++ b/docs/_openfact_5x/configuring_openfact.md
@@ -4,13 +4,14 @@ toc_levels: 1
 title: "Configuring OpenFact with facter.conf"
 ---
 
-The `facter.conf` file is a configuration file that allows you to cache and block fact groups, and manage how OpenFact interacts with your system. There are three sections: `facts`, `global` and `cli`. All sections are optional and can be listed in any order within the file.
+The `facter.conf` file is a configuration file that allows you to cache and block fact groups, and manage how OpenFact interacts with your system. There are three sections: `facts`, `global` and `cli`.
+All sections are optional and can be listed in any order within the file.
 
 When you run OpenFact from the Ruby API, only the `facts` section and limited `global` settings are loaded.
 
 Example facter.conf file:
 
-~~~
+~~~yaml
 facts : {
     blocklist : [ "file system", "EC2" ],
     ttls : [
@@ -33,15 +34,18 @@ cli : {
 }
 ~~~
 
-### Location
+## Location
 
-OpenFact does not create the `facter.conf` file automatically, so you must create it manually, or use a module to manage it. OpenFact loads the file by default from `/etc/puppetlabs/facter/facter.conf` on *nix systems and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows. Or, you can specify a different default with the `--config` command line option:
+OpenFact does not create the `facter.conf` file automatically, so you must create it manually, or use a module to manage it.
+OpenFact loads the file by default from `/etc/puppetlabs/facter/facter.conf` on *nix systems and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows.
+Or, you can specify a different default with the `--config` command line option:
 
 `facter --config path/to/my/config/file/facter.conf`
 
 ### `facts`
 
-This section of `facter.conf` contains settings that affect fact groups. A fact group is a set of individual facts that are resolved together because they all rely on the same underlying system information. When you add a group name to the config file as a part of either of these `facts` settings, all facts in that group will be affected. Currently only built-in facts can be cached or blocked.
+This section of `facter.conf` contains settings that affect fact groups. A fact group is a set of individual facts that are resolved together because they all rely on the same underlying system information.
+When you add a group name to the config file as a part of either of these `facts` settings, all facts in that group will be affected. Currently only built-in facts can be cached or blocked.
 
 Settings:
 
@@ -53,13 +57,16 @@ Settings:
 
   * Cached facts are stored as JSON in `/opt/puppetlabs/facter/cache/cached_facts` on *nix and `C:\ProgramData\PuppetLabs\facter\cache\cached_facts` on Windows.
 
-Caching and blocking facts is useful when OpenFact is taking a long time and slowing down your code. When a system has a lot of something --- for example, mount points or disks --- OpenFact can take a long time to collect the facts from each one. When this is a problem, you can speed up OpenFact’s collection by either blocking facts you’re uninterested in (`blocklist`), or caching ones you don’t need retrieved frequently (`ttls`).
+Caching and blocking facts is useful when OpenFact is taking a long time and slowing down your code. When a system has a lot of something - for example, mount points or disks - OpenFact can take a long time
+to collect the facts from each one.
+When this is a problem, you can speed up OpenFact’s collection by either blocking facts you’re uninterested in (`blocklist`), or caching ones you don’t need retrieved frequently (`ttls`).
 
 #### Example
 
-To see a list of valid group names, from the command line, run `facter --list-block-groups` or `facter --list-cache-groups`. The output shows the fact group at the top level, with all facts in that group nested below.
+To see a list of valid group names, from the command line, run `facter --list-block-groups` or `facter --list-cache-groups`.
+The output shows the fact group at the top level, with all facts in that group nested below.
 
-~~~
+~~~text
 $ facter --list-block-groups
 EC2
   - ec2_metadata
@@ -72,8 +79,7 @@ file system
 
 If you want to block any of these groups, add the group name to the `facts` section of `facter.conf`, with the `blocklist` setting.
 
-
-~~~
+~~~yaml
 facts : {
     blocklist : [ "file system" ],
 }
@@ -81,18 +87,17 @@ facts : {
 
 Here, the "file system" group has been added, so the `mountpoints`, `filesystems`, and `partitions` facts will all be prevented from loading.
 
-
 ### `global`
 
 The `global` section of `facter.conf` contains settings to control how OpenFact interacts with its external elements on your system.
 
-Setting        | Effect                                                        | Default
----------------|---------------------------------------------------------------|--------
-`external-dir` | A list of directories to search for external facts.           |
-`custom-dir`   | A list of directories to search for custom facts.             |
-`no-external`* | If true, prevents OpenFact from searching for external facts.   | `false`
-`no-custom`*   | If true, prevents OpenFact from searching for custom facts.     | `false`
-`no-ruby`*     | If true, prevents OpenFact from loading its Ruby functionality. | `false`
+| Setting | Effect | Default |
+| ------- | ------ | ------- |
+| `external-dir` | A list of directories to search for external facts. | |
+| `custom-dir` | A list of directories to search for custom facts. | |
+| `no-external`* | If true, prevents OpenFact from searching for external facts. | `false` |
+| `no-custom`* | If true, prevents OpenFact from searching for custom facts. | `false` |
+| `no-ruby`* | If true, prevents OpenFact from loading its Ruby functionality. | `false` |
 
 \*Not available when you run OpenFact from the Ruby API.
 
@@ -100,12 +105,9 @@ Setting        | Effect                                                        |
 
 The `cli` section of `facter.conf` contains settings that affect OpenFact’s command line output. All of these settings are ignored when you run OpenFact from the Ruby API.
 
-
-Setting         | Effect                                           | Default
-----------------|--------------------------------------------------|-------
-`debug`         | If true, OpenFact outputs debug messages.                                      | `false`
-`trace`         | If true, OpenFact prints stacktraces from errors arising in your custom facts. | `false`
-`verbose`       | If true, OpenFact outputs its most detailed messages.                          | `false`
-`log-level`     | Sets the minimum level of message severity that gets logged. Valid options: “none”, “fatal”, “error”, “warn”, “info”, “debug”, “trace”. | “warn”
-
-
+| Setting | Effect | Default |
+| ------- | ------ | ------- |
+| `debug` | If true, OpenFact outputs debug messages. | `false` |
+| `trace` | If true, OpenFact prints stacktraces from errors arising in your custom facts. | `false` |
+| `verbose` | If true, OpenFact outputs its most detailed messages. | `false` |
+| `log-level` | Sets the minimum level of message severity that gets logged. Valid options: “none”, “fatal”, “error”, “warn”, “info”, “debug”, “trace”. | “warn” |

--- a/docs/_openfact_5x/custom_facts.md
+++ b/docs/_openfact_5x/custom_facts.md
@@ -6,6 +6,7 @@ title: "Custom facts walkthrough"
 [Plugins in Modules]: /openvox/latest/plugins_in_modules.html
 [Adding plug-ins to a module]: /openvox/latest/plugins_in_modules.html
 [Facts overview]: ./fact_overview.html
+[openvoxdb]: /openvoxdb/latest
 
 You can add custom facts by adding snippets of Ruby code to the OpenVox server. OpenVox then uses [Plugins in Modules][] to distribute the facts to all agents.
 
@@ -15,7 +16,8 @@ For information on how to add custom facts to modules, see [Adding plug-ins to a
 
 Sometimes you need to be able to write conditional expressions based on site-specific data that just isn't available via OpenFact, or perhaps you'd like to include it in a template.
 
-Because you can't include arbitrary Ruby code in your manifests, the best solution is to add a new fact to OpenFact. These additional facts can then be distributed to OpenVox agent and are available for use in manifests and templates, just like any other fact is.
+Because you can't include arbitrary Ruby code in your manifests, the best solution is to add a new fact to OpenFact.
+These additional facts can then be distributed to OpenVox agent and are available for use in manifests and templates, just like any other fact is.
 
 > **Note:** OpenFact provides a [custom facts API](https://github.com/openvoxproject/openfact/blob/master/Extensibility.md#custom-facts-compatibility).
 
@@ -23,9 +25,9 @@ Because you can't include arbitrary Ruby code in your manifests, the best soluti
 
 OpenFact offers multiple methods of loading facts:
 
--   `$LOAD_PATH`, or the Ruby library load path
--   The `--custom-dir` command line option
--   The environment variable 'FACTERLIB'
+- `$LOAD_PATH`, or the Ruby library load path
+- The `--custom-dir` command line option
+- The environment variable 'FACTERLIB'
 
 You can use these methods to do things like test files locally before distributing them, or you can arrange to have a specific set of facts available on certain machines.
 
@@ -36,11 +38,13 @@ subdirectories named `facter`, and loads all Ruby files in those directories.
 If you had a directory in your `$LOAD_PATH` like `~/lib/ruby`, set up like
 this:
 
+```text
     #~/lib/ruby
     └── facter
         ├── rackspace.rb
         ├── system_load.rb
         └── users.rb
+```
 
 OpenFact loads `facter/system_load.rb`, `facter/users.rb`, and
 `facter/rackspace.rb`.
@@ -51,6 +55,7 @@ OpenFact can take multiple `--custom-dir` options on the command line that speci
 to search for custom facts. OpenFact attempts to load all Ruby files in the specified directories.
 This allows you to do something like this:
 
+```text
     #~/my_facts
     └── system_load.rb
     #~/my_other_facts
@@ -59,6 +64,7 @@ This allows you to do something like this:
     $ facter --custom-dir=./my_facts --custom-dir=./my_other_facts system_load users
     system_load => 0.25
     users => thomas,pat
+```
 
 ### Using the `FACTERLIB` environment variable
 
@@ -66,6 +72,7 @@ OpenFact also checks the environment variable `FACTERLIB` for a delimited (semic
 other platforms) set of directories, and tries to load all Ruby files in those directories.
 This allows you to do something like this:
 
+```text
     #~/my_facts
     └── system_load.rb
     #~/my_other_facts
@@ -75,13 +82,14 @@ This allows you to do something like this:
     $ facter system_load users
     system_load => 0.25
     users => thomas,pat
+```
 
 ## Two parts of every custom fact
 
 Most facts have at least two elements:
 
-1.  A call to `Facter.add('fact_name')`, which determines the name of the fact.
-2.  A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
+1. A call to `Facter.add('fact_name')`, which determines the name of the fact.
+2. A `setcode` statement for simple resolutions, which is evaluated to determine the fact's value.
 
 Facts *can* get a lot more complicated than that, but those two together are the most common implementation of a custom fact.
 
@@ -97,20 +105,22 @@ The OpenFact API gives you a few ways to
 execute shell commands:
 
 - To run a command and use the output verbatim, as your fact's value, you can pass the command into `setcode` directly. For example: `setcode 'uname --hardware-platform'`
-- If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block. Whatever the `setcode` statement returns is used as the fact's value.
+- If your fact is more complicated than that, you can call `Facter::Core::Execution.execute('uname --hardware-platform')` from within the `setcode do`...`end` block.
+  Whatever the `setcode` statement returns is used as the fact's value.
 - Your shell command is also a Ruby string, so you need to escape special characters if you want to pass them through.
 
-> **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would, but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
+> **Note:** Not everything that works in the terminal works in a fact. You can use the pipe (`|`) and similar operators as you normally would.
+> but Bash-specific syntax like `if` statements do not work. The best way to handle this limitation is to write your conditional logic in Ruby.
 
 ### Example
 
 To get the output of `uname --hardware-platform` to single out a specific type of workstation, you create a new custom fact.
 
-1.  Start by giving the fact a name, in this case, `hardware_platform`.
+1. Start by giving the fact a name, in this case, `hardware_platform`.
 
-2.  Create your new fact in a file, `hardware_platform.rb` on an OpenVox agent system:
+2. Create your new fact in a file, `hardware_platform.rb` on an OpenVox agent system:
 
-    ``` ruby
+    ```ruby
     #~/my_facts/hardware_platform.rb
 
     Facter.add('hardware_platform') do
@@ -120,7 +130,7 @@ To get the output of `uname --hardware-platform` to single out a specific type o
     end
     ```
 
-3.  Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next OpenVox run, the value of the new fact is available to use in your manifests and templates.
+3. Use the instructions in the [Plugins in Modules][] page to copy the new fact to a module and distribute it. During your next OpenVox run, the value of the new fact is available to use in your manifests and templates.
 
 ## Accessing other facts
 
@@ -250,7 +260,8 @@ You can see some relevant examples in the [writing structured facts](./fact_over
 
 ## Aggregate resolutions
 
-If your fact combines the output of multiple commands, it may make sense to use aggregate resolutions. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact. After all of the chunks have been resolved separately, they're combined into a single flat or structured fact and returned.
+If your fact combines the output of multiple commands, it may make sense to use aggregate resolutions. An aggregate resolution is split into "chunks", each one responsible for resolving one piece of the fact.
+After all of the chunks have been resolved separately, they're combined into a single flat or structured fact and returned.
 
 Aggregate resolutions have several key differences compared to simple resolutions, beginning with the fact declaration. To introduce an aggregate resolution, add the `:type => :aggregate` parameter:
 
@@ -273,7 +284,8 @@ chunk(:two) do
 end
 ```
 
-Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks. Whatever value the `aggregate` block returns is the fact's value. Here's an example that just combines the strings from the two chunks above:
+Aggregate resolutions *never* have a `setcode` statement. Instead, they have an optional `aggregate` block that combines the chunks.
+Whatever value the `aggregate` block returns is the fact's value. Here's an example that just combines the strings from the two chunks above:
 
 ``` ruby
 aggregate do |chunks|
@@ -302,7 +314,8 @@ If your Puppet masters are configured to use [OpenVox-DB][OpenVox-DB], you can v
 
 ### What are external facts?
 
-External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data. If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
+External facts provide a way to use arbitrary executables or scripts as facts, or set facts statically with structured data.
+If you've ever wanted to write a custom fact in Perl, C, or a one-line text file, this is how.
 
 ### Executable external facts --- Unix
 
@@ -321,58 +334,74 @@ for k in data:
 
 You must ensure that the script has its execute bit set:
 
+```shell
     chmod +x /etc/facter/facts.d/my_fact_script.py
+```
 
 For OpenFact to parse the output, the script must return key/value pairs on
 STDOUT in the format:
 
+```text
     key1=value1
     key2=value2
     key3=value3
+```
 
 Using this format, a single script can return multiple facts.
 
 ### Executable external facts --- Windows
 
-Executable facts on Windows work by dropping an executable file into the external fact path. Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
+Executable facts on Windows work by dropping an executable file into the external fact path.
+Unlike with Unix, the external facts interface expects Windows scripts to end with a known extension. Line endings can be either `LF` or `CRLF`. The following extensions are currently supported:
 
--   `.com` and `.exe`: binary executables
--   `.bat` and `.cmd`: batch scripts
--   `.ps1`: PowerShell scripts
+- `.com` and `.exe`: binary executables
+- `.bat` and `.cmd`: batch scripts
+- `.ps1`: PowerShell scripts
 
 As with Unix facts, each script must return key/value pairs on STDOUT in the format:
 
+```text
     key1=value1
     key2=value2
     key3=value3
+```
 
 Using this format, a single script can return multiple facts in one return.
 
 #### Executable eternal fact locations
 
-The best way to distribute external executable facts is with pluginsync, To add external executable facts to your OpenVox modules, just place them in <MODULEPATH>/<MODULE>/facts.d/.
+The best way to distribute external executable facts is with pluginsync, To add external executable facts to your OpenVox modules, just place them in `<MODULEPATH>/<MODULE>/facts.d/`.
 
-If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system and whether you are running as root/Administrator. When calling OpenFact from the command line, you can specify the external facts directory with the `--external-dir` option.
+If you're not using pluginsync, then external facts must go in a standard directory. The location of this directory varies depending on your operating system and whether you are running as root/Administrator.
+When calling OpenFact from the command line, you can specify the external facts directory with the `--external-dir` option.
 
 > **Note:** These directories don't necessarily exist by default; you may need to create them. If you create the directory, make sure to restrict access so that only Administrators can write to the directory.
 
 In a module (recommended):
 
+```text
     <MODULEPATH>/<MODULE>/facts.d/
+```
 
 On Unix/Linux/OS X, there are three directories:
 
+```text
     /opt/puppetlabs/facter/facts.d/
     /etc/puppetlabs/facter/facts.d/
     /etc/facter/facts.d/
+```
 
 On Windows:
 
+```text
     C:\ProgramData\PuppetLabs\facter\facts.d\
+```
 
 When running as a non-root / non-Administrator user:
 
+```text
     <HOME DIRECTORY>/.facter/facts.d/
+```
 
 > **Note:** You can only use custom facts as a non-root user if you have previously run OpenVox agent as that same user.
 
@@ -382,12 +411,14 @@ The file encoding for `.bat/.cmd` files must be `ANSI` or `UTF8 without BOM` (By
 
 Here is a sample batch script which outputs facts using the required format:
 
+```text
     @echo off
     echo key1=val1
     echo key2=val2
     echo key3=val3
     REM Invalid - echo 'key4=val4'
     REM Invalid - echo "key5=val5"
+```
 
 #### PowerShell scripts
 
@@ -395,9 +426,11 @@ The encoding that should be used with `.ps1` files is pretty open. PowerShell de
 
 Here is a sample PowerShell script which outputs facts using the required format:
 
+```powershell
     Write-Host "key1=val1"
     Write-Host 'key2=val2'
     Write-Host key3=val3
+```
 
 You should be able to save and execute this PowerShell script on the command line.
 
@@ -428,7 +461,7 @@ key3: val3
 
 `.txt`: Key value pairs, of the `String` data type, in the following format:
 
-```
+```text
 key1=value1
 key2=value2
 key3=value3
@@ -456,25 +489,30 @@ As with executable facts, structured data files can set multiple facts at once.
 
 All of the above types are supported on Windows with the following caveats:
 
--   The line endings can be either `LF` or `CRLF`.
--   The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
+- The line endings can be either `LF` or `CRLF`.
+- The file encoding must be either `ANSI` or `UTF8 without BOM` (Byte Order Mark).
 
 ### Troubleshooting external facts
 
 If your external fact is not appearing in OpenFact's output, running
 OpenFact in debug mode should give you a meaningful reason and tell you which file is causing the problem:
 
+```shell
     # puppet facts --debug
+```
 
 One example of when this can happen is in cases where a fact returns invalid characters.
 For example if you used a hyphen instead of an equals sign in your script `test.sh`:
 
+```shell
     #!/bin/bash
 
     echo "key1-value1"
+```
 
 Running `puppet facts --debug` yields a useful message:
 
+```text
     ...
     Debug: Facter: resolving facts from executable file "/tmp/test.sh".
     Debug: Facter: executing command: /tmp/test.sh
@@ -483,6 +521,7 @@ Running `puppet facts --debug` yields a useful message:
     Debug: Facter: process exited with status code 0.
     Debug: Facter: completed resolving facts from executable file "/tmp/test.sh".
     ...
+```
 
 #### External facts and `stdlib`
 
@@ -494,5 +533,5 @@ found in the `stdlib` module.
 
 While external facts provide a mostly-equal way to create variables for OpenVox, they have a few drawbacks:
 
--   An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
--   External executable facts are forked instead of executed within the same process.
+- An external fact cannot internally reference another fact. However, due to parse order, you can reference an external fact from a Ruby fact.
+- External executable facts are forked instead of executed within the same process.

--- a/docs/_openfact_5x/fact_overview.md
+++ b/docs/_openfact_5x/fact_overview.md
@@ -3,7 +3,6 @@ layout: default
 title: "Overview of custom facts with examples"
 ---
 
-
 A typical fact in OpenFact is a fairly simple assemblage of just a few different elements.
 This page is an example-driven tour of those elements, and is intended as a quick primer or reference
 for authors of custom facts. You need some familiarity with Ruby to understand most of these examples.
@@ -85,7 +84,8 @@ Simple facts are typically made up of the following parts:
 
 ## Writing structured facts
 
-Structured facts can take the form of hashes or arrays. You don't have to do anything special to mark the fact as structured --- if your fact returns a hash or array, OpenFact recognizes it as a structured fact. Structured facts can have [simple](#main-components-of-simple-resolutions) or [aggregate resolutions](#main-components-of-aggregate-resolutions).
+Structured facts can take the form of hashes or arrays. You don't have to do anything special to mark the fact as structured --- if your fact returns a hash or array, OpenFact recognizes it as a structured fact.
+Structured facts can have [simple](#main-components-of-simple-resolutions) or [aggregate resolutions](#main-components-of-aggregate-resolutions).
 
 ### Example: Returning an array of network interfaces
 
@@ -121,11 +121,13 @@ end
 
 ## Writing facts with aggregate resolutions
 
-Aggregate resolutions allow you to split up the resolution of a fact into separate chunks. By default, OpenFact merges hashes with hashes or arrays with arrays, resulting in a [structured fact](#writing-structured-facts), but you can also aggregate the chunks into a flat fact using concatenation, addition, or any other function that you can express in Ruby code.
+Aggregate resolutions allow you to split up the resolution of a fact into separate chunks.By default, OpenFact merges hashes with hashes or arrays with arrays, resulting in a [structured fact](#writing-structured-facts).
+But you can also aggregate the chunks into a flat fact using concatenation, addition, or any other function that you can express in Ruby code.
 
 ### Main components of aggregate resolutions
 
-Aggregate resolutions have two key differences compared to simple resolutions: the presence of `chunk` statements and the lack of a `setcode` statement. The `aggregate` block is optional, and without it OpenFact merges hashes with hashes or arrays with arrays.
+Aggregate resolutions have two key differences compared to simple resolutions: the presence of `chunk` statements and the lack of a `setcode` statement.
+The `aggregate` block is optional, and without it OpenFact merges hashes with hashes or arrays with arrays.
 
 1. A call to `Facter.add(:fact_name, :type => :aggregate)`:
     * Introduces a new fact *or* a new resolution for an existing fact with the same name.
@@ -152,7 +154,8 @@ Aggregate resolutions have two key differences compared to simple resolutions: t
 
 ### Example: Building a structured fact progressively
 
-This example builds a new fact, `networking_primary_sha`, by progressively merging two chunks. One chunk encodes each networking interface's MAC address as an encoded base64 value, and the other determines if each interface is the system's primary interface.
+This example builds a new fact, `networking_primary_sha`, by progressively merging two chunks.
+One chunk encodes each networking interface's MAC address as an encoded base64 value, and the other determines if each interface is the system's primary interface.
 
 ``` ruby
 require 'digest'
@@ -227,4 +230,3 @@ Facter.add(:total_free_memory_mb, :type => :aggregate) do
   end
 end
 ```
-


### PR DESCRIPTION
### Short description

There are tables with long content in cells.
Doing alignment looks more than ugly.
Using style compact with aligned_delimiter enabled

see https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md060.md

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
