### PR TITLE
Fix facter CLI doc generation: use mandoc instead of pandoc man reader

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,9 +72,9 @@ jobs:
         with:
           ruby-version: '3.2'
           bundler-cache: true
-      - name: Install pandoc
+      - name: Install pandoc and mandoc
         run: |
-          sudo apt install -y pandoc
+          sudo apt install -y pandoc mandoc
       - name: Build website
         run: |
           bundle exec rake references:openfact INSTALLPATH=docs

--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -31,8 +31,9 @@ module PuppetReferences
           puts "Encountered an error while building the facter cli docs, will abort: #{err}"
           return
         end
-        require 'pandoc-ruby'
-        markdown_text = PandocRuby.new(raw_text, from: 'man').to_markdown
+        markdown_text, = Open3.capture3('mandoc -T markdown', stdin_data: raw_text)
+        # Strip the "TITLE - Manual" header line and the dated footer line mandoc adds
+        markdown_text = markdown_text.lines[1...-1].join
         content = make_header(header_data) + PREAMBLE + markdown_text
         filename = OUTPUT_DIR + 'cli.md'
         filename.open('w') { |f| f.write(content) }


### PR DESCRIPTION
## Summary

- `facter man` outputs mdoc (BSD man page format), but the pipeline was using `PandocRuby.new(raw_text, from: 'man')` which uses pandoc's traditional groff man reader — it does not understand mdoc and silently drops all section headers
- The Ubuntu pandoc package (2.x/3.1) also predates mdoc reader support added in pandoc 3.6, making `from: 'mdoc'` non-viable
- Replace with `mandoc -T markdown`, which is purpose-built for mdoc and produces correct output
- Add `mandoc` to the build workflow `apt install` step alongside `pandoc`

## Test plan

- [x] Verify mandoc is available on Ubuntu 24.04: `apt install mandoc` — tested via Docker
- [x] Run `bundle exec rake references:openfact` and verify `cli.md` contains proper Markdown section headers (NAME, SYNOPSIS, DESCRIPTION, OPTIONS, FILES, EXAMPLES)
- [x] Verify page renders correctly at `/openfact/latest/cli.html`

## Linting

```
$ bundle exec rubocop lib/puppet_references/facter/facter_cli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## References

- Issue: #103
- Upstream openfact `.El` fix (required for valid mdoc input): OpenVoxProject/openfact#119