### PR TITLE
Fix sidebar scroll reset on nav clicks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'versionomy', '~> 0.5.0'
 
 group(:build_site) do
   gem 'jekyll', '~> 4.4'
-  gem 'jekyll-vitepress-theme', '~> 1.2'
+  gem 'jekyll-vitepress-theme', '~> 1.4'
 end
 
 group(:generate_references) do

--- a/_includes/nav-item.html
+++ b/_includes/nav-item.html
@@ -33,7 +33,7 @@
   <div class="VPSidebarItem level-{{ include.level }} is-link{% if nav_item_url == page.url %} is-active{% endif %}">
     <div class="item">
       <div class="indicator"></div>
-      <a class="VPLink link link" href="{{ nav_item_url }}">
+      <a class="VPLink link link" href="{{ nav_item_url }}" data-vp-sidebar-link data-turbo="true" data-turbo-frame="vp-content-frame" data-turbo-action="advance">
         <p class="text">{{ include.item.text }}</p>
       </a>
     </div>


### PR DESCRIPTION
## Summary

- Bumps `jekyll-vitepress-theme` from `~> 1.2` to `~> 1.4`, picking up all fixes since 1.2.2
- Fixes the local `_includes/nav-item.html` override which was missing the `data-vp-sidebar-link`, `data-turbo`, `data-turbo-frame`, and `data-turbo-action` attributes present in the theme's sidebar template — without these, sidebar clicks triggered full page reloads and the sidebar scroll position reset to the top on every navigation

The theme's sidebar template generates these attributes automatically, but our custom `nav-item.html` (which supports arbitrary nesting depth and per-collection nav) did not mirror them.

### Theme fixes included (1.2.3 → 1.4.1)

| Version | Fix |
|---------|-----|
| 1.2.3 | Fix clipped right-side outline headings so long labels wrap ([crmne/jekyll-vitepress-theme#3](https://github.com/crmne/jekyll-vitepress-theme/issues/3)) |
| 1.3.0 | Turbo-based client-side navigation — content frame swaps without full page reloads ([crmne/jekyll-vitepress-theme#5](https://github.com/crmne/jekyll-vitepress-theme/issues/5)) |
| 1.4.1 | Fix anchored heading scrolling and outline state |

Closes #105

## Test plan

- [x] `bundle exec jekyll build` passes
- [x] Sidebar scroll position is preserved when clicking between doc pages locally
- [x] Long outline headings wrap instead of clipping