### PR TITLE
Fix top nav sidebar sync and OpenVoxDB link URL

### DIFF
--- a/_data/nav_map.yml
+++ b/_data/nav_map.yml
@@ -1,0 +1,15 @@
+- nav_key: openfact_5x
+  collections: openfact_latest|openfact_5x
+  base: /openfact/latest/
+
+- nav_key: openvox_8x
+  collections: openvox_latest|openvox_8x
+  base: /openvox/latest/
+
+- nav_key: openvox-server_8x
+  collections: openvox-server_latest|openvox-server_8x
+  base: /openvox-server/latest/
+
+- nav_key: openvoxdb_8x
+  collections: openvoxdb_latest|openvoxdb_8x
+  base: /openvoxdb/latest/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,5 +8,5 @@
   url: /openvox-server/latest/
   collections: [openvox-server_latest, openvox-server_8x]
 - title: OpenVoxDB
-  url: /openvox-server/latest/
+  url: /openvoxdb/latest/
   collections: [openvoxdb_latest, openvoxdb_8x]

--- a/_includes/jekyll_vitepress/layout_end.html
+++ b/_includes/jekyll_vitepress/layout_end.html
@@ -32,6 +32,22 @@
 
 <script>
   (function () {
+    function syncSidebarNavGroups() {
+      var frameState = document.getElementById('vp-page-state');
+      if (!frameState) return;
+      var currentCollection = frameState.getAttribute('data-collection') || '';
+      document.querySelectorAll('[data-nav-key]').forEach(function (group) {
+        var collections = (group.getAttribute('data-nav-collections') || '').split('|');
+        group.hidden = collections.indexOf(currentCollection) < 0;
+      });
+    }
+    document.addEventListener('turbo:frame-load', function (event) {
+      if (!event.target || event.target.id !== 'vp-content-frame') return;
+      syncSidebarNavGroups();
+    });
+  })();
+
+  (function () {
     function init() {
       if (document.getElementById('under-construction-banner')) return;
 

--- a/_includes/nav-item.html
+++ b/_includes/nav-item.html
@@ -13,7 +13,7 @@
   {% endif %}
 
   <div class="group no-transition">
-    <section class="VPSidebarItem level-{{ include.level }} collapsible{% if nav_has_active %} has-active{% endif %}">
+    <section class="VPSidebarItem level-{{ include.level }} collapsible{% if nav_has_active %} has-active{% endif %}" data-vp-sidebar-group>
       <div class="item" role="button" tabindex="0">
         <div class="indicator"></div>
         <h2 class="text">{{ include.item.text }}</h2>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,12 +11,24 @@
   <nav class="nav" id="VPSidebarNav" aria-labelledby="sidebar-aria-label" tabindex="-1">
     <span class="visually-hidden" id="sidebar-aria-label">Sidebar Navigation</span>
 
-    {% assign nav_items = site.data.nav[page.nav] %}
-    {% assign nav_collection_dir = page.collection | prepend: '_' | append: '/' %}
-    {% assign nav_page_subpath = page.relative_path | remove_first: nav_collection_dir | replace: '.md', '.html' | replace: '.markdown', '.html' %}
-    {% assign nav_base = page.url | remove: nav_page_subpath %}
-    {% for item in nav_items %}
-      {% include nav-item.html item=item level=0 %}
+    {%- assign current_nav_collection_dir = page.collection | prepend: '_' | append: '/' -%}
+    {%- assign current_nav_page_subpath = page.relative_path | remove_first: current_nav_collection_dir | replace: '.md', '.html' | replace: '.markdown', '.html' -%}
+    {%- assign current_nav_base = page.url | remove: current_nav_page_subpath -%}
+
+    {% for nav_entry in site.data.nav_map %}
+      {%- assign nav_key = nav_entry.nav_key -%}
+      {%- assign is_current = false -%}
+      {%- if nav_key == page.nav -%}
+        {%- assign is_current = true -%}
+        {%- assign nav_base = current_nav_base -%}
+      {%- else -%}
+        {%- assign nav_base = nav_entry.base -%}
+      {%- endif -%}
+      <div data-nav-key="{{ nav_key }}" data-nav-collections="{{ nav_entry.collections }}"{% unless is_current %} hidden{% endunless %}>
+        {% for item in site.data.nav[nav_key] %}
+          {% include nav-item.html item=item level=0 %}
+        {% endfor %}
+      </div>
     {% endfor %}
   </nav>
 </aside>


### PR DESCRIPTION
## Summary

- Pre-renders all product nav groups in the sidebar so clicking a top nav item updates the sidebar without a full page reload
- Fixes OpenVoxDB top nav link pointing to `/openvox-server/latest/` instead of `/openvoxdb/latest/`

Closes #108

## Details

The custom `_includes/sidebar.html` rendered only the current page's collection nav at build time. Clicking a top nav item swapped the content frame via Turbo but left the sidebar showing the previous product's nav — the theme has no built-in visibility logic for switching between separate product navs.

**Changes:**
- `_data/nav_map.yml` — new file mapping each nav key to its collections and `latest` base URL
- `_includes/sidebar.html` — renders all four product nav groups; all but the current are `hidden` at build time
- `_includes/jekyll_vitepress/layout_end.html` — adds a `turbo:frame-load` listener on `vp-content-frame` that reads `data-collection` from `vp-page-state` and toggles nav group visibility (matches the same event the theme uses for `syncPersistentNavState`)
- `_includes/nav-item.html` — adds `data-vp-sidebar-group` to collapsible sections so the theme's JS can re-expand the active group after collection switching
- `_data/navigation.yml` — fix copy-paste error on OpenVoxDB URL

## Test plan

- [x] `bundle exec jekyll build` passes
- [x] Clicking top nav items updates the sidebar to the correct product nav
- [x] Sidebar scroll position preserved within a product (Turbo frame, sidebar stays mounted)
- [x] OpenVoxDB top nav navigates to `/openvoxdb/latest/`