### PR TITLE
Add htmlproofer CI workflow (advisory)

### DIFF
--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -1,0 +1,31 @@
+---
+name: HTML Proofer
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  html-proofer:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build
+      - name: Check links (advisory — failures reported but do not block)
+        continue-on-error: true
+        run: |
+          bundle exec htmlproofer _site \
+            --disable-external \
+            --ignore-urls "/puppet/,/pe/,/puppetlabs/" \
+            --allow-hash-href

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rake', '~> 13.0', '>= 13.0.1'
 gem 'versionomy', '~> 0.5.0'
 
 group(:build_site) do
+  gem 'html-proofer', '~> 5.0'
   gem 'jekyll', '~> 4.4'
   gem 'jekyll-vitepress-theme', '~> 1.4'
 end


### PR DESCRIPTION
## Summary

Adds htmlproofer to the CI pipeline to catch broken internal links on every PR and push to master.

Currently runs in **advisory mode** (`continue-on-error: true`) due to significant inherited link debt from the Puppet docs migration. Will be made enforced once the outstanding issues are resolved.

## What it checks

- Internal links only (`--disable-external`) — avoids flakiness from third-party sites going down
- Ignores legacy URL prefixes (`/puppet/`, `/pe/`, `/puppetlabs/`) that appear in inherited content
- Runs against the full built `_site/` directory

## Known outstanding failures (advisory until fixed)

| Category | Count | Tracked in |
|---|---|---|
| `.markdown` ref-style link definitions | ~122 | #118 / #119 |
| `.html` links to deleted/missing pages | ~783 | follow-up |
| `.md` extension links | ~38 | follow-up |

## Roadmap to enforcement

1. Merge #119 (ref-style link definitions) — drops ~1000 failures
2. Fix remaining `.markdown` and `.md` edge cases
3. Address broken `.html` links (deleted man pages, missing hiera pages)
4. Flip `continue-on-error` to `false`