### PR TITLE
Show source and used version in auto generated content

### DIFF
--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -38,9 +38,9 @@ module PuppetReferences
     ]
     config = PuppetReferences::Config.read
     repo = PuppetReferences::Repo.new('openvox', PUPPET_DIR, nil, config['puppet']['repo'])
-    version_commit = commit || repo.describe.split('-')[0]
-    puts "Using tag #{version_commit}"
-    real_commit = repo.checkout(version_commit)
+    $version_commit = commit || repo.describe.split('-')[0]
+    puts "Using tag #{$version_commit}"
+    real_commit = repo.checkout($version_commit)
     repo.update_bundle
     build_from_list_of_classes(references, real_commit)
   end
@@ -57,13 +57,13 @@ module PuppetReferences
     # we need the CLI docs for 3.y. We can remove this when we stop building 3.y.
     version4 = Gem::Version.create('4.0.0')
     repo = PuppetReferences::Repo.new('openfact', FACTER_DIR)
-    version_commit = commit || repo.describe.split('-')[0]
-    puts "Using tag #{version_commit}"
-    real_commit = repo.checkout(version_commit)
+    $version_commit = commit || repo.describe.split('-')[0]
+    puts "Using tag #{$version_commit}"
+    real_commit = repo.checkout($version_commit)
     repo.update_bundle
-    if !semantic?(version_commit) || (semantic?(version_commit) && Gem::Version.create(version_commit) >= version4)
+    if !semantic?($version_commit) || (semantic?($version_commit) && Gem::Version.create($version_commit) >= version4)
       references << PuppetReferences::Facter::FacterCli
-    elsif semantic?(version_commit) && Gem::Version.create(version_commit) < version4
+    elsif semantic?($version_commit) && Gem::Version.create($version_commit) < version4
       reference = PuppetReferences::Facter::FacterCli.new(real_commit)
       reference.build_v3_cli
     end

--- a/lib/puppet_references/facter/core_facts.rb
+++ b/lib/puppet_references/facter/core_facts.rb
@@ -20,7 +20,7 @@ module PuppetReferences
         header_data = { title: 'Facter: Core Facts',
                         toc: 'columns',
                         canonical: "#{@latest}/core_facts.html", }
-        content = make_header(header_data) + PREAMBLE + raw_text
+        content = make_header(header_data, 'OpenFact', $version_commit) + PREAMBLE + raw_text # rubocop:disable Style/GlobalVars
         filename = OUTPUT_DIR + 'core_facts.md'
         filename.open('w') { |f| f.write(content) }
         puts 'Core facts: done!'

--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -32,7 +32,7 @@ module PuppetReferences
         markdown_text, = Open3.capture3('mandoc -T markdown', stdin_data: raw_text)
         # Strip the "TITLE - Manual" header line and the dated footer line mandoc adds
         markdown_text = markdown_text.lines[1...-1].join
-        content = make_header(header_data) + markdown_text
+        content = make_header(header_data, 'OpenFact', $version_commit) + markdown_text # rubocop:disable Style/GlobalVars
         filename = OUTPUT_DIR + 'cli.md'
         filename.open('w') { |f| f.write(content) }
         puts 'CLI documentation is done!'

--- a/lib/puppet_references/puppet/functions.rb
+++ b/lib/puppet_references/puppet/functions.rb
@@ -46,7 +46,7 @@ module PuppetReferences
         # This substitution could potentially make things a bit brittle, but it has to be done because the jump
         # From H2s to H4s is causing issues with the DITA-OT, which sees this as a rule violation. If it
         # Does become an issue, we should return to this and figure out a better way to generate the functions doc.
-        content = make_header(header_data) + "\n\n" + PREAMBLE + "\n\n" + body.gsub(/#####\s(.*?:)/, '**\1**').gsub(
+        content = make_header(header_data, 'OpenVox', $version_commit) + "\n\n" + PREAMBLE + "\n\n" + body.gsub(/#####\s(.*?:)/, '**\1**').gsub( # rubocop:disable Style/GlobalVars
           /####\s/, '###\s'
         )
         output_path = OUTPUT_DIR + filename

--- a/lib/puppet_references/puppet/http.rb
+++ b/lib/puppet_references/puppet/http.rb
@@ -47,7 +47,7 @@ module PuppetReferences
                 end
         header_data = { title: "Puppet HTTP API: #{title}",
                         canonical: "#{@latest}/#{shortname}.html", }
-        content = make_header(header_data) + file.read
+        content = make_header(header_data, 'OpenVox', $version_commit) + file.read
         dest = DOCS_DIR + file.basename
         dest.open('w') { |f| f.write(content) }
       end

--- a/lib/puppet_references/puppet/man.rb
+++ b/lib/puppet_references/puppet/man.rb
@@ -76,7 +76,7 @@ module PuppetReferences
         header_data = { title: 'Puppet Man Pages',
                         canonical: "#{@latest}/overview.html", }
         index_text = <<~MSG
-          #{make_header(header_data)}
+          #{make_header(header_data, 'OpenVox', $version_commit)} # rubocop:disable Style/GlobalVars
 
           Puppet's command line tools consist of a single `puppet` binary with many subcommands. The following subcommands are available in this version of Puppet:
 
@@ -124,7 +124,7 @@ module PuppetReferences
                         canonical: "#{@latest}/#{subcommand}.html", }
         # raw_text = PuppetReferences::ManCommand.new(subcommand).get
         man_filepath = PuppetReferences::PUPPET_DIR.to_s + "/man/man8/puppet-#{subcommand}.8"
-        content = make_header(header_data) + PuppetReferences::Util.convert_man(man_filepath)
+        content = make_header(header_data, 'OpenVox', $version_commit) + PuppetReferences::Util.convert_man(man_filepath) # rubocop:disable Style/GlobalVars
         filename = OUTPUT_DIR + "#{subcommand}.md"
         filename.open('w') { |f| f.write(content) }
       end

--- a/lib/puppet_references/puppet/puppet_doc.rb
+++ b/lib/puppet_references/puppet/puppet_doc.rb
@@ -30,7 +30,7 @@ module PuppetReferences
         header_data = { title: "#{reference.capitalize} Reference",
                         toc: 'columns',
                         canonical: "#{@latest}/#{reference}.html", }
-        content = make_header(header_data) + raw_content
+        content = make_header(header_data, 'OpenVox', $version_commit) + raw_content # rubocop:disable Style/GlobalVars
         filename = OUTPUT_DIR + "#{reference}.md"
         filename.open('w') { |f| f.write(content) }
       end

--- a/lib/puppet_references/puppet/type.rb
+++ b/lib/puppet_references/puppet/type.rb
@@ -46,7 +46,7 @@ module PuppetReferences
         links = names.map do |name|
           "* [#{name}](./#{name}.md)" unless skip_names.include?(name)
         end
-        content = make_header(header_data) + "## List of resource types\n\n" + links.join("\n") + "\n\n" + PREAMBLE
+        content = make_header(header_data, 'OpenVox', $version_commit) + "## List of resource types\n\n" + links.join("\n") + "\n\n" + PREAMBLE # rubocop:disable Style/GlobalVars
         filename = @output_dir_individual + 'overview.md'
         filename.open('w') { |f| f.write(content) }
       end
@@ -68,7 +68,7 @@ module PuppetReferences
           text_for_type(name, typedocs[name])
         end.join("\n\n---------\n\n")
 
-        content = make_header(header_data) + "\n\n" + PREAMBLE + all_type_docs + "\n\n"
+        content = make_header(header_data, 'OpenVox', $version_commit) + "\n\n" + PREAMBLE + all_type_docs + "\n\n" # rubocop:disable Style/GlobalVars
         filename = @output_dir_unified + "#{@base_filename}.md"
         filename.open('w') { |f| f.write(content) }
       end
@@ -83,7 +83,7 @@ module PuppetReferences
         puts "Type ref: Building #{name}"
         header_data = { title: "Resource Type: #{name}",
                         canonical: "#{@latest}/types/#{name}.html", }
-        content = make_header(header_data) + "\n\n" + text_for_type(name, data) + "\n\n"
+        content = make_header(header_data, 'OpenVox', $version_commit) + "\n\n" + text_for_type(name, data) + "\n\n" # rubocop:disable Style/GlobalVars
         filename = @output_dir_individual + "#{name}.md"
         filename.open('w') { |f| f.write(content) }
       end

--- a/lib/puppet_references/reference.rb
+++ b/lib/puppet_references/reference.rb
@@ -10,10 +10,10 @@ module PuppetReferences
       @commit = commit
     end
 
-    def make_header(header_data)
+    def make_header(header_data, source, commit)
       default_header_data = { layout: 'default',
                               built_from_commit: @commit, }
-      PuppetReferences::Util.make_header(default_header_data.merge(header_data))
+      PuppetReferences::Util.make_header(default_header_data.merge(header_data), source, commit)
     end
   end
 end

--- a/lib/puppet_references/util.rb
+++ b/lib/puppet_references/util.rb
@@ -6,9 +6,9 @@ require 'versionomy'
 module PuppetReferences
   module Util
     # Given a hash of data, return YAML frontmatter suitable for the docs site.
-    def self.make_header(data)
+    def self.make_header(data, repo, commit)
       # clean out any symbols:
-      generated_at = "> **NOTE:** This page was generated from the OpenVox source code on #{Time.now}"
+      generated_at = "> **NOTE:** This page was generated from the #{repo} source code based on version #{$version_commit} on #{Time.now}"
       clean_data = data.transform_keys(&:to_s)
       YAML.dump(clean_data) + "---\n\n" + "# #{clean_data['title']}" + "\n\n" + generated_at + "\n\n"
     end


### PR DESCRIPTION
### Short description

Example: Show

```text
> **NOTE:** This page was generated from the OpenVox source code based on version 8.26.2 on 2026-04-30 17:27:15 +0200
> **NOTE:** This page was generated from the Openact source code based on version 5.6.0 on 2026-04-30 17:27:15 +0200

```

instead of

```text
> **NOTE:** This page was generated from the OpenVox source code based on 2026-04-30 17:27:15 +0200
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
