### PR TITLE
Fix broken environments.html links in openvox_8x

### DIFF
--- a/docs/_openvox_8x/config_file_auth.markdown
+++ b/docs/_openvox_8x/config_file_auth.markdown
@@ -6,7 +6,7 @@ title: "Config files: auth.conf (LEGACY)"
 [rest_authconfig]: ./configuration.html#restauthconfig
 [api]: ./http_api/http_api_index.html
 [default_file]: https://github.com/puppetlabs/puppet/blob/4.3.0/conf/auth.conf
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [server_ca]: /openvox-server/latest/config_file_ca.html
 [server_master]: /openvox-server/latest/config_file_master.html
 [server_auth_conf]: /openvox-server/latest/config_file_auth.html

--- a/docs/_openvox_8x/config_file_environment.markdown
+++ b/docs/_openvox_8x/config_file_environment.markdown
@@ -3,8 +3,8 @@ layout: default
 title: "Config files: environment.conf"
 ---
 
-[environment]: ./environments.html
-[environmentpath]: ./environments.html#about-environmentpath
+[environment]: ./environments_about.html
+[environmentpath]: ./environments_creating.html#environmentpath
 [modulepath]: /puppet/3.8/configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
 [basemodulepath]: /puppet/3.8/configuration.html#basemodulepath

--- a/docs/_openvox_8x/config_file_main.markdown
+++ b/docs/_openvox_8x/config_file_main.markdown
@@ -11,7 +11,7 @@ title: "Config files: The main config file (puppet.conf)"
 [reports]: ./configuration.html#reports
 [modulepath]: ./configuration.html#modulepath
 [ssldir]: ./configuration.html#ssldir
-[dir_environments]: ./environments.html
+[dir_environments]: ./environments_about.html
 [environmentpath]: ./configuration.html#environmentpath
 [puppetserver_diff]: /openvox-server/latest/puppet_conf_setting_diffs.html
 

--- a/docs/_openvox_8x/config_important_settings.markdown
+++ b/docs/_openvox_8x/config_important_settings.markdown
@@ -6,7 +6,7 @@ title: "Configuration: Short list of important settings"
 [cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line
 [trusted_and_facts]: ./lang_facts_and_builtin_vars.html
 [config_reference]: ./configuration.html
-[environments]: ./environments.html
+[environments]: ./environments_about.html
 [multi_master]: /guides/scaling_multiple_masters.html
 [enc]: ./nodes_external.html
 [meta_noop]: ./metaparameter.html#noop

--- a/docs/_openvox_8x/config_print.markdown
+++ b/docs/_openvox_8x/config_print.markdown
@@ -7,7 +7,7 @@ title: "Configuration: Checking values of settings"
 [config_sections]: ./config_file_main.html#config-sections
 [setting_sources]: ./config_about_settings.html
 [confdir_sys]: ./dirs_confdir.html#location
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [confdir]: ./dirs_confdir.html
 [vardir]: ./dirs_vardir.html
 [modulepath]: ./dirs_modulepath.html

--- a/docs/_openvox_8x/config_set.markdown
+++ b/docs/_openvox_8x/config_set.markdown
@@ -5,7 +5,7 @@ title: "Configuration: Editing settings on the command line"
 
 [config_sections]: ./config_file_main.html#config-sections
 [puppet.conf]: ./config_file_main.html
-[environments]: ./environments.html
+[environments]: ./environments_about.html
 [confdir_sys]: ./dirs_confdir.html#location
 
 Puppet loads most of its settings from [the puppet.conf config file.][puppet.conf] You can edit this file directly, or you can change individual settings with the `puppet config set` command.

--- a/docs/_openvox_8x/dirs_manifest.markdown
+++ b/docs/_openvox_8x/dirs_manifest.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Directories: The main manifest"
 ---
 
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [catalog_compilation]: ./subsystem_catalog_compilation.html
 [confdir]: ./dirs_confdir.html
 [manifest_setting]: ./configuration.html#manifest

--- a/docs/_openvox_8x/dirs_modulepath.markdown
+++ b/docs/_openvox_8x/dirs_modulepath.markdown
@@ -4,13 +4,13 @@ title: "Directories: The modulepath (default config)"
 ---
 
 [module_fundamentals]: ./modules_fundamentals.html
-[environments]: ./environments.html
-[env_modules]: ./environments.html#setting-up-environments-on-a-puppet-master
+[environments]: ./environments_about.html
+[env_modules]: ./environments_creating.html
 [confdir]: ./dirs_confdir.html
 [basemodulepath_setting]: ./configuration.html#basemodulepath
 [modulepath_setting]: ./configuration.html#modulepath
 [config_print]: ./config_print.html
-[enable_dir_envs]: ./environments.html#enabling-directory-environments
+[enable_dir_envs]: ./environments_creating.html
 [puppet.conf]: ./config_file_main.html
 [environment.conf]: ./config_file_environment.html
 

--- a/docs/_openvox_8x/functions_basics.md
+++ b/docs/_openvox_8x/functions_basics.md
@@ -10,7 +10,7 @@ title: "Writing custom functions: Introduction"
 [stdlib]: http://forge.puppetlabs.com/puppetlabs/stdlib
 [built-in]: ./function.html
 [module]: ./modules_fundamentals.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 
 [func_puppet]: ./lang_write_functions_in_puppet.html
 [func_legacy]: ./functions_legacy.html

--- a/docs/_openvox_8x/functions_legacy.md
+++ b/docs/_openvox_8x/functions_legacy.md
@@ -3,7 +3,7 @@ layout: default
 title: "The legacy Ruby functions API"
 ---
 
-[environments]: ./environments.html
+[environments]: ./environments_about.html
 [func_modern]: ./functions_ruby_overview.html
 [func_puppet]: ./lang_write_functions_in_puppet.html
 

--- a/docs/_openvox_8x/lang_facts_and_builtin_vars.markdown
+++ b/docs/_openvox_8x/lang_facts_and_builtin_vars.markdown
@@ -4,7 +4,7 @@ title: "Language: Facts and built-in variables"
 ---
 
 [definedtype]: ./lang_defined_types.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [topscope]: ./lang_scope.html#top-scope
 [core_facts]: /openfact/latest/core_facts.html
 [facter]: /openfact/latest

--- a/docs/_openvox_8x/lang_reserved.markdown
+++ b/docs/_openvox_8x/lang_reserved.markdown
@@ -17,7 +17,7 @@ title: "Language: Reserved words and acceptable names"
 [class]: ./lang_classes.html
 [type_ref]: ./type.html
 [func_ref]: ./function.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 
 ## Reserved words
 

--- a/docs/_openvox_8x/modules_fundamentals.markdown
+++ b/docs/_openvox_8x/modules_fundamentals.markdown
@@ -15,7 +15,7 @@ title: "Module fundamentals"
 [classes]: ./lang_classes.html
 [defined_types]: ./lang_defined_types.html
 [enc]: ./nodes_external.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [templates]: ./lang_template.html
 [forge]: http://forge.puppetlabs.com
 [file_function]: ./function.html#file

--- a/docs/_openvox_8x/modules_installing.markdown
+++ b/docs/_openvox_8x/modules_installing.markdown
@@ -23,7 +23,7 @@ title: "Installing modules"
 [approved]: https://forge.puppet.com/approved
 [supported]: https://forge.puppet.com/supported
 [score]: /forge/assessingmodulequality.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [pdk]: {{pdk}}/pdk.html
 
 

--- a/docs/_openvox_8x/nodes_external.md
+++ b/docs/_openvox_8x/nodes_external.md
@@ -3,7 +3,7 @@ layout: default
 title: "Writing external node classifiers"
 ---
 
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [node definition]: ./lang_node_definitions.html
 [main manifest]: ./dirs_manifest.html
 

--- a/docs/_openvox_8x/nodes_ldap.md
+++ b/docs/_openvox_8x/nodes_ldap.md
@@ -6,7 +6,7 @@ title: "The LDAP Node Classifier"
 [class parameters]: ./lang_classes.html#class-parameters-and-variables
 [hiera]: ./hiera_intro.html
 [custom hiera backend]: ./hiera_custom_backends.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [node definitions]: ./lang_node_definitions.html
 
 > **Note:** For background on Puppet's main sources of node data, see [the page on external node classifiers](./nodes_external.html).

--- a/docs/_openvox_8x/plugins_in_modules.markdown
+++ b/docs/_openvox_8x/plugins_in_modules.markdown
@@ -4,7 +4,7 @@ title: Plug-ins in Modules
 ---
 
 [modules]: ./modules_fundamentals.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [modulepath]: ./dirs_modulepath.html
 [external facts]: /openfact/latest/custom_facts.html#external-facts
 [vardir]: ./dirs_vardir.html

--- a/docs/_openvox_8x/services_apply.markdown
+++ b/docs/_openvox_8x/services_apply.markdown
@@ -6,7 +6,7 @@ title: "Puppet's services: Puppet apply"
 
 [man]: ./man/apply.html
 [resource type reference]: ./type.html
-[environments]: ./environments.html
+[environments]: ./environments_about.html
 [main manifest]: ./dirs_manifest.html
 [manifest_setting]: ./configuration.html#manifest
 [env_main_manifest]: ./environments_creating.html#the-main-manifest

--- a/docs/_openvox_8x/static_catalogs.md
+++ b/docs/_openvox_8x/static_catalogs.md
@@ -11,7 +11,7 @@ title: "Static catalogs"
 [resource_declaration]: ./lang_resources.html
 [file resources]: ./types/file.html
 [puppet catalog]: ./man/catalog.html
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [facts]: ./lang_facts_and_builtin_vars.html
 [exported resources]: ./lang_exported.html
 [main manifest]: ./dirs_manifest.html

--- a/docs/_openvox_8x/subsystem_catalog_compilation.markdown
+++ b/docs/_openvox_8x/subsystem_catalog_compilation.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Subsystems: Catalog compilation"
 ---
 
-[environment]: ./environments.html
+[environment]: ./environments_about.html
 [certname]: ./config_important_settings.html#basics
 [resource_declaration]: ./lang_resources.html
 [relationships]: ./lang_relationships.html


### PR DESCRIPTION
## Summary

- Fixes 42 htmlproofer failures caused by reference-style links pointing to `environments.html`, which was split into `environments_about.html` and `environments_creating.html` during the Puppet docs migration
- Updated 20 files across `_openvox_8x` to point to the correct pages
- Anchor-specific links remapped to best available targets in the split pages

Part of the link debt being surfaced by #120.

## Changes

| Old link | New link |
|---|---|
| `./environments.html` | `./environments_about.html` |
| `./environments.html#about-environmentpath` | `./environments_creating.html#environmentpath` |
| `./environments.html#setting-up-environments-on-a-puppet-master` | `./environments_creating.html` |
| `./environments.html#enabling-directory-environments` | `./environments_creating.html` |

## Test plan

- [x] `bundle exec jekyll build` passes
- [x] `bundle exec htmlproofer _site --disable-external --ignore-urls "/puppet/,/pe/,/puppetlabs/" --allow-hash-href` shows zero `environments.html` failures