### PR TITLE
Fix .markdown extension links in openvox-server and openvoxdb docs

### DIFF
--- a/docs/_openvox-server_8x/config_file_auth.markdown
+++ b/docs/_openvox-server_8x/config_file_auth.markdown
@@ -78,7 +78,7 @@ If this setting is `true`, Puppet Server ignores any presented certificate and r
 
 You cannot rename any of the `X-Client` headers when this setting is enabled, and you must specify identity through the `X-Client-Verify`, `X-Client-DN`, and `X-Client-Cert` headers.
 
-For more information, see [External SSL Termination](./external_ssl_termination.markdown#disable-https-for-puppet-server) in the Puppet Server documentation and
+For more information, see [External SSL Termination](./external_ssl_termination.html#disable-https-for-puppet-server) in the Puppet Server documentation and
 [Configuring the Authorization Service](https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#allow-header-cert-info) in the `trapperkeeper-authorization`
 documentation.
 

--- a/docs/_openvox-server_8x/config_file_auth_migration.markdown
+++ b/docs/_openvox-server_8x/config_file_auth_migration.markdown
@@ -41,25 +41,25 @@ The following rules, settings, and values have no direct equivalent in the new H
 
 The HOCON `auth.conf` file has some fundamental structural requirements:
 
-- An [`authorization`](./config_file_auth.markdown#authorization) section, which contains:
-  - A [`version`](./config_file_auth.markdown#version) setting.
-  - A [`rules`](./config_file_auth.markdown#rules) array of map values, each representing an authorization rule. Each rule must contain:
-    - A [`match-request`](./config_file_auth.markdown#match-request) section.
-      - Each `match-request` section must contain at least one [`path`](./config_file_auth.markdown#path) and [`type`](./config_file_auth.markdown#type).
-    - A numeric [`sort-order`](./config_file_auth.markdown#sort-order) value.
+- An [`authorization`](./config_file_auth.html#authorization) section, which contains:
+  - A [`version`](./config_file_auth.html#version) setting.
+  - A [`rules`](./config_file_auth.html#rules) array of map values, each representing an authorization rule. Each rule must contain:
+    - A [`match-request`](./config_file_auth.html#match-request) section.
+      - Each `match-request` section must contain at least one [`path`](./config_file_auth.html#path) and [`type`](./config_file_auth.html#type).
+    - A numeric [`sort-order`](./config_file_auth.html#sort-order) value.
       - If the value is between 1 and 399, the rule supersedes Puppet Server's default authorization rules.
       - If the value is between 601 and 998, the rule can be overridden by Puppet Server's default authorization rules.
-    - A string [`name`](./config_file_auth.markdown#name) value.
+    - A string [`name`](./config_file_auth.html#name) value.
     - At least one of the following:
-      - An [`allow` value, a `deny` value, or both](./config_file_auth.markdown#allow-allow-unauthenticated-and-deny). The `allow` or `deny` values can contain:
+      - An [`allow` value, a `deny` value, or both](./config_file_auth.html#allow-allow-unauthenticated-and-deny). The `allow` or `deny` values can contain:
         - A single string, representing the request's "name" derived from the Common Name (CN) attribute within an X.509 certificate's Subject Distinguished Name (DN). This string can be an exact name, a glob,
           or a regular expression.
         - A single map value containing an `extension` key.
         - A single map value containing a `certname` key.
         - An array of values, including string and map values.
-      - An [`allow-unauthenticated`](./config_file_auth.markdown#allow-allow-unauthenticated-and-deny) value, but if present, there cannot also be an `allow` value.
+      - An [`allow-unauthenticated`](./config_file_auth.html#allow-allow-unauthenticated-and-deny) value, but if present, there cannot also be an `allow` value.
 
-For an full example of a HOCON `auth.conf` file, see the [HOCON `auth.conf` documentation](./config_file_auth.markdown#hocon-example).
+For an full example of a HOCON `auth.conf` file, see the [HOCON `auth.conf` documentation](./config_file_auth.html#hocon-example).
 
 ### Converting a simple rule
 
@@ -92,7 +92,7 @@ authorization: {
 
 Next, let's convert each component of the deprecated rule to the new HOCON format.
 
-1. Add the path to the new rule's [`path`](./config_file_auth.markdown#match-request) setting in its `match-request` section.
+1. Add the path to the new rule's [`path`](./config_file_auth.html#match-request) setting in its `match-request` section.
 
    ```hocon
    ...
@@ -107,7 +107,7 @@ Next, let's convert each component of the deprecated rule to the new HOCON forma
    ...
    ```
 
-2. Next, add its type to the section's [`type`](./config_file_auth.markdown#match-request) setting. Because this is a literal string path, the type is `path`.
+2. Next, add its type to the section's [`type`](./config_file_auth.html#match-request) setting. Because this is a literal string path, the type is `path`.
 
    ```hocon
    ...
@@ -122,8 +122,8 @@ Next, let's convert each component of the deprecated rule to the new HOCON forma
    ...
    ```
 
-3. The legacy rule has a [`method`](./config_file_auth.markdown#method-1) setting, with an indirector value of `find` that's equivalent to the GET and POST HTTP methods. We can implement these by adding an
-   optional HOCON [`method`](./config_file_auth.markdown#match-request) setting in the rule's `match-request` section and specifying GET and POST as an array.
+3. The legacy rule has a [`method`](./config_file_auth.html#method-1) setting, with an indirector value of `find` that's equivalent to the GET and POST HTTP methods. We can implement these by adding an
+   optional HOCON [`method`](./config_file_auth.html#match-request) setting in the rule's `match-request` section and specifying GET and POST as an array.
 
    ```hocon
    ...

--- a/docs/_openvox-server_8x/crl_refresh.markdown
+++ b/docs/_openvox-server_8x/crl_refresh.markdown
@@ -6,7 +6,7 @@ canonical: "/puppetserver/latest/crl_refresh.html"
 
 Starting in version 5.1.0, Puppet Server can automatically reload an updated CRL into the running SSL context, so that the revocation of an agent's certificate no longer requires a restart of the service to take effect. Prior versions required an explicit restart or reload of this service to reload the CRL, resulting in some small amount of downtime to effect the revocation of a certificate. Revocation is now transparent and requires no service downtime.
 
-If you are upgrading and have modified your ca.cfg, adding the following line manually may be required. See [Service Bootstraping](./configuration.markdown#service-bootstrapping) for information on how to update your Puppet Server's services bootstrap configuration.
+If you are upgrading and have modified your ca.cfg, adding the following line manually may be required. See [Service Bootstraping](./configuration.html#service-bootstrapping) for information on how to update your Puppet Server's services bootstrap configuration.
 
 `puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service`
 

--- a/docs/_openvox-server_8x/gems.markdown
+++ b/docs/_openvox-server_8x/gems.markdown
@@ -90,7 +90,7 @@ As an example, the following command installs `pry` locally in the project. Note
     Successfully installed pry-0.10.1-java
     5 gems installed
 
-With the gem installed into the project tree `pry` can be invoked from inside Ruby code. For more detailed information on `pry` see [Puppet Server: Debugging](./dev_debugging.markdown#pry).
+With the gem installed into the project tree `pry` can be invoked from inside Ruby code. For more detailed information on `pry` see [Puppet Server: Debugging](./dev_debugging.html#pry).
 
 ## Gems with Native (C) Extensions
 

--- a/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
+++ b/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
@@ -9,17 +9,17 @@ Puppet Server honors almost all settings in puppet.conf and should pick them up 
 
 ## [`autoflush`](https://puppet.com/docs/puppet/latest/configuration.html#autoflush)
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
+Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
 
 ## [`bindaddress`](https://puppet.com/docs/puppet/latest/configuration.html#bindaddress)
 
 Puppet Server does not use this setting. To set the address on which the master listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
-[webserver.conf](./configuration.markdown#webserverconf) file.
+[webserver.conf](./configuration.html#webserverconf) file.
 
 ## [`ca`](https://puppet.com/docs/puppet/latest/configuration.html#ca)
 
 Puppet Server does not use this setting. Instead, Puppet Server acts as a certificate authority based on the certificate authority service configuration in the `ca.cfg` file. See
-[Service Bootstrapping](./configuration.markdown#service-bootstrapping) for more details.
+[Service Bootstrapping](./configuration.html#service-bootstrapping) for more details.
 
 ## [`ca_ttl`](https://puppet.com/docs/puppet/latest/configuration.html#cattl)
 
@@ -28,11 +28,11 @@ Puppet Server enforces a max ttl of 50 standard years (up to 1576800000 seconds)
 ## [`cacert`](https://puppet.com/docs/puppet/latest/configuration.html#cacert)
 
 If you enable Puppet Server's certificate authority service, it uses the `cacert` setting in puppet.conf to determine the location of the CA certificate for such tasks as generating the CA certificate or using
-the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./configuration.markdown#webserverconf).
+the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./configuration.html#webserverconf).
 
 ## [`cacrl`](https://puppet.com/docs/puppet/latest/configuration.html#cacrl)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
 clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, Puppet Server will _not_ use a CRL to validate clients via SSL.
 
 If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
@@ -55,7 +55,7 @@ Puppet Server does not use this setting.
 
 ## [`hostcert`](https://puppet.com/docs/puppet/latest/configuration.html#hostcert)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.markdown#webserverconf), Puppet Server presents the file at `ssl-cert` to clients as the server
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server presents the file at `ssl-cert` to clients as the server
 certificate via SSL.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-cert` is not set, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
@@ -66,7 +66,7 @@ determine the location of the server host certificate to generate.
 
 ## [`hostcrl`](https://puppet.com/docs/puppet/latest/configuration.html#hostcrl)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
 clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, Puppet Server will _not_ use a CRL to validate clients via SSL.
 
 If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
@@ -77,7 +77,7 @@ the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
 ## [`hostprivkey`](https://puppet.com/docs/puppet/latest/configuration.html#hostprivkey)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-key` as the server private key during SSL
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-key` as the server private key during SSL
 transactions.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-key` is not, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set, Puppet
@@ -89,7 +89,7 @@ regardless of the configuration of the `ssl-` settings in webserver.conf.
 ## [`http_debug`](https://puppet.com/docs/puppet/latest/configuration.html#httpdebug)
 
 Puppet Server does not use this setting. Debugging for HTTP client code in the Puppet Server master is controlled through Puppet Server's common logging mechanism. For more information on the master logging
-implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
+implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
 
 ## [`keylength`](https://puppet.com/docs/puppet/latest/configuration.html#keylength)
 
@@ -97,7 +97,7 @@ Puppet Server does not currently use this setting. Puppet Server's certificate a
 
 ## [`localcacert`](https://puppet.com/docs/puppet/latest/configuration.html#localcacert)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-ca-cert` as the CA cert store for
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-ca-cert` as the CA cert store for
 authenticating clients via SSL.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-ca-cert` is not set, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf is set,
@@ -105,24 +105,24 @@ Puppet Server uses the CA file defined for the `localcacert` setting in puppet.c
 
 ## [`logdir`](https://puppet.com/docs/puppet/latest/configuration.html#logdir)
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
+Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
 
 ## [`masterhttplog`](https://puppet.com/docs/puppet/latest/configuration.html#masterhttplog)
 
-Puppet Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.markdown#webserverconf) file.
+Puppet Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.html#webserverconf) file.
 
 ## [`masterlog`](https://puppet.com/docs/puppet/latest/configuration.html#masterlog)
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
+Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
 
 ## [`masterport`](https://puppet.com/docs/puppet/latest/configuration.html#masterport)
 
 Puppet Server does not use this setting. To set the port on which the master listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
-[webserver.conf](./configuration.markdown#webserverconf) file.
+[webserver.conf](./configuration.html#webserverconf) file.
 
 ## [`puppetdlog`](https://puppet.com/docs/puppet/latest/configuration.html#puppetdlog)
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
+Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
 
 ## [`rails_loglevel`](https://puppet.com/docs/puppet/latest/configuration.html#railsloglevel)
 
@@ -174,7 +174,7 @@ requests that the master would make to the `reporturl` for the `http` report pro
 
 ## Overriding Puppet settings in Puppet Server
 
-Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](./configuration.markdown#puppetserver.conf) contains five settings (`master-conf-dir`, `master-code-dir`, `master-var-dir`,
+Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](./configuration.html#puppetserver.conf) contains five settings (`master-conf-dir`, `master-code-dir`, `master-var-dir`,
 `master-run-dir`, and `master-log-dir`) that allow you to override settings set in your `puppet.conf` file. On installation, these five settings will be set to the proper default values.
 
 While you are free to change these settings at will, please note that any changes made to the `master-conf-dir` and `master-code-dir` settings absolutely MUST be made to the corresponding Puppet settings

--- a/docs/_openvox-server_8x/release_notes.markdown
+++ b/docs/_openvox-server_8x/release_notes.markdown
@@ -165,7 +165,7 @@ Released 17 September 2019
 
 - You can now enable sending a list of all the Hiera keys looked up during compile to PuppetDB, via the `jruby-puppet.track-lookups` setting in `puppetserver.conf`. This is currently only used by CD4PE. [SERVER-2538](https://tickets.puppetlabs.com/browse/SERVER-2538)
 
-- Added the `/puppet-admin-api/v1/jruby-pool/thread-dump` endpoint, which returns a thread dump of running JRuby instances, if `jruby.management.enabled` has been set to `true` in the JVM running Puppet Server. See [Admin API: JRuby Pool](./admin-api/v1/jruby-pool.markdown#get-puppet-admin-apiv1jruby-poolthread-dump) for details. [SERVER-2193](https://tickets.puppetlabs.com/browse/SERVER-2193)
+- Added the `/puppet-admin-api/v1/jruby-pool/thread-dump` endpoint, which returns a thread dump of running JRuby instances, if `jruby.management.enabled` has been set to `true` in the JVM running Puppet Server. See [Admin API: JRuby Pool](./admin-api/v1/jruby-pool.html#get-puppet-admin-apiv1jruby-poolthread-dump) for details. [SERVER-2193](https://tickets.puppetlabs.com/browse/SERVER-2193)
 
 - Puppet Server now runs with JRuby 9.2.8.0. [SERVER-2388](https://tickets.puppetlabs.com/browse/SERVER-2588)
  
@@ -228,7 +228,7 @@ Released 26 March 2019
 
 ### New features
 
-- Puppet Server has a new endpoint for catalog retrieval, allowing more options than the previous endpoint. This endpoint is controlled by `tk-auth`, and by default is not generally accessible. It is an API that integrators can use to provide [functionality similar to `puppet master --compile`](https://tickets.puppetlabs.com/browse/PUP-9055). For details on the API, see the [Puppet API catalog](https://github.com/puppetlabs/puppetserver/blob/master/documentation/puppet-api/v4/catalog.markdown). This endpoint is intended for use by other Puppet services. [SERVER-2434](https://tickets.puppetlabs.com/browse/SERVER-2434) 
+- Puppet Server has a new endpoint for catalog retrieval, allowing more options than the previous endpoint. This endpoint is controlled by `tk-auth`, and by default is not generally accessible. It is an API that integrators can use to provide [functionality similar to `puppet master --compile`](https://tickets.puppetlabs.com/browse/PUP-9055). For details on the API, see the [Puppet API catalog](https://github.com/puppetlabs/puppetserver/blob/master/documentation/puppet-api/v4/catalog.html). This endpoint is intended for use by other Puppet services. [SERVER-2434](https://tickets.puppetlabs.com/browse/SERVER-2434) 
 
 ### Enhancements
 

--- a/docs/_openvox-server_8x/restarting.markdown
+++ b/docs/_openvox-server_8x/restarting.markdown
@@ -74,8 +74,8 @@ quickest, but picks up only certain types of changes. A HUP signal or service re
 
 ### Changes that require a full Server restart
 
-- Changes to JVM arguments, such as [heap size settings](./tuning_guide.markdown#jvm-heap-size), that are typically configured in your `/etc/sysconfig/puppetserver` or `/etc/default/puppetserver` file.
-- Changes to [`ca.cfg`](./configuration.markdown#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service.
+- Changes to JVM arguments, such as [heap size settings](./tuning_guide.html#jvm-heap-size), that are typically configured in your `/etc/sysconfig/puppetserver` or `/etc/default/puppetserver` file.
+- Changes to [`ca.cfg`](./configuration.html#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service.
 
 For these types of changes, you must restart the process by using the operating system's service framework, for example, by using the `systemctl` or `service` commands.
 

--- a/docs/_openvox-server_8x/scaling_puppet_server.markdown
+++ b/docs/_openvox-server_8x/scaling_puppet_server.markdown
@@ -116,7 +116,7 @@ Before running `puppet agent` or `puppet master` on the new server:
     - ssl-ca-cert
     - ssl-crl-path
 
-1. [Disable Puppet Server's certificate authority services](./configuration.markdown#service-bootstrapping).
+1. [Disable Puppet Server's certificate authority services](./configuration.html#service-bootstrapping).
 
     If you're using the [individual agent configuration method of CA centralization](#directing-individual-agents-to-a-central-ca), set `ca_server` in `puppet.conf` to the hostname of your CA server in the
     `[main]` config block. If an `ssldir` is configured, make sure it's configured in the `[main]` block only.

--- a/docs/_openvox-server_8x/services_master_puppetserver.markdown
+++ b/docs/_openvox-server_8x/services_master_puppetserver.markdown
@@ -125,7 +125,7 @@ Puppet Server also relies on Logback to manage, rotate, and archive Server log f
 automatically deletes the oldest logs.
 
 Logback is heavily configurable; if you need something more specialized than a unified log file, you can probably get it.
-[See the configuration docs for info on configuring logging.](./configuration.markdown#logging)
+[See the configuration docs for info on configuring logging.](./configuration.html#logging)
 
 Finally, there's a special "daemon" log file used only for errors that happen before logging is set up or which cause the logging system to die. This file can be found at
 `/var/log/puppetlabs/puppetserver/puppetserver-daemon.log` on platforms using SysV-style init, and in journalctl on platforms using systemd.

--- a/docs/_openvox-server_8x/tuning_guide.markdown
+++ b/docs/_openvox-server_8x/tuning_guide.markdown
@@ -42,7 +42,7 @@ Puppet Server.
 ### Number of JRubies
 
 The most important setting that you can use to improve the throughput of your
-Puppet Server installation is the [`max-active-instances`](./configuration.markdown#puppetserver_conf)
+Puppet Server installation is the [`max-active-instances`](./configuration.html#puppetserver_conf)
 setting.  The value of this setting is used by Puppet Server to determine how
 many JRuby instances to create when the server starts up.
 

--- a/docs/_openvoxdb_8x/api/query/v4/aggregate-event-counts.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/aggregate-event-counts.markdown
@@ -50,11 +50,11 @@ This endpoint builds on top of the [`event-counts`][event-counts] endpoint, and 
 
 ### Query operators
 
-This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same operators.](./events.markdown#query-operators)
+This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same operators.](./events.html#query-operators)
 
 ### Query fields
 
-This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same fields.](./events.markdown#query-fields)
+This endpoint builds on top of the [`event-counts`][event-counts] and [`events`][events] endpoints, and supports all of the [same fields.](./events.html#query-fields)
 
 ### Response format
 

--- a/docs/_openvoxdb_8x/api/query/v4/event-counts.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/event-counts.markdown
@@ -49,11 +49,11 @@ See the [`events`][events] endpoint for additional documentation, as this endpoi
 
 ### Query operators
 
-This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same operators.](./events.markdown#query-operators)
+This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same operators.](./events.html#query-operators)
 
 ### Query fields
 
-This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same fields.](./events.markdown#query-fields)
+This endpoint builds on top of the [`events`][events] endpoint, and supports all of the [same fields.](./events.html#query-fields)
 
 ### Response format
 

--- a/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
@@ -90,7 +90,7 @@ Each change below is marked with the corresponding release version.
 
 ### New endpoints
 
-- (2.2.0) `/pdb/query/v4/factsets` This endpoint returns a key-value hash for each certname. For more information, see the [factsets documentation](factsets.markdown#response-format).
+- (2.2.0) `/pdb/query/v4/factsets` This endpoint returns a key-value hash for each certname. For more information, see the [factsets documentation](factsets.html#response-format).
 
 - (2.2.0) `/pdb/query/v4/fact-paths` This endpoint is similar to the existing fact-names endpoint in that one expected use is GUI autocompletion. For more information, see the [documentation](fact-paths.html).
 
@@ -109,36 +109,36 @@ Each change below is marked with the corresponding release version.
 
 ### Features affecting all endpoints
 
-- (3.0) Extract is available as a top-level query operator, useful for selecting only certain fields from a response. See the [documentation on the extract operator](../../../api/query/v4/ast.markdown#extract)
+- (3.0) Extract is available as a top-level query operator, useful for selecting only certain fields from a response. See the [documentation on the extract operator](../../../api/query/v4/ast.html#extract)
   for more information.
 
 - (2.2.0) The `in` and `extract` operators have been changed to accept multiple fields, allowing more concise subquerying as explained [here](https://github.com/puppetlabs/puppetdb/pull/1053).
 
 ### /pdb/query/v4/events
 
-- (3.0) The v4 events endpoint does not require a query parameter, so `/pdb/query/v4/events` is now a valid query. See the [events endpoint documentation](../../../api/query/v4/events.markdown#pdbqueryv4events)
+- (3.0) The v4 events endpoint does not require a query parameter, so `/pdb/query/v4/events` is now a valid query. See the [events endpoint documentation](../../../api/query/v4/events.html#pdbqueryv4events)
   for more information.
 
 ### /pdb/query/v4/reports
 
 - (3.0) The response of the reports endpoint includes the new fields `noop`, `environment`, `status`, `resource_events`, `logs`, and `metrics`. For more information, see the
-  [documentation on the reports endpoint](../../../api/query/v4/reports.html). For comparison, see [an example of the new format](../../../api/query/v4/reports.markdown#examples), and
-  [an example of the old format](https://github.com/puppetlabs/puppetdb/blob/doc-2.3/documentation/api/query/v3/reports.markdown#response-format) (PuppetDB 2.3 docs).
+  [documentation on the reports endpoint](../../../api/query/v4/reports.html). For comparison, see [an example of the new format](../../../api/query/v4/reports.html#examples), and
+  [an example of the old format](https://github.com/puppetlabs/puppetdb/blob/doc-2.3/documentation/api/query/v3/reports.html#response-format) (PuppetDB 2.3 docs).
 
 - (3.0) The reports endpoint takes a `latest_report?` query to return only reports associated with the most recent puppet run for their nodes. Similar to the corresponding events query, there is no
-  corresponding field in the response. For more information, see the [documentation on the report query fields](../../../api/query/v4/reports.markdown#query-fields).
+  corresponding field in the response. For more information, see the [documentation on the report query fields](../../../api/query/v4/reports.html#query-fields).
 
 ### /pdb/query/v4/catalogs
 
 - (3.0) The v4 catalogs endpoint is queryable like the other endpoints, whereas before it could only return a catalog for a single host. The old query format (`/pdb/query/v4/catalogs/myhost`) still works as
-  before, but `/pdb/query/v4/catalogs` returns results too. For more information, see the [catalog query examples](catalogs.markdown#examples).
+  before, but `/pdb/query/v4/catalogs` returns results too. For more information, see the [catalog query examples](catalogs.html#examples).
 
 ### Operators
 
 - (2.2.0) The new `select_fact_contents` subquery operator allows for filtering the results of other endpoints based on detailed queries about structured fact values. This is exhibited on the bottom of the
-  [subquery examples documentation](../../../api/query/v4/ast.markdown#explicit-subquery-examples).
+  [subquery examples documentation](../../../api/query/v4/ast.html#explicit-subquery-examples).
 
 - (2.2.0) We have added the regexp array match operator `~>` for querying fact paths on the `fact-contents` or `fact-paths endpoints`. This is documented with the other
-  [operators](../../../api/query/v4/ast.markdown#regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](../../../api/query/v4/ast.markdown#explicit-subquery-examples).
+  [operators](../../../api/query/v4/ast.html#regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](../../../api/query/v4/ast.html#explicit-subquery-examples).
 
-- (3.0) We have added the `group_by` and `function` operators, as well as support for the `count` function. For more information, see the [operators documentation](../../../api/query/v4/ast.markdown#function).
+- (3.0) We have added the `group_by` and `function` operators, as well as support for the `count` function. For more information, see the [operators documentation](../../../api/query/v4/ast.html#function).

--- a/docs/_openvoxdb_8x/release_notes.markdown
+++ b/docs/_openvoxdb_8x/release_notes.markdown
@@ -308,8 +308,8 @@ Released April 25 2023
   ([PDB-5557](https://tickets.puppetlabs.com/browse/PDB-5557))
 * PuppetDB now supports query timeouts for queries to the `query/` endpoint via
   an [optional query parameter][query-timeout-parameter]. A
-  [default](./configure.markdown#query-timeout-default) and a
-  [maximum](./configure.markdown#query-timeout-max) can also be specified in
+  [default](./configure.html#query-timeout-default) and a
+  [maximum](./configure.html#query-timeout-max) can also be specified in
   the configuration. The current default is ten minutes.
   ([PDB-4937](https://tickets.puppetlabs.com/browse/PDB-4937))
 

--- a/docs/_openvoxdb_8x/release_notes_5.2.markdown
+++ b/docs/_openvoxdb_8x/release_notes_5.2.markdown
@@ -107,7 +107,7 @@ Austin Blatt, Claire Cadman, and Zak Kent
 
 - **New `delete` command.** Use the `delete` command to immediately delete the
   data associated with a certname. For more information, see
-  [Commands endpoint](api/admin/v1/cmd.markdown#delete-version-1).
+  [Commands endpoint](api/admin/v1/cmd.html#delete-version-1).
   [PDB-3300](https://tickets.puppetlabs.com/browse/PDB-3300)
 
 ### Bug fixes

--- a/docs/_openvoxdb_8x/release_notes_6.0.markdown
+++ b/docs/_openvoxdb_8x/release_notes_6.0.markdown
@@ -155,7 +155,7 @@ when the minimum successful submissions have been met. ([PDB-4020](https://ticke
 
 ### Deprecations
 
-- PuppetDB no longer officially supports JDK 7. PuppetDB 6.0.0 officially supports JDK 8, and has been tested against JDK 10. Please see the [FAQ](puppetdb-faq.markdown#which-versions-of-java-are-supported) for further, or more current information. ([PDB-4069](https://tickets.puppetlabs.com/browse/PDB-4069))
+- PuppetDB no longer officially supports JDK 7. PuppetDB 6.0.0 officially supports JDK 8, and has been tested against JDK 10. Please see the [FAQ](puppetdb-faq.html#which-versions-of-java-are-supported) for further, or more current information. ([PDB-4069](https://tickets.puppetlabs.com/browse/PDB-4069))
 - Support for these database configuration options has been completely retired: `classname`, `subprotocol`, `log-slow-statements`, and `conn-keep-alive`. Aside from warning at startup, PuppetDB will completely ignore them, and references to them have been removed from the documentation. ([PDB-3935](https://tickets.puppetlabs.com/browse/PDB-3935))
 
 ### Contributors

--- a/docs/_openvoxdb_8x/release_notes_6.3.markdown
+++ b/docs/_openvoxdb_8x/release_notes_6.3.markdown
@@ -12,7 +12,7 @@ canonical: "/puppetdb/latest/release_notes.html"
 
 ### New features and improvements
 
-- **New `delete` command.** Use the `delete` command to immediately delete the data associated with a certname. For more information, see [Commands endpoint](api/admin/v1/cmd.markdown#delete-version-1).
+- **New `delete` command.** Use the `delete` command to immediately delete the data associated with a certname. For more information, see [Commands endpoint](api/admin/v1/cmd.html#delete-version-1).
   [PDB-3300](https://tickets.puppetlabs.com/browse/PDB-3300)
 
 ### Bug fixes

--- a/docs/_openvoxdb_8x/release_notes_6.markdown
+++ b/docs/_openvoxdb_8x/release_notes_6.markdown
@@ -499,7 +499,7 @@ Austin Blatt, Claire Cadman, and Morgan Rhodes
 
   > **Note:** As of this release, running PostgreSQL without the `pg_trgm` extension is deprecated.
 
-- **Improved queries.** PuppetDB now has an [experimental query optimizer](./api/query/v4/query.markdown#experimental_query_optimization) that may be able to substantially decrease the cost and response time of
+- **Improved queries.** PuppetDB now has an [experimental query optimizer](./api/query/v4/query.html#experimental_query_optimization) that may be able to substantially decrease the cost and response time of
   some queries. [PDB-4512](https://tickets.puppetlabs.com/browse/PDB-4512)
 
 ### Bug fixes
@@ -527,9 +527,9 @@ Austin Blatt, Heston Hoffman, Reinhard Vicinus, Robert Roland, and Zak Kent
 ### New features and improvements
 
 - **New `resource-events-ttl` configuration parameter.** Use the `resource-events-ttl` configuration parameter to automatically delete report events older than the specified time. The parameter rounds up to the
-  nearest day. For example, `14h` rounds up to `1d`. For more information, see [Configuring PuppetDB](./configure.markdown#resource-events-ttl). [PDB-2487](https://tickets.puppetlabs.com/browse/PDB-2487)
+  nearest day. For example, `14h` rounds up to `1d`. For more information, see [Configuring PuppetDB](./configure.html#resource-events-ttl). [PDB-2487](https://tickets.puppetlabs.com/browse/PDB-2487)
 
-- **New `delete` command.** Use the `delete` command to immediately delete the data associated with a certname. For more information, see [Commands endpoint](./api/admin/v1/cmd.markdown#delete-version-1).
+- **New `delete` command.** Use the `delete` command to immediately delete the data associated with a certname. For more information, see [Commands endpoint](./api/admin/v1/cmd.html#delete-version-1).
   [PDB-3300](https://tickets.puppetlabs.com/browse/PDB-3300)
 
 ### Bug fixes

--- a/docs/_openvoxdb_8x/release_notes_7.markdown
+++ b/docs/_openvoxdb_8x/release_notes_7.markdown
@@ -194,7 +194,7 @@ Released December 6 2022
 ### New features and improvements
 
 - The timing of garbage collection operations can be controlled more selectively. The `gc-interval` controls the timing of a set of operations, and now the timing of each of those operations can be
-  [specified individually](./configure.markdown#database-settings). ([PDB-5547](https://tickets.puppetlabs.com/browse/PDB-5547))
+  [specified individually](./configure.html#database-settings). ([PDB-5547](https://tickets.puppetlabs.com/browse/PDB-5547))
 
 ### Bug fixes
 
@@ -205,7 +205,7 @@ Released December 6 2022
   updated to include a suitable `grant puppetdb_read to puppetdb`. ([PDB-5559](https://tickets.puppetlabs.com/browse/PDB-5559))
 
 - The coordination of database migrations will now disallow `[read-database]` user connections as intended. If you do not use the PostgreSQL module, have the recommended, separate `[read-database]` `username`,
-  and have enabled migration coordination via a [`migrator-username`](./configure.markdown#migrator-username) then you may need to make adjustments.
+  and have enabled migration coordination via a [`migrator-username`](./configure.html#migrator-username) then you may need to make adjustments.
 
   Specifically, the the normal `migrator-username` must have the ability to terminate the `[read-database]` `username`'s connections, which the [recommended configuration](./configure_postgres.html)
   accomplishes by granting the write user's role to the migrator via the `grant puppetdb to puppetdb_migrator`, allowing the migrator to terminate the read user's connections indirectly via the

--- a/docs/_openvoxdb_8x/release_notes_8.markdown
+++ b/docs/_openvoxdb_8x/release_notes_8.markdown
@@ -308,8 +308,8 @@ Released April 25 2023
   ([PDB-5557](https://tickets.puppetlabs.com/browse/PDB-5557))
 * PuppetDB now supports query timeouts for queries to the `query/` endpoint via
   an [optional query parameter][query-timeout-parameter]. A
-  [default](./configure.markdown#query-timeout-default) and a
-  [maximum](./configure.markdown#query-timeout-max) can also be specified in
+  [default](./configure.html#query-timeout-default) and a
+  [maximum](./configure.html#query-timeout-max) can also be specified in
   the configuration. The current default is ten minutes.
   ([PDB-4937](https://tickets.puppetlabs.com/browse/PDB-4937))
 

--- a/docs/_openvoxdb_8x/release_notes_older.markdown
+++ b/docs/_openvoxdb_8x/release_notes_older.markdown
@@ -197,7 +197,7 @@ trigger background/GC tasks manually via POST. This release also includes severa
 - Added support for "dotted query" syntax to resource parameters. Support for this is available in both AST and PQL query langauges. ([PDB-2632](https://tickets.puppetlabs.com/browse/PDB-2632))
 
 - Added a new `ast_only` parameter to the root query endpoint that translates a PQL query to an equivalent AST query. More information is available in the
-  [root endpoint](api/query/v4/overview.markdown#url-parameters) docs. ([PDB-2528](https://tickets.puppetlabs.com/browse/PDB-2528))
+  [root endpoint](api/query/v4/overview.html#url-parameters) docs. ([PDB-2528](https://tickets.puppetlabs.com/browse/PDB-2528))
 
 - Added "quick retries" on command failures. This will retry commands (such as storing a new report or updating a catalog) immediately after a failure. The command will be retried 4 times before falling back to
   the regular retry process that involves delaying the message and reenqueuing it. This should result in faster command processing times and use less disk I/O in the most common kinds of failures.
@@ -281,7 +281,7 @@ old reports and node expiration and purging.
 - PuppetDB now has packages for Ubuntu Xenial - 16.04 and Ubuntu Wily - 15.10 ([PDB-2475](https://tickets.puppetlabs.com/browse/PDB-2475)).
 
 - Allow configuration of AciveMQ Broker's memoryLimit. For PuppetDB instances with larger amount of memory and heavy load, this can improve performance. More information in the
-  [config docs](configure.markdown#memory-usage) ([PDB-2726](https://tickets.puppetlabs.com/browse/PDB-2726)).
+  [config docs](configure.html#memory-usage) ([PDB-2726](https://tickets.puppetlabs.com/browse/PDB-2726)).
 
 - Preliminary support for HUP signal handling. Note that due to [AMQ-5263](https://issues.apache.org/jira/browse/AMQ-5263) there is a possibility of a crash when HUPed. We've observed this race condition when
   under heavy load and repeatedly HUPed. This will be fixed and more robust in a future release ([PDB-2546](https://tickets.puppetlabs.com/browse/PDB-2546)).
@@ -655,7 +655,7 @@ bug fixes.
 
 - New [`code_id`](http://docs.puppetlabs.com/puppetdb/3.2/api/query/v4/catalogs.html#query-fields) field in preparation for new filesync service. ([PDB-1810](https://tickets.puppetlabs.com/browse/PDB-1810))
 
-- Introduction of [`latest_report_status` and `latest_report_hash`](http://docs.puppetlabs.com/puppetdb/3.2/api/query/v4/nodes.markdown#query-fields) to the `nodes` entity, as projected from the a nodes latest
+- Introduction of [`latest_report_status` and `latest_report_hash`](http://docs.puppetlabs.com/puppetdb/3.2/api/query/v4/nodes.html#query-fields) to the `nodes` entity, as projected from the a nodes latest
   report. ([PDB-1820](https://tickets.puppetlabs.com/browse/PDB-1820))
 
 - Experimental: [Implicit subqueries](http://docs.puppetlabs.com/puppetdb/3.2/api/query/v4/operators.html#subquery-implicit-subqueries) now provide a way to perform subqueries on other entities within a query
@@ -1452,7 +1452,7 @@ Andrew Roetker, Erik Dalén, Jean Bond, Ken Barber, Preben Ingvaldsen, Rob Brade
 
 - An incorrect reference to "Java" has been changed to "JVM" in the [configuration](http://docs.puppetlabs.com/puppetdb/2.3/configure.html) documentation.
 
-- The relationship between "MQ depth" and "Command Queue depth" has been clarified in the [tuning and maintenance](http://docs.puppetlabs.com/puppetdb/2.3/maintain_and_tune.markdown) documentation.
+- The relationship between "MQ depth" and "Command Queue depth" has been clarified in the [tuning and maintenance](http://docs.puppetlabs.com/puppetdb/2.3/maintain_and_tune.html) documentation.
 
 - An example that uses curl with SSL to communicate with Puppet Enterprise has been added to the [curl](http://docs.puppetlabs.com/puppetdb/2.3/api/query/curl.html) documentation.
 

--- a/docs/_openvoxdb_8x/repl.markdown
+++ b/docs/_openvoxdb_8x/repl.markdown
@@ -13,7 +13,7 @@ security reasons, it should generally be left disabled.
 
 ## Enabling the REPL
 
-To enable the REPL, you must edit PuppetDB's config file to [enable it, configure the listening IP address, and choose a port](./configure.markdown#nrepl-settings):
+To enable the REPL, you must edit PuppetDB's config file to [enable it, configure the listening IP address, and choose a port](./configure.html#nrepl-settings):
 
     # /etc/puppetdb/conf.d/repl.ini
     [nrepl]


### PR DESCRIPTION
## Summary

Extends the fix from #119 to the remaining two collections. Inline links in `_openvox-server_8x` and `_openvoxdb_8x` used `.markdown` extensions, which Jekyll renders as `.html` — causing 404s on the built site.

22 files updated across both collections.

Part of the link debt being surfaced by #120.

## Test plan

- [x] `bundle exec jekyll build` passes
- [x] No `.markdown` link failures in htmlproofer output