### PR TITLE
Add OpenBolt documentation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,6 +79,7 @@ jobs:
         run: |
           bundle exec rake references:openfact INSTALLPATH=docs
           bundle exec rake references:openvox INSTALLPATH=docs
+          bundle exec rake references:openbolt INSTALLPATH=docs
           bundle exec jekyll build
       - name: Archive website
         run: |

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ task :references do
   puts 'The following references are available:'
   puts 'bundle exec rake references:openvox [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
   puts 'bundle exec rake references:openfact [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
+  puts 'bundle exec rake references:openbolt [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
   puts 'bundle exec rake references:version_tables'
   puts '  VERSION can be omitted, uses latest tag'
   puts '  INSTALLPATH can be omitted, defaults to references_output/'
@@ -44,6 +45,11 @@ namespace :references do
   task openfact: 'references:check' do
     require 'puppet_references'
     PuppetReferences.build_facter_references(ENV.fetch('VERSION', nil))
+  end
+
+  task openbolt: 'references:check' do
+    require 'puppet_references'
+    PuppetReferences.build_openbolt_references(ENV.fetch('VERSION', nil))
   end
 
   task :version_tables do

--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,13 @@ collections:
     output: true
     permalink: '/openvoxdb/8.x/:path:output_ext'
 
+  openbolt_latest:
+    output: true
+    permalink: '/openbolt/latest/:path:output_ext'
+  openbolt_5x:
+    output: true
+    permalink: '/openbolt/5.x/:path:output_ext'
+
 defaults:
   - scope:
       path: ''
@@ -105,6 +112,17 @@ defaults:
       type: openvoxdb_8x
     values:
       nav: openvoxdb_8x
+
+  - scope:
+      path: ''
+      type: openbolt_latest
+    values:
+      nav: openbolt_5x
+  - scope:
+      path: ''
+      type: openbolt_5x
+    values:
+      nav: openbolt_5x
 
 
 # Ignores all legacy files present in the root directory as of

--- a/_data/nav/openbolt_5x.yml
+++ b/_data/nav/openbolt_5x.yml
@@ -1,0 +1,117 @@
+---
+- text: Overview
+  items:
+  - text: Welcome to OpenBolt
+    link: index.html
+  - text: Getting started
+    link: getting_started_with_bolt.html
+  - text: Versioning
+    link: bolt_versioning.html
+  - text: Known issues
+    link: bolt_known_issues.html
+  - text: Troubleshooting
+    link: troubleshooting.html
+  - text: Upgrading to Bolt 3
+    link: upgrading_to_bolt_3.html
+  - text: Glossary
+    link: glossary.html
+- text: Installation
+  items:
+  - text: Installing Bolt
+    link: bolt_installing.html
+  - text: Running Bolt in Docker
+    link: running_bolt_in_docker.html
+  - text: VS Code and Bolt
+    link: vscode_and_bolt.html
+- text: Configuration
+  items:
+  - text: Configuring Bolt
+    link: configuring_bolt.html
+  - text: Projects
+    link: projects.html
+  - text: Inventory files
+    link: inventory_files.html
+  - text: Inventory reference
+    link: bolt_inventory_reference.html
+  - text: Hiera
+    link: hiera.html
+  - text: Supported plugins
+    link: supported_plugins.html
+- text: Commands and scripts
+  items:
+  - text: Running Bolt commands
+    link: running_bolt_commands.html
+  - text: Running scripts
+    link: bolt_running_scripts.html
+  - text: Running Bolt over a network
+    link: running_bolt_network.html
+- text: Tasks
+  items:
+  - text: Introduction to tasks
+    link: tasks.html
+  - text: Running tasks
+    link: bolt_running_tasks.html
+  - text: Writing tasks
+    link: writing_tasks.html
+  - text: Inspecting tasks
+    link: inspecting_tasks.html
+  - text: Task helpers
+    link: task_helpers.html
+- text: Plans
+  items:
+  - text: Introduction to plans
+    link: plans.html
+  - text: Running plans
+    link: bolt_running_plans.html
+  - text: Writing plans
+    link: writing_plans.html
+  - text: Writing YAML plans
+    link: writing_yaml_plans.html
+  - text: Creating a script plan
+    link: creating_a_script_plan.html
+  - text: Inspecting plans
+    link: inspecting_plans.html
+  - text: Debugging plans
+    link: debugging_plans.html
+  - text: Testing plans
+    link: testing_plans.html
+  - text: Applying manifest blocks
+    link: applying_manifest_blocks.html
+- text: Modules
+  items:
+  - text: Modules
+    link: modules.html
+  - text: Module structure
+    link: module_structure.html
+  - text: Installing modules
+    link: bolt_installing_modules.html
+- text: Plugins
+  items:
+  - text: Using plugins
+    link: using_plugins.html
+  - text: Writing plugins
+    link: writing_plugins.html
+- text: Reference
+  items:
+  - text: Bolt spec reference
+    link: boltspec_reference.html
+  - text: JSON output reference
+    link: json_output_reference.html
+  - text: Connecting to PuppetDB
+    link: bolt_connect_puppetdb.html
+  - text: Choria transport
+    link: choria-transport.html
+  - text: Automating Windows targets
+    link: automating_windows_targets.html
+  - text: Analytics
+    link: analytics.html
+  - text: Experimental features
+    link: experimental_features.html
+  - text: Logs
+    link: logs.html
+  - text: TIG stack
+    link: tig_stack.html
+  - text: Developer updates
+    link: developer_updates.html
+  - text: Examples
+    link: bolt_examples.html

--- a/_data/nav_map.yml
+++ b/_data/nav_map.yml
@@ -13,3 +13,7 @@
 - nav_key: openvoxdb_8x
   collections: openvoxdb_latest|openvoxdb_8x
   base: /openvoxdb/latest/
+
+- nav_key: openbolt_5x
+  collections: openbolt_latest|openbolt_5x
+  base: /openbolt/latest/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,6 @@
 - title: OpenVoxDB
   url: /openvoxdb/latest/
   collections: [openvoxdb_latest, openvoxdb_8x]
+- title: OpenBolt
+  url: /openbolt/latest/
+  collections: [openbolt_latest, openbolt_5x]

--- a/docs/_openbolt_5x/.gitignore
+++ b/docs/_openbolt_5x/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/docs/_openbolt_latest
+++ b/docs/_openbolt_latest
@@ -1,0 +1,1 @@
+_openbolt_5x

--- a/index.md
+++ b/index.md
@@ -30,6 +30,11 @@ features:
     title: OpenVox DB
     details: OpenVoxDB is the fast, scalable, and reliable data warehouse for OpenVox.
     link: openvoxdb/latest/
+
+  - icon: 🔩
+    title: OpenBolt
+    details: OpenBolt is an open source orchestration tool that automates on-demand changes to remote targets such as servers, network devices, and cloud services.
+    link: openbolt/latest/
 ---
 
 {% include alert.html type="warning" title="Under Construction" content="The contents of this documentation site are currently being re-built from various upstream sources. Links may be broken and some version information may be out of date. Pardon the mess as we get things cleaned up!" %}

--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -7,6 +7,7 @@ module PuppetReferences
   PUPPET_DIR = BASE_DIR + 'vendor/openvox'
   FACTER_DIR = BASE_DIR + 'vendor/openfact'
   AGENT_DIR = BASE_DIR + 'vendor/openvox-agent'
+  BOLT_DIR = BASE_DIR + 'vendor/openbolt'
   INSTALLPATH = ENV['INSTALLPATH'] ? ENV.fetch('INSTALLPATH') : 'references_output'
   OUTPUT_DIR = BASE_DIR + INSTALLPATH
 
@@ -24,6 +25,7 @@ module PuppetReferences
   require 'puppet_references/puppet/functions'
   require 'puppet_references/facter/core_facts'
   require 'puppet_references/facter/facter_cli'
+  require 'puppet_references/openbolt/docs'
   require 'puppet_references/version_tables/config'
   require 'puppet_references/version_tables/data/pe'
   require 'puppet_references/version_tables/data/agent'
@@ -67,6 +69,18 @@ module PuppetReferences
       reference = PuppetReferences::Facter::FacterCli.new(real_commit)
       reference.build_v3_cli
     end
+    build_from_list_of_classes(references, real_commit)
+  end
+
+  def self.build_openbolt_references(commit)
+    references = [
+      PuppetReferences::Openbolt::Docs,
+    ]
+    config = PuppetReferences::Config.read
+    repo = PuppetReferences::Repo.new('openbolt', BOLT_DIR, nil, config.dig('openbolt', 'repo') || {})
+    version_commit = commit || repo.describe.split('-')[0]
+    puts "Using tag #{version_commit}"
+    real_commit = repo.checkout(version_commit)
     build_from_list_of_classes(references, real_commit)
   end
 

--- a/lib/puppet_references/openbolt/docs.rb
+++ b/lib/puppet_references/openbolt/docs.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'puppet_references'
+require 'fileutils'
+
+module PuppetReferences
+  module Openbolt
+    class Docs < PuppetReferences::Reference
+      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openbolt_latest'
+      DOCS_SOURCE = PuppetReferences::BOLT_DIR + 'documentation'
+
+      # README.md is repo housekeeping, not a user-facing doc page.
+      SKIP_FILES = %w[README.md].freeze
+
+      def initialize(*)
+        @latest = '/openbolt/latest'
+        super
+      end
+
+      def build_all
+        OUTPUT_DIR.mkpath
+        puts 'OpenBolt Docs: Building all...'
+        copy_docs
+        puts 'OpenBolt Docs: Done!'
+      end
+
+      def copy_docs
+        Pathname.glob(DOCS_SOURCE + '*.md').each do |file|
+          next if SKIP_FILES.include?(file.basename.to_path)
+
+          munge_and_copy_doc_file(file)
+        end
+        Pathname.glob(DOCS_SOURCE + '*.{png,jpg,gif,svg}').each do |img|
+          FileUtils.cp(img.to_path, (OUTPUT_DIR + img.basename).to_path)
+        end
+        write_index
+      end
+
+      # bolt.md is the welcome/overview page; writing it as index.md gives
+      # /openbolt/latest/ a landing page instead of a directory listing.
+      def write_index
+        source = DOCS_SOURCE + 'bolt.md'
+        content = source.read
+        title = extract_title(content) || 'OpenBolt'
+        header_data = { title: title, canonical: "#{@latest}/index.html" }
+        body = strip_leading_h1(content)
+        (OUTPUT_DIR + 'index.md').open('w') { |f| f.write(make_header(header_data) + body) }
+      end
+
+      # Upstream bolt docs are plain markdown with no frontmatter; Jekyll
+      # requires it to treat files as collection pages.
+      def munge_and_copy_doc_file(file)
+        content = file.read
+        title = extract_title(content) || humanize(file.basename('.md').to_path)
+        shortname = file.basename('.md').to_path
+        header_data = {
+          title: title,
+          canonical: "#{@latest}/#{shortname}.html",
+        }
+        body = strip_leading_h1(content)
+        dest = OUTPUT_DIR + file.basename
+        dest.open('w') { |f| f.write(make_header(header_data) + body) }
+      end
+
+      # Overrides the base class version, which emits "generated from OpenVox
+      # source code" and re-adds an H1 — both wrong for OpenBolt pages.
+      def make_header(header_data)
+        require 'yaml'
+        data = {
+          'layout' => 'default',
+          'built_from_commit' => @commit,
+          'title' => header_data[:title],
+          'canonical' => header_data[:canonical],
+        }
+        generated_at = "> **NOTE:** This page was generated from the OpenBolt source code on #{Time.now}"
+        YAML.dump(data) + "---\n\n" + generated_at + "\n\n"
+      end
+
+      private
+
+      def extract_title(content)
+        match = content.match(/^#\s+(.+)$/)
+        match[1].strip if match
+      end
+
+      # The theme renders the H1 from frontmatter `title:`, so the source H1
+      # would appear twice if left in the body.
+      def strip_leading_h1(content)
+        content.sub(/\A#[^\n]*\n+/, '')
+      end
+
+      def humanize(filename)
+        filename.gsub(/[-_]/, ' ').split.map(&:capitalize).join(' ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `rake references:openbolt` task that clones `OpenVoxProject/openbolt`, checks out the latest tag, and copies all docs and images from its `documentation/` directory into `docs/_openbolt_5x/` with Jekyll frontmatter
- Registers `openbolt_5x` / `openbolt_latest` collections in `_config.yml`, `_data/nav_map.yml`, and `_data/navigation.yml`
- Adds the sidebar nav file `_data/nav/openbolt_5x.yml` with pages organised into sections
- Wires `rake references:openbolt INSTALLPATH=docs` into the CI build step alongside the existing openvox/openfact tasks
- Adds an OpenBolt feature card on the homepage

Closes #98.

## Nav maintenance note

`_data/nav/openbolt_5x.yml` is hand-authored and not generated by the rake task. If pages are added, renamed, or removed in the upstream `OpenVoxProject/openbolt` `documentation/` directory, this file will need a corresponding manual update to keep the sidebar accurate.

## Test plan

- [x] `bundle exec rubocop lib/puppet_references/openbolt/docs.rb` — no offenses
- [x] `bundle exec rake references:openbolt` — clones repo, generates 49 pages + 4 images into `references_output/_openbolt_latest/`
- [x] `bundle exec rake references:openbolt INSTALLPATH=docs` — files land correctly in `docs/_openbolt_5x/` via symlink
- [x] `bundle exec jekyll build` — clean build, pages served at `/openbolt/latest/` and `/openbolt/5.x/`
- [x] Sidebar nav renders with correct section groupings and active-page highlighting
- [x] Top navbar and homepage feature card link correctly to `/openbolt/latest/`
- [x] Generated files are gitignored via `docs/_openbolt_5x/.gitignore`