### PR TITLE
Fix broken .md links in generated OpenBolt docs

### DIFF
--- a/lib/puppet_references/openbolt/docs.rb
+++ b/lib/puppet_references/openbolt/docs.rb
@@ -43,7 +43,7 @@ module PuppetReferences
         content = source.read
         title = extract_title(content) || 'OpenBolt'
         header_data = { title: title, canonical: "#{@latest}/index.html" }
-        body = strip_leading_h1(content)
+        body = rewrite_md_links(strip_leading_h1(content))
         (OUTPUT_DIR + 'index.md').open('w') { |f| f.write(make_header(header_data) + body) }
       end
 
@@ -57,7 +57,7 @@ module PuppetReferences
           title: title,
           canonical: "#{@latest}/#{shortname}.html",
         }
-        body = strip_leading_h1(content)
+        body = rewrite_md_links(strip_leading_h1(content))
         dest = OUTPUT_DIR + file.basename
         dest.open('w') { |f| f.write(make_header(header_data) + body) }
       end
@@ -87,6 +87,25 @@ module PuppetReferences
       # would appear twice if left in the body.
       def strip_leading_h1(content)
         content.sub(/\A#[^\n]*\n+/, '')
+      end
+
+      # Upstream links reference other docs as .md; rewrite to .html so they
+      # resolve once Jekyll has processed the collection. Handles both markdown
+      # links [text](file.md) and inline HTML href="file.md". Absolute URLs
+      # (http/https) are left alone. Capture groups are saved to local variables
+      # before calling .sub() — that call resets Regexp.last_match, so reading
+      # group 2 after it would silently drop anchors (#section).
+      def rewrite_md_links(content)
+        result = content.gsub(%r{\]\(((?!https?://)[^)#]*\.md)(#[^)]*)?\)}) do
+          path = Regexp.last_match(1)
+          anchor = Regexp.last_match(2)
+          "](#{path.sub(/\.md$/, '.html')}#{anchor})"
+        end
+        result.gsub(%r{href="((?!https?://)[^"#]*\.md)(#[^"]*)?"}i) do
+          path = Regexp.last_match(1)
+          anchor = Regexp.last_match(2)
+          "href=\"#{path.sub(/\.md$/, '.html')}#{anchor}\""
+        end
       end
 
       def humanize(filename)


### PR DESCRIPTION
## Summary

- Adds a `rewrite_md_links` step to the OpenBolt doc copy pipeline that converts relative `.md` cross-reference links to `.html` so they resolve correctly once Jekyll has processed the collection
- Handles both markdown-style links `[text](file.md)` and raw HTML `<a href="file.md">` attributes
- Absolute `http`/`https` URLs are left untouched
- Anchors (`#section`) are preserved

## Why not `jekyll-relative-links`?

`jekyll-relative-links` was evaluated first. It only processes markdown-style links after Kramdown converts them — it does not touch raw HTML `<a href="...">` attributes that appear verbatim in the source. The bolt docs use raw HTML for most of their cross-references (e.g. the "Helpful Bolt docs links" table on the index page), so the plugin left the majority of broken links unresolved. The in-pipeline rewrite covers both formats in one pass.

## Implementation note

Capture groups are assigned to local variables before calling `.sub()` inside each `gsub` block. Calling `.sub()` resets `Regexp.last_match`, so reading group 2 (the anchor) after it would silently return `nil` and drop `#section` from rewritten links.

## Test plan

- [x] `bundle exec rubocop lib/puppet_references/openbolt/docs.rb` — no offenses
- [x] `bundle exec rake references:openbolt INSTALLPATH=docs && bundle exec jekyll build` — clean build
- [x] No `href="*.md"` links remain in `_site/openbolt/latest/index.html`
- [x] Anchored links (e.g. `file.md#section`) rewrite to `file.html#section`
- [x] Absolute URLs unchanged