### PR TITLE
Modernize openvox-server landing page and nav

### DIFF
--- a/_data/nav/openvox-server_8x.yml
+++ b/_data/nav/openvox-server_8x.yml
@@ -1,6 +1,4 @@
 ---
-- text: Index
-  link: index.html
 - text: About OpenVox Server
   link: services_puppetserver.html
 - text: Release notes
@@ -19,11 +17,11 @@
     link: install_what_and_where.html
   - text: Upgrading OpenVox Server
     link: upgrade_minor.html
-- text: Configuring Puppet Server
+- text: Configuring OpenVox Server
   items:
-  - text: Configuring Puppet Server
+  - text: Configuring OpenVox Server
     link: configuration.html
-  - text: 'Main Puppet Server configurations: puppetserver.conf'
+  - text: 'Main OpenVox Server configurations: puppetserver.conf'
     link: config_file_puppetserver.html
   - text: 'Global settings: global.conf'
     link: config_file_global.html
@@ -41,27 +39,25 @@
     link: config_logging_advanced.html
   - text: 'CA service: ca.conf'
     link: config_file_ca.html
-  - text: Puppet Server use of puppet.conf settings
+  - text: OpenVox Server use of puppet.conf settings
     link: puppet_conf_setting_diffs.html
   - text: 'Configuring product-level interactions (optional): product.conf'
     link: config_file_product.html
   - text: Bootstrap upgrade notes
     link: bootstrap_upgrade_notes.html
-- text: Using and extending Puppet Server
+- text: Using and extending OpenVox Server
   items:
   - text: Using Ruby gems
     link: gems.html
   - text: Subcommands
     link: subcommands.html
-  - text: Using an external certificate authority
-    link: external_ca_configuration.html
   - text: Infrastructure CRL
     link: infrastructure_crl.html
   - text: Intermediate CA
     link: intermediate_ca.html
-  - text: External SSL germination
+  - text: External SSL termination
     link: external_ssl_termination.html
-  - text: Restarting Puppet server
+  - text: Restarting OpenVox Server
     link: restarting.html
 - text: Tuning, troubleshooting, and known issues
   items:
@@ -70,7 +66,7 @@
   - text: SSL problems with load-balanced PuppetDB servers ("Server Certificate Change"
       error)
     link: ssl_server_certificate_change_and_virtual_ips.html
-  - text: Puppet Server tuning guide
+  - text: OpenVox Server tuning guide
     link: tuning_guide.html
   - text: Migrating to the HOCON auth.conf format
     link: config_file_auth_migration.html

--- a/docs/_openvox-server_8x/index.markdown
+++ b/docs/_openvox-server_8x/index.markdown
@@ -18,7 +18,7 @@ It also runs a built-in certificate authority for signing agent certificates.
 For a full description of the service and its internal components, see
 [About OpenVox Server](./services_puppetserver.html).
 
-## Core packages
+## OpenVox Server packages
 
 | Package | Contents |
 | ------- | -------- |

--- a/docs/_openvox-server_8x/index.markdown
+++ b/docs/_openvox-server_8x/index.markdown
@@ -1,61 +1,27 @@
 ---
 layout: default
-title: "Puppet Server: Index"
-canonical: "/puppetserver/latest/"
+title: "OpenVox Server 8"
 ---
 
-Puppet Server is the next-generation application for managing Puppet agents.
+OpenVox Server is the primary server component in an OpenVox agent/server deployment.
+It compiles configuration catalogs for managed nodes, serves files, manages certificates,
+and receives reports from agents.
+It is a Ruby and Clojure application that runs on the Java Virtual Machine (JVM).
 
-> **Note:** For information about configuring and tuning settings specific to [Puppet Enterprise](https://puppet.com/docs/pe/), see
-> [its documentation](https://puppet.com/docs/pe/latest/configuring/config_puppetserver.html).
+## How it works
 
-- [**About OpenVox Server**](./services_puppetserver.html)
-  - [Release notes](./release_notes.html)
-  - [Deprecated features](./deprecated_features.html)
-  - [Notable differences vs. the Apache/Passenger stack](./puppetserver_vs_passenger.html)
-  - [Compatibility with Puppet agent](./compatibility_with_puppet_agent.html)
-- [**Installing Puppet Server**](./install_from_packages.html)
-- [**Configuring Puppet Server**](./configuration.html)
-  - [global.conf](./config_file_global.html)
-  - [webserver.conf](./config_file_webserver.html)
-  - [web-routes.conf](./config_file_web-routes.html)
-  - [puppetserver.conf](./config_file_puppetserver.html)
-  - [auth.conf](./config_file_auth.html)
-    - [Migrating deprecated authentication rules](./config_file_auth_migration.html)
-  - [metrics.conf](./config_file_metrics.html)
-  - [logback.xml](./config_file_logbackxml.html)
-    - [Advanced logging configuration](./config_logging_advanced.html)
-  - [master.conf](./config_file_master.html) (deprecated)
-  - [ca.conf](./config_file_ca.html)
-  - [Differing behavior in puppet.conf](./puppet_conf_setting_diffs.html)
-- **Using and extending Puppet Server**
-  - [Subcommands](./subcommands.html)
-  - [Using Ruby gems](./gems.html)
-  - [Using an external certificate authority](./external_ca_configuration.html)
-  - [External SSL termination](./external_ssl_termination.html)
-  - [Monitoring Puppet Server metrics](./puppet_server_metrics.html)
-    - [HTTP client metrics](./http_client_metrics.html)
-  - [Tuning guide](./tuning_guide.html)
-  - [Applying metrics to improve performance](./puppet_server_metrics_performance.html)
-  - [Scaling Puppet Server](./scaling_puppet_server.html)
-  - [Restarting Puppet Server](./restarting.html)
-- **Known issues and workarounds**
-  - [Known issues](./known_issues.html)
-  - [SSL problems with load-balanced PuppetDB servers ("Server Certificate Change" error)](./ssl_server_certificate_change_and_virtual_ips.html)
-- **Administrative API endpoints**
-  - [Environment cache](./admin-api/v1/environment-cache.html)
-  - [JRuby pool](./admin-api/v1/jruby-pool.html)
-- **Server-specific Puppet API endpoints**
-  - [Environment classes](./puppet-api/v3/environment_classes.html)
-  - [Environment modules](./puppet-api/v3/environment_modules.html)
-  - [Static file content](./puppet-api/v3/static_file_content.html)
-- **Status API endpoints**
-  - [Status services](./status-api/v1/services.html)
-  - [Simple status](./status-api/v1/simple.html)
-- **Metrics API endpoints**
-  - [v1 metrics](./metrics-api/v1/metrics_api.html)
-  - [v2 (Jolokia) metrics](./metrics-api/v2/metrics_api.html)
-- **Developer information**
-  - [Debugging](./dev_debugging.html)
-  - [Running from source](./dev_running_from_source.html)
-  - [Tracing code events](./dev_trace_func.html)
+OpenVox agents periodically contact OpenVox Server over mutual-TLS HTTPS.
+The server compiles a node-specific catalog from Puppet code and Hiera data, returns it
+to the agent for enforcement, and collects the resulting report.
+It also runs a built-in certificate authority for signing agent certificates.
+
+For a full description of the service and its internal components, see
+[About OpenVox Server](./services_puppetserver.html).
+
+## Getting started
+
+1. Review [pre-install tasks](install_pre.html) — system requirements, DNS, firewall, and time synchronization
+2. [Install OpenVox Server](install_from_packages.html)
+3. [Configure OpenVox Server](configuration.html)
+
+For community help and support resources, see the [Vox Pupuli support page](https://voxpupuli.org/openvox/support/).

--- a/docs/_openvox-server_8x/index.markdown
+++ b/docs/_openvox-server_8x/index.markdown
@@ -18,6 +18,12 @@ It also runs a built-in certificate authority for signing agent certificates.
 For a full description of the service and its internal components, see
 [About OpenVox Server](./services_puppetserver.html).
 
+## Core packages
+
+| Package | Contents |
+| ------- | -------- |
+| `openvox-server` | JVM-based catalog server; depends on `openvox-agent`. Requires Java 17 or 21 (not bundled). |
+
 ## Getting started
 
 1. Review [pre-install tasks](install_pre.html) — system requirements, DNS, firewall, and time synchronization


### PR DESCRIPTION
Closes #150

## Summary

- Replaces the legacy `index.markdown` ToC (titled "Puppet Server: Index", with a Puppet Enterprise note and a `canonical` pointing at `puppetserver/latest/`) with a concise landing page modeled on the openvox agent index
- New page describes what OpenVox Server is, explains the agent/server architecture, provides a 3-step getting-started path (pre-install → install → configure), and links to the Vox Pupuli support page
- Adds a Core packages table noting the Java 17/21 requirement and that a JDK is not bundled
- Removes the redundant "Index" top-level nav entry
- Renames all remaining "Puppet Server" nav labels to "OpenVox Server"
- Removes the dead `external_ca_configuration.html` nav link
- Fixes a typo in the nav: "SSL germination" → "SSL termination"

## Test plan

- [x] `bundle exec jekyll serve` — verify `/openvox-server/latest/` renders the new landing page
- [x] Confirm the three getting-started links (pre-install, install, configure) resolve correctly
- [x] Confirm `services_puppetserver.html` resolves
- [x] Confirm the sidebar no longer shows an "Index" entry and all renamed labels appear correctly
- [x] Verify the removed `external_ca_configuration.html` nav entry no longer appears