### PR TITLE
Modernize puppet_conf_setting_diffs page

### DIFF
--- a/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
+++ b/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
@@ -10,16 +10,6 @@ OpenVox Server honors almost all settings in puppet.conf and should pick them up
 
 OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## `bindaddress`
-
-OpenVox Server does not use this setting. To set the address on which the server listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
-[webserver.conf](./configuration.html#webserverconf) file.
-
-## `ca`
-
-OpenVox Server does not use this setting. Instead, OpenVox Server acts as a certificate authority based on the certificate authority service configuration in the `ca.cfg` file. See
-[Service Bootstrapping](./configuration.html#service-bootstrapping) for more details.
-
 ## `ca_ttl`
 
 OpenVox Server enforces a max ttl of 50 standard years (up to 1576800000 seconds).
@@ -39,14 +29,6 @@ OpenVox Server copies the file for the `cacrl` setting, if one exists, over to t
 
 Any CRL file updates from the OpenVox Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location
 of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
-
-## `capass`
-
-OpenVox Server does not use this setting. OpenVox Server's certificate authority does not create a `capass` password file when the CA certificate and key are generated.
-
-## `caprivatedir`
-
-OpenVox Server does not use this setting. OpenVox Server's certificate authority does not create this directory.
 
 ## `daemonize`
 
@@ -106,14 +88,6 @@ OpenVox Server uses the CA file defined for the `localcacert` setting in puppet.
 
 OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## `masterhttplog`
-
-OpenVox Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.html#webserverconf) file.
-
-## `masterlog`
-
-OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
-
 ## `masterport`
 
 OpenVox Server does not use this setting. To set the port on which the server listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
@@ -122,14 +96,6 @@ OpenVox Server does not use this setting. To set the port on which the server li
 ## `puppetdlog`
 
 OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
-
-## `rails_loglevel`
-
-OpenVox Server does not use this setting.
-
-## `railslog`
-
-OpenVox Server does not use this setting.
 
 ## `ssl_client_header`
 
@@ -141,11 +107,6 @@ OpenVox Server honors this setting only if the `allow-header-cert-info` setting 
 OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to `true`. For more information on this setting, see the documentation on
 [external SSL termination](./external_ssl_termination.html).
 
-## `ssl_server_ca_auth`
-
-OpenVox Server does not use this setting. It only considers the `ssl-ca-cert` setting from the webserver.conf file and the `cacert` setting from the puppet.conf file. See [`cacert`](#cacert) for more
-information.
-
 ## `syslogfacility`
 
 OpenVox Server does not use this setting.
@@ -155,11 +116,6 @@ OpenVox Server does not use this setting.
 OpenVox Server does not use this setting.
 
 ## HttpPool-Related Server Settings
-
-## `configtimeout`
-
-OpenVox Server does not currently consider this setting for any code running on the server and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to
-any requests that the server would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
 ## `http_proxy_host`
 

--- a/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
+++ b/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
@@ -6,10 +6,6 @@ title: "How OpenVox Server uses the values in puppet.conf"
 OpenVox Server honors almost all settings in puppet.conf and should pick them up automatically. For more complete information on puppet.conf settings, see the
 [Configuration Reference](/openvox/latest/configuration.html) page.
 
-## `autoflush`
-
-OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
-
 ## `ca_ttl`
 
 OpenVox Server enforces a max ttl of 50 standard years (up to 1576800000 seconds).
@@ -30,10 +26,6 @@ OpenVox Server copies the file for the `cacrl` setting, if one exists, over to t
 Any CRL file updates from the OpenVox Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location
 of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
-## `daemonize`
-
-OpenVox Server does not use this setting.
-
 ## `hostcert`
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server presents the file at `ssl-cert` to clients as the server
@@ -42,7 +34,7 @@ certificate via SSL.
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
 OpenVox Server uses the file for the `hostcert` setting in puppet.conf as the server certificate during SSL negotiation.
 
-Regardless of the configuration of the `ssl-` "webserver.conf" settings, OpenVox Server's certificate authority service, if enabled, uses the `hostcert` "puppet.conf" setting, and not the `ssl-cert` setting,
+Regardless of the configuration of the `ssl-` `webserver.conf` settings, OpenVox Server's certificate authority service, if enabled, uses the `hostcert` `puppet.conf` setting, and not the `ssl-cert` setting,
 to determine the location of the server host certificate to generate.
 
 ## `hostcrl`
@@ -67,15 +59,6 @@ OpenVox Server uses the file for the `hostprivkey` setting in puppet.conf as the
 If you enable the OpenVox Server certificate authority service, OpenVox Server uses the `hostprivkey` setting in puppet.conf to determine the location of the server host private key to generate. This is true
 regardless of the configuration of the `ssl-` settings in webserver.conf.
 
-## `http_debug`
-
-OpenVox Server does not use this setting. Debugging for HTTP client code in the OpenVox Server is controlled through OpenVox Server's common logging mechanism. For more information on the server logging
-implementation, see the [logging configuration section](./configuration.html#logging).
-
-## `keylength`
-
-OpenVox Server does not currently use this setting. OpenVox Server's certificate authority generates 4096-bit keys in conjunction with any SSL certificates that it generates.
-
 ## `localcacert`
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-ca-cert` as the CA cert store for
@@ -84,36 +67,20 @@ authenticating clients via SSL.
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-ca-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf is set,
 OpenVox Server uses the CA file defined for the `localcacert` setting in puppet.conf for SSL authentication.
 
-## `logdir`
-
-OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
-
 ## `masterport`
 
 OpenVox Server does not use this setting. To set the port on which the server listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
 [webserver.conf](./configuration.html#webserverconf) file.
 
-## `puppetdlog`
-
-OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
-
 ## `ssl_client_header`
 
-OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to 'true'. For more information on this setting, see the documentation on
-[external SSL termination](./external_ssl_termination.html).
+OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the [`master.conf`](./config_file_master.html) file (deprecated) is set to `true`. For more information,
+see the documentation on [external SSL termination](./external_ssl_termination.html).
 
 ## `ssl_client_verify_header`
 
-OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to `true`. For more information on this setting, see the documentation on
-[external SSL termination](./external_ssl_termination.html).
-
-## `syslogfacility`
-
-OpenVox Server does not use this setting.
-
-## `user`
-
-OpenVox Server does not use this setting.
+OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the [`master.conf`](./config_file_master.html) file (deprecated) is set to `true`. For more information,
+see the documentation on [external SSL termination](./external_ssl_termination.html).
 
 ## HttpPool-Related Server Settings
 

--- a/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
+++ b/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
@@ -1,193 +1,192 @@
 ---
 layout: default
-title: "How Puppet Server uses the values in puppet.conf"
-canonical: "/puppetserver/latest/puppet_conf_setting_diffs.html"
+title: "How OpenVox Server uses the values in puppet.conf"
 ---
 
-Puppet Server honors almost all settings in puppet.conf and should pick them up automatically. For more complete information on puppet.conf settings, see our
-[Configuration Reference](https://puppet.com/docs/puppet/latest/configuration.html) page.
+OpenVox Server honors almost all settings in puppet.conf and should pick them up automatically. For more complete information on puppet.conf settings, see the
+[Configuration Reference](/openvox/latest/configuration.html) page.
 
-## [`autoflush`](https://puppet.com/docs/puppet/latest/configuration.html#autoflush)
+## `autoflush`
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
+OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## [`bindaddress`](https://puppet.com/docs/puppet/latest/configuration.html#bindaddress)
+## `bindaddress`
 
-Puppet Server does not use this setting. To set the address on which the master listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
+OpenVox Server does not use this setting. To set the address on which the server listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
 [webserver.conf](./configuration.html#webserverconf) file.
 
-## [`ca`](https://puppet.com/docs/puppet/latest/configuration.html#ca)
+## `ca`
 
-Puppet Server does not use this setting. Instead, Puppet Server acts as a certificate authority based on the certificate authority service configuration in the `ca.cfg` file. See
+OpenVox Server does not use this setting. Instead, OpenVox Server acts as a certificate authority based on the certificate authority service configuration in the `ca.cfg` file. See
 [Service Bootstrapping](./configuration.html#service-bootstrapping) for more details.
 
-## [`ca_ttl`](https://puppet.com/docs/puppet/latest/configuration.html#cattl)
+## `ca_ttl`
 
-Puppet Server enforces a max ttl of 50 standard years (up to 1576800000 seconds).
+OpenVox Server enforces a max ttl of 50 standard years (up to 1576800000 seconds).
 
-## [`cacert`](https://puppet.com/docs/puppet/latest/configuration.html#cacert)
+## `cacert`
 
-If you enable Puppet Server's certificate authority service, it uses the `cacert` setting in puppet.conf to determine the location of the CA certificate for such tasks as generating the CA certificate or using
-the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./configuration.html#webserverconf).
+If you enable OpenVox Server's certificate authority service, it uses the `cacert` setting in puppet.conf to determine the location of the CA certificate for such tasks as generating the CA certificate or
+using the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./configuration.html#webserverconf).
 
-## [`cacrl`](https://puppet.com/docs/puppet/latest/configuration.html#cacrl)
+## `cacrl`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
-clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, Puppet Server will _not_ use a CRL to validate clients via SSL.
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
+clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, OpenVox Server will _not_ use a CRL to validate clients via SSL.
 
-If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
-Puppet Server copies the file for the `cacrl` setting, if one exists, over to the location in the `hostcrl` setting.
+If none of the `ssl-` settings in webserver.conf are set, OpenVox Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
+OpenVox Server copies the file for the `cacrl` setting, if one exists, over to the location in the `hostcrl` setting.
 
-Any CRL file updates from the Puppet Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location of
-the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
+Any CRL file updates from the OpenVox Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location
+of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
-## [`capass`](https://puppet.com/docs/puppet/latest/configuration.html#capass)
+## `capass`
 
-Puppet Server does not use this setting. Puppet Server's certificate authority does not create a `capass` password file when the CA certificate and key are generated.
+OpenVox Server does not use this setting. OpenVox Server's certificate authority does not create a `capass` password file when the CA certificate and key are generated.
 
-## [`caprivatedir`](https://puppet.com/docs/puppet/latest/configuration.html#caprivatedir)
+## `caprivatedir`
 
-Puppet Server does not use this setting. Puppet Server's certificate authority does not create this directory.
+OpenVox Server does not use this setting. OpenVox Server's certificate authority does not create this directory.
 
-## [`daemonize`](https://puppet.com/docs/puppet/latest/configuration.html#daemonize)
+## `daemonize`
 
-Puppet Server does not use this setting.
+OpenVox Server does not use this setting.
 
-## [`hostcert`](https://puppet.com/docs/puppet/latest/configuration.html#hostcert)
+## `hostcert`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server presents the file at `ssl-cert` to clients as the server
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server presents the file at `ssl-cert` to clients as the server
 certificate via SSL.
 
-If at least one of the `ssl-` settings in webserver.conf is set but `ssl-cert` is not set, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
-Puppet Server uses the file for the `hostcert` setting in puppet.conf as the server certificate during SSL negotiation.
+If at least one of the `ssl-` settings in webserver.conf is set but `ssl-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
+OpenVox Server uses the file for the `hostcert` setting in puppet.conf as the server certificate during SSL negotiation.
 
-Regardless of the configuration of the `ssl-` "webserver.conf" settings, Puppet Server's certificate authority service, if enabled, uses the `hostcert` "puppet.conf" setting, and not the `ssl-cert` setting, to
-determine the location of the server host certificate to generate.
+Regardless of the configuration of the `ssl-` "webserver.conf" settings, OpenVox Server's certificate authority service, if enabled, uses the `hostcert` "puppet.conf" setting, and not the `ssl-cert` setting,
+to determine the location of the server host certificate to generate.
 
-## [`hostcrl`](https://puppet.com/docs/puppet/latest/configuration.html#hostcrl)
+## `hostcrl`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating
-clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, Puppet Server will _not_ use a CRL to validate clients via SSL.
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
+clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, OpenVox Server will _not_ use a CRL to validate clients via SSL.
 
-If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
-Puppet Server copies the file for the `cacrl` setting, if one exists, over to the location in the `hostcrl` setting.
+If none of the `ssl-` settings in webserver.conf are set, OpenVox Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
+OpenVox Server copies the file for the `cacrl` setting, if one exists, over to the location in the `hostcrl` setting.
 
-Any CRL file updates from the Puppet Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location of
-the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
+Any CRL file updates from the OpenVox Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location
+of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
-## [`hostprivkey`](https://puppet.com/docs/puppet/latest/configuration.html#hostprivkey)
+## `hostprivkey`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-key` as the server private key during SSL
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-key` as the server private key during SSL
 transactions.
 
-If at least one of the `ssl-` settings in webserver.conf is set but `ssl-key` is not, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set, Puppet
-Server uses the file for the `hostprivkey` setting in puppet.conf as the server private key during SSL negotiation.
+If at least one of the `ssl-` settings in webserver.conf is set but `ssl-key` is not, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
+OpenVox Server uses the file for the `hostprivkey` setting in puppet.conf as the server private key during SSL negotiation.
 
-If you enable the Puppet Server certificate authority service, Puppet Server uses the `hostprivkey` setting in puppet.conf to determine the location of the server host private key to generate. This is true
+If you enable the OpenVox Server certificate authority service, OpenVox Server uses the `hostprivkey` setting in puppet.conf to determine the location of the server host private key to generate. This is true
 regardless of the configuration of the `ssl-` settings in webserver.conf.
 
-## [`http_debug`](https://puppet.com/docs/puppet/latest/configuration.html#httpdebug)
+## `http_debug`
 
-Puppet Server does not use this setting. Debugging for HTTP client code in the Puppet Server master is controlled through Puppet Server's common logging mechanism. For more information on the master logging
-implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
+OpenVox Server does not use this setting. Debugging for HTTP client code in the OpenVox Server is controlled through OpenVox Server's common logging mechanism. For more information on the server logging
+implementation, see the [logging configuration section](./configuration.html#logging).
 
-## [`keylength`](https://puppet.com/docs/puppet/latest/configuration.html#keylength)
+## `keylength`
 
-Puppet Server does not currently use this setting. Puppet Server's certificate authority generates 4096-bit keys in conjunction with any SSL certificates that it generates.
+OpenVox Server does not currently use this setting. OpenVox Server's certificate authority generates 4096-bit keys in conjunction with any SSL certificates that it generates.
 
-## [`localcacert`](https://puppet.com/docs/puppet/latest/configuration.html#localcacert)
+## `localcacert`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), Puppet Server uses the file at `ssl-ca-cert` as the CA cert store for
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-ca-cert` as the CA cert store for
 authenticating clients via SSL.
 
-If at least one of the `ssl-` settings in webserver.conf is set but `ssl-ca-cert` is not set, Puppet Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf is set,
-Puppet Server uses the CA file defined for the `localcacert` setting in puppet.conf for SSL authentication.
+If at least one of the `ssl-` settings in webserver.conf is set but `ssl-ca-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf is set,
+OpenVox Server uses the CA file defined for the `localcacert` setting in puppet.conf for SSL authentication.
 
-## [`logdir`](https://puppet.com/docs/puppet/latest/configuration.html#logdir)
+## `logdir`
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
+OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## [`masterhttplog`](https://puppet.com/docs/puppet/latest/configuration.html#masterhttplog)
+## `masterhttplog`
 
-Puppet Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.html#webserverconf) file.
+OpenVox Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.html#webserverconf) file.
 
-## [`masterlog`](https://puppet.com/docs/puppet/latest/configuration.html#masterlog)
+## `masterlog`
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
+OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## [`masterport`](https://puppet.com/docs/puppet/latest/configuration.html#masterport)
+## `masterport`
 
-Puppet Server does not use this setting. To set the port on which the master listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
+OpenVox Server does not use this setting. To set the port on which the server listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
 [webserver.conf](./configuration.html#webserverconf) file.
 
-## [`puppetdlog`](https://puppet.com/docs/puppet/latest/configuration.html#puppetdlog)
+## `puppetdlog`
 
-Puppet Server does not use this setting. For more information on the master logging implementation for Puppet Server, see the [logging configuration section](./configuration.html#logging).
+OpenVox Server does not use this setting. For more information on the server logging implementation, see the [logging configuration section](./configuration.html#logging).
 
-## [`rails_loglevel`](https://puppet.com/docs/puppet/latest/configuration.html#railsloglevel)
+## `rails_loglevel`
 
-Puppet Server does not use this setting.
+OpenVox Server does not use this setting.
 
-## [`railslog`](https://puppet.com/docs/puppet/latest/configuration.html#railslog)
+## `railslog`
 
-Puppet Server does not use this setting.
+OpenVox Server does not use this setting.
 
-## [`ssl_client_header`](https://puppet.com/docs/puppet/latest/configuration.html#sslclientheader)
+## `ssl_client_header`
 
-Puppet Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to 'true'. For more information on this setting, see the documentation on
+OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to 'true'. For more information on this setting, see the documentation on
 [external SSL termination](./external_ssl_termination.html).
 
-## [`ssl_client_verify_header`](https://puppet.com/docs/puppet/latest/configuration.html#sslclientverifyheader)
+## `ssl_client_verify_header`
 
-Puppet Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to `true`. For more information on this setting, see the documentation on
+OpenVox Server honors this setting only if the `allow-header-cert-info` setting in the `master.conf` file is set to `true`. For more information on this setting, see the documentation on
 [external SSL termination](./external_ssl_termination.html).
 
-## [`ssl_server_ca_auth`](https://puppet.com/docs/puppet/latest/configuration.html#sslservercaauth)
+## `ssl_server_ca_auth`
 
-Puppet Server does not use this setting. It only considers the `ssl-ca-cert` setting from the webserver.conf file and the `cacert` setting from the puppet.conf file. See [`cacert`](#cacert) for more
+OpenVox Server does not use this setting. It only considers the `ssl-ca-cert` setting from the webserver.conf file and the `cacert` setting from the puppet.conf file. See [`cacert`](#cacert) for more
 information.
 
-## [`syslogfacility`](https://puppet.com/docs/puppet/latest/configuration.html#syslogfacility)
+## `syslogfacility`
 
-Puppet Server does not use this setting.
+OpenVox Server does not use this setting.
 
-## [`user`](https://puppet.com/docs/puppet/latest/configuration.html#user)
+## `user`
 
-Puppet Server does not use this setting.
+OpenVox Server does not use this setting.
 
 ## HttpPool-Related Server Settings
 
-## [`configtimeout`](https://puppet.com/docs/puppet/latest/configuration.html#configtimeout)
+## `configtimeout`
 
-Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any
-requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
+OpenVox Server does not currently consider this setting for any code running on the server and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to
+any requests that the server would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
-## [`http_proxy_host`](https://puppet.com/docs/puppet/latest/configuration.html#httpproxyhost)
+## `http_proxy_host`
 
-Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any
-requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
+OpenVox Server does not currently consider this setting for any code running on the server and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to
+any requests that the server would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
-## [`http_proxy_port`](https://puppet.com/docs/puppet/latest/configuration.html#httpproxyport)
+## `http_proxy_port`
 
-Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any
-requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
+OpenVox Server does not currently consider this setting for any code running on the server and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to
+any requests that the server would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
-## Overriding Puppet settings in Puppet Server
+## Overriding Puppet settings in OpenVox Server
 
 Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](./configuration.html#puppetserver.conf) contains five settings (`master-conf-dir`, `master-code-dir`, `master-var-dir`,
 `master-run-dir`, and `master-log-dir`) that allow you to override settings set in your `puppet.conf` file. On installation, these five settings will be set to the proper default values.
 
 While you are free to change these settings at will, please note that any changes made to the `master-conf-dir` and `master-code-dir` settings absolutely MUST be made to the corresponding Puppet settings
-(`confdir` and `codedir`) as well to ensure that Puppet Server and the Puppet cli tools (such as `puppetserver ca` and `puppet module`) use the same directories. The `master-conf-dir` and `master-code-dir`
-settings apply to Puppet Server only, and will be ignored by the ruby code that runs when the Puppet CLI tools are run.
+(`confdir` and `codedir`) as well to ensure that OpenVox Server and the Puppet cli tools (such as `puppetserver ca` and `puppet module`) use the same directories. The `master-conf-dir` and `master-code-dir`
+settings apply to OpenVox Server only, and will be ignored by the ruby code that runs when the Puppet CLI tools are run.
 
-For example, say you have the `codedir` setting left unset in your `puppet.conf` file, and you change the `master-code-dir` setting to `/etc/my-puppet-code-dir`. In this case, Puppet Server will read code from
-`/etc/my-puppet-code-dir`, but the `puppet module` tool will think that your code is stored in `/etc/puppetlabs/code`.
+For example, say you have the `codedir` setting left unset in your `puppet.conf` file, and you change the `master-code-dir` setting to `/etc/my-puppet-code-dir`. In this case, OpenVox Server will read code
+from `/etc/my-puppet-code-dir`, but the `puppet module` tool will think that your code is stored in `/etc/puppetlabs/code`.
 
-While it is not as critical to keep `master-var-dir`, `master-run-dir`, and `master-log-dir` in sync with the `vardir`, `rundir`, and `logdir` Puppet settings, please note that this applies to these settings as
-well.
+While it is not as critical to keep `master-var-dir`, `master-run-dir`, and `master-log-dir` in sync with the `vardir`, `rundir`, and `logdir` Puppet settings, please note that this applies to these settings
+as well.
 
 Also, please note that these configuration differences also apply to the interpolation of the `confdir`, `codedir`, `vardir`, `rundir`, and `logdir` settings in your `puppet.conf` file. So, take the above
-example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Because the `basemodulepath` setting is by default `$codedir/modules:/opt/puppetlabs/puppet/modules`, then Puppet Server would use
+example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Because the `basemodulepath` setting is by default `$codedir/modules:/opt/puppetlabs/puppet/modules`, then OpenVox Server would use
 `/etc/my-puppet-code-dir/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting, whereas the `puppet module` tool would use
 `/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting.


### PR DESCRIPTION
Closes #150 (partial — one file from the backlog)

## Summary

- OpenVox branding throughout; removed 31 puppet.com section heading links; intro now links to `/openvox/latest/configuration.html`
- Removed 10 settings confirmed absent from the openvox-server codebase (`bindaddress`, `ca`, `capass`, `caprivatedir`, `configtimeout`, `masterhttplog`, `masterlog`, `rails_loglevel`, `railslog`, `ssl_server_ca_auth`)
- Removed 8 more sections that only said "does not use this setting" with no actionable content (`autoflush`, `daemonize`, `http_debug`, `keylength`, `logdir`, `puppetdlog`, `syslogfacility`, `user`)
- Fixed quote formatting inconsistency in `hostcert` section
- Added deprecation note to `ssl_client_header` and `ssl_client_verify_header` sections referencing `master.conf`
- All remaining claims verified against the openvox-server source

Page goes from 32 sections to 14, all of which document genuine behavioral differences worth explaining.

## Test plan

- [x] `npx markdownlint-cli2` — 0 errors
- [x] Page renders at `/openvox-server/8.x/puppet_conf_setting_diffs.html` (200)
- [x] All linked pages return 200 (`configuration.html`, `config_file_master.html`, `external_ssl_termination.html`, `/openvox/latest/configuration.html`)
- [x] Content verified against openvox-server source (Clojure CA and config core)