### PR TITLE
Add OpenVox ecosystem orientation guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,13 @@ jekyll_vitepress:
 
 collections_dir: docs
 collections:
+  ecosystem_latest:
+    output: true
+    permalink: '/ecosystem/latest/:path:output_ext'
+  ecosystem_8x:
+    output: true
+    permalink: '/ecosystem/8.x/:path:output_ext'
+
   openfact_latest:
     output: true
     permalink: '/openfact/latest/:path:output_ext'
@@ -62,6 +69,17 @@ collections:
     permalink: '/openvoxdb/8.x/:path:output_ext'
 
 defaults:
+  - scope:
+      path: ''
+      type: ecosystem_latest
+    values:
+      nav: ecosystem_8x
+  - scope:
+      path: ''
+      type: ecosystem_8x
+    values:
+      nav: ecosystem_8x
+
   - scope:
       path: ''
       type: openfact_latest

--- a/_data/nav/ecosystem_8x.yaml
+++ b/_data/nav/ecosystem_8x.yaml
@@ -1,0 +1,13 @@
+---
+- text: OpenVox Ecosystem
+  items:
+  - text: Overview
+    link: index.html
+  - text: Projects
+    link: projects.html
+  - text: Learning paths
+    link: learning-path.html
+  - text: Migration orientation
+    link: migration.html
+  - text: Community
+    link: community.html

--- a/_data/nav_map.yml
+++ b/_data/nav_map.yml
@@ -1,3 +1,7 @@
+- nav_key: ecosystem_8x
+  collections: ecosystem_latest|ecosystem_8x
+  base: /ecosystem/latest/
+
 - nav_key: openfact_5x
   collections: openfact_latest|openfact_5x
   base: /openfact/latest/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,3 +1,6 @@
+- title: Ecosystem
+  url: /ecosystem/latest/
+  collections: [ecosystem_latest, ecosystem_8x]
 - title: OpenFact
   url: /openfact/latest/
   collections: [openfact_latest, openfact_5x]

--- a/docs/_ecosystem_8x/community.md
+++ b/docs/_ecosystem_8x/community.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: "Community"
+---
+
+OpenVox is maintained in the Vox Pupuli community. Use this page as a stable entry point for community channels, project repositories,
+and documentation contributions.
+
+## Background and Governance
+
+OpenVox began as a community continuation of Puppet-compatible open source configuration management. The project is stewarded through
+Vox Pupuli and the OpenVoxProject GitHub organization.
+
+For current project background, governance, and roadmap context, use:
+
+- [OpenVox Automation Framework](https://voxpupuli.org/openvox/)
+- [Puppet Standards Steering Committee](https://voxpupuli.org/openvox/standards/)
+- [OpenVox GitHub organization](https://github.com/OpenVoxProject)
+
+## Community Channels
+
+Use [Vox Pupuli Connect](https://voxpupuli.org/connect/) for current community links. It is the best source for Slack, IRC, mailing
+lists, events, social links, and other contact points.
+
+For documentation-specific discussion, see the channel guidance in the
+[OpenVox docs README](https://github.com/OpenVoxProject/openvox-docs#updating-documentation).
+
+## Project Repositories
+
+Start with the [OpenVox GitHub organization](https://github.com/OpenVoxProject) for project repositories, issues, and pull requests.
+
+Common entry points:
+
+- [OpenVox docs](https://github.com/OpenVoxProject/openvox-docs)
+- [OpenVox](https://github.com/OpenVoxProject/openvox)
+- [OpenVox Server](https://github.com/OpenVoxProject/openvoxserver)
+- [OpenVoxDB](https://github.com/OpenVoxProject/openvoxdb)
+- [OpenFact](https://github.com/OpenVoxProject/openfact)
+- [OpenBolt](https://github.com/OpenVoxProject/openbolt)
+
+## Contributing to Documentation
+
+Documentation contributions are made through pull requests to the
+[OpenVox docs repository](https://github.com/OpenVoxProject/openvox-docs).
+
+Before opening a pull request:
+
+1. Read the [contribution guide](https://github.com/OpenVoxProject/openvox-docs/blob/master/CONTRIBUTING.md).
+2. Preview changes locally with Jekyll.
+3. Update the relevant navigation file under `_data/nav/` when adding or moving pages.
+4. Keep new pages focused and link to canonical docs instead of duplicating existing material.
+
+## Contributing Modules
+
+OpenVox uses the existing Puppet module ecosystem. For module work, start with:
+
+- [Module fundamentals](/openvox/latest/modules_fundamentals.html)
+- [Roles and profiles](/openvox/latest/the_roles_and_profiles_method.html)
+- [Puppet Forge](https://forge.puppet.com/)
+- [Vox Pupuli Connect](https://voxpupuli.org/connect/)

--- a/docs/_ecosystem_8x/index.md
+++ b/docs/_ecosystem_8x/index.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: "OpenVox ecosystem"
+---
+
+The OpenVox ecosystem is a set of related projects for describing, applying, reporting on, and extending system configuration.
+This section is an orientation map. It explains where the pieces fit and points to the canonical documentation for details.
+
+## Projects
+
+[OpenVox](/openvox/latest/), [OpenVox Server](/openvox-server/latest/), [OpenVoxDB](/openvoxdb/latest/),
+[OpenFact](/openfact/latest/), and [OpenBolt](https://github.com/OpenVoxProject/openbolt).
+See the [project map](./projects.html) for descriptions and canonical links.
+
+## Start Here
+
+- New to OpenVox: start with the [OpenVox overview](/openvox/latest/) and the [agent overview](/openvox/latest/about_agent.html).
+- Learning the model: read the [architecture overview](/openvox/latest/architecture.html), then the
+  [language summary](/openvox/latest/lang_summary.html).
+- Organizing code: use the [roles and profiles method](/openvox/latest/the_roles_and_profiles_method.html) and
+  [module fundamentals](/openvox/latest/modules_fundamentals.html).
+- Separating data from code: read the [Hiera introduction](/openvox/latest/hiera_intro.html).
+- Operating a server: start with [OpenVox Server](/openvox-server/latest/) and its
+  [configuration guide](/openvox-server/latest/configuration.html).
+- Working with reports and queries: start with [OpenVoxDB](/openvoxdb/latest/) and the
+  [PQL tutorial](/openvoxdb/latest/api/query/tutorial-pql.html).
+- Working with facts: start with [OpenFact](/openfact/latest/) and the
+  [facts overview](/openfact/latest/fact_overview.html).
+
+## Community
+
+OpenVox is maintained by the Vox Pupuli community. Use [Vox Pupuli Connect](https://voxpupuli.org/connect/) for current community
+channels, events, and contact points.

--- a/docs/_ecosystem_8x/learning-path.md
+++ b/docs/_ecosystem_8x/learning-path.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: "Learning paths"
+---
+
+Use these paths to find the right starting point for your role and current experience. Each path links to the canonical docs for the
+topic instead of repeating the material here.
+
+## New to OpenVox
+
+Start with the system model, then move into a small working example.
+
+1. Read the [OpenVox overview](/openvox/latest/).
+2. Learn how agents and servers fit together in the [architecture overview](/openvox/latest/architecture.html).
+3. Run through the [quick start](/openvox/latest/quick_start.html).
+4. Read the [language summary](/openvox/latest/lang_summary.html).
+5. Learn how reusable code is organized in [module fundamentals](/openvox/latest/modules_fundamentals.html).
+6. Learn how data is separated from code in the [Hiera introduction](/openvox/latest/hiera_intro.html).
+
+## Existing Puppet Users
+
+Focus on the OpenVox project map, compatibility expectations, and operational entry points.
+
+1. Review the [migration orientation](./migration.html) for a high-level picture of what carries forward and how to sequence the move.
+2. Review the [project map](./projects.html).
+3. Read the [OpenVox overview](/openvox/latest/).
+4. Check [installation locations and package contents](/openvox/latest/install_what_and_where.html).
+5. Review [important configuration settings](/openvox/latest/config_important_settings.html).
+6. Review [OpenVox Server configuration](/openvox-server/latest/configuration.html) if you operate a primary server.
+7. Review [OpenVoxDB installation](/openvoxdb/latest/install_from_packages.html) if you use PuppetDB-compatible reporting.
+
+## Module Authors
+
+Start with the module model, then layer on roles, profiles, data, and facts.
+
+1. Read [module fundamentals](/openvox/latest/modules_fundamentals.html).
+2. Use the [beginner's guide to modules](/openvox/latest/bgtm.html) for a guided example.
+3. Organize site code with the [roles and profiles method](/openvox/latest/the_roles_and_profiles_method.html).
+4. Use Hiera with [automatic parameter lookup](/openvox/latest/hiera_automatic.html).
+5. Add data hierarchy behavior with [Hiera configuration](/openvox/latest/hiera_config_yaml_5.html).
+6. Extend node data with [custom facts](/openfact/latest/custom_facts.html) when built-in facts are not enough.
+
+## Operators
+
+Focus on installation, services, certificates, reports, and query workflows.
+
+1. Install agents with the [Linux installation guide](/openvox/latest/install_linux.html).
+2. Review [agent services on Unix](/openvox/latest/services_agent_unix.html) or
+   [agent services on Windows](/openvox/latest/services_agent_windows.html).
+3. Install and configure server components with [OpenVox Server](/openvox-server/latest/).
+4. Review [server service management](/openvox-server/latest/services_puppetserver.html).
+5. Understand certificate workflows with the [certificate API docs](/openvox-server/latest/http_certificate.html).
+6. Install OpenVoxDB with the [package guide](/openvoxdb/latest/install_from_packages.html).
+7. Check service health with [OpenVox Server service docs](/openvox-server/latest/services_puppetserver.html) and
+   [OpenVoxDB status docs](/openvoxdb/latest/api/status/v1/status.html).
+8. Query infrastructure data with the [PQL tutorial](/openvoxdb/latest/api/query/tutorial-pql.html).
+
+## Contributors
+
+Start with the community entry points, then choose the project whose docs or code you want to improve.
+
+1. Use [Vox Pupuli Connect](https://voxpupuli.org/connect/) for current communication channels.
+2. Browse the [OpenVox GitHub organization](https://github.com/OpenVoxProject).
+3. Use the [project map](./projects.html) to find the relevant documentation section.
+4. For module work, review [module fundamentals](/openvox/latest/modules_fundamentals.html) and the
+   [Puppet Forge](https://forge.puppet.com/).

--- a/docs/_ecosystem_8x/migration.md
+++ b/docs/_ecosystem_8x/migration.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: "Migration orientation"
+---
+
+OpenVox is intended to preserve the familiar Puppet language, resource model, module layout, and operational workflows. This page is
+a starting point for Puppet users planning a move to OpenVox. Use the linked product docs for detailed procedures.
+
+Migrate server-side services first, then migrate agents. Validate catalog compilation, certificate workflows, environments, Hiera,
+and reporting on the server side before rolling agent packages through the fleet.
+
+## What Carries Forward
+
+Most Puppet knowledge remains directly useful when moving to OpenVox:
+
+- Manifests, classes, defined types, resources, and modules use the same language model.
+- Hiera remains the data lookup system for separating configuration data from code.
+- Agents and servers continue to use certificates for authenticated communication.
+- PuppetDB-compatible reporting and query workflows are represented by OpenVoxDB.
+- Existing Puppet Forge modules are generally usable because the module structure and language remain compatible.
+
+Start with the [OpenVox overview](/openvox/latest/) and the [project map](./projects.html) to orient yourself before changing
+packages or services.
+
+## Before You Change Packages
+
+Review the current layout and configuration on the systems you plan to migrate.
+
+- Back up server-side state before changing packages. At minimum, preserve the CA, OpenVox Server configuration, OpenVoxDB/PostgreSQL
+  data if used, and your control repo or deployed code.
+- Confirm installed components and expected paths with [what gets installed](/openvox/latest/install_what_and_where.html).
+- Review important settings in [configuration settings](/openvox/latest/config_about_settings.html) and
+  [important configuration settings](/openvox/latest/config_important_settings.html).
+- Check `puppet.conf` behavior with the [main configuration file reference](/openvox/latest/config_file_main.html).
+- Review existing module and environment workflows with [module fundamentals](/openvox/latest/modules_fundamentals.html) and
+  [environments](/openvox/latest/environments_about.html).
+- Review Hiera usage with the [Hiera introduction](/openvox/latest/hiera_intro.html) and
+  [Hiera configuration](/openvox/latest/hiera_config_yaml_5.html).
+
+## Agents
+
+For agent systems, focus on package replacement, service behavior, and certificate state.
+
+- Install agents with the [Linux installation guide](/openvox/latest/install_linux.html).
+- Review [agent services on Unix](/openvox/latest/services_agent_unix.html) or
+  [agent services on Windows](/openvox/latest/services_agent_windows.html).
+- Review certificate behavior with the [certificate API overview](/openvox-server/latest/http_certificate.html), especially if you
+  need to clean or reissue certificates during testing.
+
+## Primary Servers
+
+For primary servers, plan the server-side changes separately from agent rollout.
+
+- Start with the [OpenVox Server overview](/openvox-server/latest/).
+- Review [OpenVox Server configuration](/openvox-server/latest/configuration.html).
+- Review [server service management](/openvox-server/latest/services_puppetserver.html).
+- Review [certificate request](/openvox-server/latest/http_certificate_request.html),
+  [certificate status](/openvox-server/latest/http_certificate_status.html), and
+  [certificate cleanup](/openvox-server/latest/http_certificate_clean.html) workflows.
+- Check [OpenVox Server known issues](/openvox-server/latest/known_issues.html) before rollout.
+
+## Reporting and Queries
+
+If your Puppet deployment uses PuppetDB-compatible workflows, review OpenVoxDB separately.
+
+- Start with the [OpenVoxDB overview](/openvoxdb/latest/).
+- Install from packages with the [OpenVoxDB package guide](/openvoxdb/latest/install_from_packages.html).
+- Configure OpenVoxDB with the [configuration guide](/openvoxdb/latest/configure.html).
+- Connect it to the server with [connecting OpenVox Server](/openvoxdb/latest/connect_puppet_server.html).
+- Review upgrade considerations in the [OpenVoxDB upgrade guide](/openvoxdb/latest/upgrade.html).
+- For multi-node OpenVoxDB deployments, review
+  [database migration coordination](/openvoxdb/latest/migration_coordination.html).
+
+## Suggested Rollout Shape
+
+Use the same release discipline you would use for infrastructure code changes:
+
+1. Inventory agents, primary servers, OpenVoxDB/PuppetDB nodes, and integrations.
+2. Confirm package repositories and versions for each platform.
+3. Back up server-side state, especially the CA and OpenVoxDB/PostgreSQL data if OpenVoxDB is in use.
+4. Migrate and validate server-side services first, including OpenVox Server and OpenVoxDB if it is in use.
+5. Test server-side workflows, including certificates, catalog compilation, environments, Hiera, reports, and queries.
+6. Test an agent against the migrated server-side services in a non-production environment.
+7. Roll agent package changes out in batches, keeping existing environment and Hiera workflows stable.
+
+This page is intentionally not a replacement for an environment-specific migration runbook. Treat it as a map to the docs you need
+while writing that runbook.

--- a/docs/_ecosystem_8x/projects.md
+++ b/docs/_ecosystem_8x/projects.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: "Projects"
+---
+
+The OpenVox ecosystem is made of focused projects that share the Puppet language, catalog model, and operational conventions.
+Use this page to find the canonical documentation for each part of the stack.
+
+## Core Configuration Management
+
+[OpenVox](/openvox/latest/) is the core configuration management project. It includes the Puppet language, resource model, agent,
+`puppet` command line interface, catalog application, modules, environments, and Hiera data lookup.
+
+Start with:
+
+- [OpenVox overview](/openvox/latest/)
+- [Architecture overview](/openvox/latest/architecture.html)
+- [Language summary](/openvox/latest/lang_summary.html)
+- [Module fundamentals](/openvox/latest/modules_fundamentals.html)
+- [Hiera introduction](/openvox/latest/hiera_intro.html)
+
+## Server-Side Services
+
+[OpenVox Server](/openvox-server/latest/) provides the server-side services used by managed agents. It compiles catalogs, serves
+files, manages certificate authority workflows, and exposes server APIs.
+
+Start with:
+
+- [OpenVox Server overview](/openvox-server/latest/)
+- [Configuration](/openvox-server/latest/configuration.html)
+- [Managing services](/openvox-server/latest/services_puppetserver.html)
+- [Restarting OpenVox Server](/openvox-server/latest/restarting.html)
+
+## Data and Querying
+
+[OpenVoxDB](/openvoxdb/latest/) stores catalogs, facts, reports, and resource data. It gives operators a queryable view of managed
+infrastructure and backs reporting workflows.
+
+Start with:
+
+- [OpenVoxDB overview](/openvoxdb/latest/)
+- [Project overview](/openvoxdb/latest/overview.html)
+- [Installing from packages](/openvoxdb/latest/install_from_packages.html)
+- [PQL tutorial](/openvoxdb/latest/api/query/tutorial-pql.html)
+
+## Facts
+
+[OpenFact](/openfact/latest/) discovers system facts such as operating system, networking, hardware, and virtualization details.
+OpenVox uses facts during catalog compilation and exposes them to manifests through the `$facts` hash.
+
+Start with:
+
+- [OpenFact overview](/openfact/latest/)
+- [Fact overview](/openfact/latest/fact_overview.html)
+- [Custom facts walkthrough](/openfact/latest/custom_facts.html)
+- [Configuring OpenFact](/openfact/latest/configuring_openfact.html)
+
+## Orchestration
+
+[OpenBolt](https://github.com/OpenVoxProject/openbolt) provides agentless orchestration for running commands, scripts, tasks, and
+plans. It complements OpenVox by handling directed operational actions that do not need continuous convergence.
+
+Until this documentation site has a local OpenBolt section, use the OpenBolt repository as the canonical project source.
+
+## Modules and Community Projects
+
+OpenVox uses Puppet modules for reusable configuration code. Most existing Puppet Forge modules can be used with OpenVox because the
+language and module model remain compatible.
+
+Start with:
+
+- [Module fundamentals](/openvox/latest/modules_fundamentals.html)
+- [Roles and profiles](/openvox/latest/the_roles_and_profiles_method.html)
+- [Puppet Forge](https://forge.puppet.com/)
+- [Vox Pupuli Connect](https://voxpupuli.org/connect/)

--- a/docs/_ecosystem_latest
+++ b/docs/_ecosystem_latest
@@ -1,0 +1,1 @@
+_ecosystem_8x

--- a/ecosystem-guide-implementation-plan.md
+++ b/ecosystem-guide-implementation-plan.md
@@ -1,0 +1,129 @@
+# Ecosystem Guide Implementation Plan
+
+## Goal
+
+Create a new OpenVox Ecosystem documentation section that orients readers without duplicating the existing product documentation.
+The ecosystem section should explain how OpenVox, OpenVox Server, OpenVoxDB, OpenFact, OpenBolt, modules, Forge, and community
+resources fit together, then route readers to canonical docs for details.
+
+## Review Context
+
+PR #176 attempted to add a full getting started guide under a new `ecosystem` collection. The direction is useful, but the draft has two structural issues:
+
+- It duplicates large amounts of existing OpenVox, OpenVox Server, OpenVoxDB, and OpenFact content.
+- Its voice is inconsistent with the rest of the docs, with generated-sounding jokes, emoji-heavy headings, and informal commentary.
+
+The replacement should be a tighter orientation layer, not a parallel documentation set.
+
+## Principles
+
+- Keep canonical content canonical. If a topic already has detailed product docs, summarize it briefly and link to that page.
+- Prefer maps, learning paths, and decision guides over rewritten references.
+- Keep the tone direct, neutral, and maintainable.
+- Avoid jokes, emoji headings, AI attribution footers, and speculative claims.
+- Use existing navigation patterns and collection conventions.
+- Every new page should have front matter and render to `.html`.
+- Every internal link should point to a generated page, not a source `.md` or stale `README.md` path.
+
+## Proposed Information Architecture
+
+Add an `ecosystem` collection with a small number of pages:
+
+1. `index.md`
+   - What the OpenVox ecosystem is.
+   - Which projects are included.
+   - Who should read which docs first.
+
+2. `projects.md`
+   - Short descriptions of each project.
+   - Canonical links to OpenVox, OpenVox Server, OpenVoxDB, OpenFact, OpenBolt, and community module resources.
+
+3. `learning-path.md`
+   - Task-oriented paths for new users, existing Puppet users, module authors, and operators.
+   - Each path should link out to canonical docs rather than recreating them.
+
+4. `migration.md`
+   - High-level migration orientation for Puppet users.
+   - Link to detailed install, compatibility, configuration, and server docs.
+
+5. `community.md`
+   - Official community channels, contribution entry points, and where to ask for help.
+   - Keep it factual and current.
+
+Do not add a full language tutorial, Hiera reference, module development guide, server administration guide, OpenVoxDB guide, or troubleshooting guide in this collection.
+
+## Canonical Sources To Link
+
+Use these existing sections as the source of truth instead of rewriting them:
+
+- OpenVox overview: `docs/_openvox_8x/index.md`
+- OpenVox agent basics: `docs/_openvox_8x/about_agent.md`
+- Architecture: `docs/_openvox_8x/architecture.markdown`
+- Language reference: `docs/_openvox_8x/lang_summary.md` and related `lang_*` pages
+- Resources and types: `docs/_openvox_8x/type.md`, `docs/_openvox_8x/types/`, and `docs/_openvox_8x/cheatsheet_core_types.md`
+- Hiera: `docs/_openvox_8x/hiera_intro.md`, `docs/_openvox_8x/hiera_quick.md`, `docs/_openvox_8x/hiera_config_yaml_5.md`, and `docs/_openvox_8x/hiera_merging.md`
+- Roles and profiles: `docs/_openvox_8x/the_roles_and_profiles_method.md`
+- Modules: `docs/_openvox_8x/modules_fundamentals.md`, `docs/_openvox_8x/bgtm.md`, and `docs/_openvox_8x/cheatsheet_module.md`
+- Environments: `docs/_openvox_8x/environments_about.markdown` and `docs/_openvox_8x/environment_isolation.md`
+- Configuration: `docs/_openvox_8x/config_about_settings.markdown`, `docs/_openvox_8x/config_important_settings.markdown`,
+  `docs/_openvox_8x/config_file_main.markdown`, `docs/_openvox_8x/config_print.markdown`, and `docs/_openvox_8x/config_set.markdown`
+- Certificates and CA: `docs/_openvox-server_8x/http_certificate.md`, `docs/_openvox-server_8x/http_certificate_request.md`,
+  `docs/_openvox-server_8x/http_certificate_status.md`, `docs/_openvox-server_8x/http_certificate_clean.markdown`, and
+  `docs/_openvox_8x/config_file_autosign.markdown`
+- OpenVox Server: `docs/_openvox-server_8x/index.markdown`, `docs/_openvox-server_8x/configuration.markdown`,
+  `docs/_openvox-server_8x/services_puppetserver.markdown`, `docs/_openvox-server_8x/restarting.markdown`, and
+  `docs/_openvox-server_8x/scaling_puppet_server.markdown`
+- OpenVoxDB: `docs/_openvoxdb_8x/index.md`, `docs/_openvoxdb_8x/overview.markdown`, `docs/_openvoxdb_8x/install_from_packages.markdown`, `docs/_openvoxdb_8x/configure.markdown`, and `docs/_openvoxdb_8x/api/query/tutorial-pql.markdown`
+- OpenFact: `docs/_openfact_5x/index.md`, `docs/_openfact_5x/fact_overview.md`, `docs/_openfact_5x/configuring_openfact.md`, and `docs/_openfact_5x/custom_facts.md`
+- OpenBolt: `https://github.com/OpenVoxProject/openbolt`
+
+If a referenced file does not currently render or is missing from navigation, fix that in the canonical section rather than copying the content into the ecosystem guide.
+
+## Implementation Tasks
+
+1. Add collection and navigation
+   - Add `ecosystem_latest` and versioned collection entries to `_config.yml`.
+   - Add an ecosystem nav file under `_data/nav/`.
+   - Add an entry to `_data/nav_map.yml`.
+   - Add a latest symlink under `docs/`.
+   - Add the ecosystem section to the home page feature list if it fits the current homepage model.
+
+2. Draft concise pages
+   - Keep pages short.
+   - Link to canonical docs for details.
+   - Avoid copying command blocks unless they are necessary to orient the reader.
+   - Prefer "Start here" lists over full tutorials.
+
+3. Validate links
+   - Build locally with Jekyll.
+   - Check that all ecosystem pages render as `.html`.
+   - Check that internal ecosystem links do not point to `.md`, `README.md`, or missing paths.
+
+4. Normalize style
+   - Remove emoji from headings and titles.
+   - Remove informal jokes and generated-sounding commentary.
+   - Use sentence case where existing docs expect it.
+   - Run markdownlint against the new files and fix issues introduced by this branch.
+
+5. Review for duplication
+   - For every section longer than a short summary, confirm whether the content already exists elsewhere.
+   - Replace duplicated reference material with a link to the canonical page.
+
+## Acceptance Criteria
+
+- The new ecosystem section builds successfully with Jekyll.
+- No ecosystem page is emitted as raw `.md`.
+- New ecosystem pages pass markdownlint.
+- Internal links in the ecosystem section resolve to generated pages.
+- The section contains orientation and route-finding content only, not a second language, Hiera, module, server, or OpenVoxDB manual.
+- Tone matches the existing docs: factual, concise, and professional.
+- The branch remains local until explicitly pushed.
+
+## Decisions
+
+- OpenBolt does not need a first-class docs collection before this work can proceed. The ecosystem guide should mention OpenBolt as part of
+  the ecosystem and link to `https://github.com/OpenVoxProject/openbolt` until local OpenBolt docs exist.
+- Community links should not be duplicated as a long-maintained directory in this repo. The ecosystem guide should point primarily to
+  Vox Pupuli Connect and include only stable, high-value links such as the OpenVox GitHub organization and docs contribution path.
+- Start from clean drafts. PR #176 can be used as context for topic coverage, but prose and structure should be rewritten to match this
+  plan rather than copied and edited in place.

--- a/index.md
+++ b/index.md
@@ -11,6 +11,11 @@ hero:
       alt: OpenVox Automation Framework
 
 features:
+  - icon: 🧭
+    title: Ecosystem
+    details: Find the OpenVox projects, learning paths, and canonical documentation for each part of the ecosystem.
+    link: ecosystem/latest/
+
   - icon: 🔍
     title: OpenFact
     details: Discover system attributes such as hardware details, network settings, OS type and version, and more.
@@ -32,4 +37,10 @@ features:
     link: openvoxdb/latest/
 ---
 
-{% include alert.html type="warning" title="Under Construction" content="The contents of this documentation site are currently being re-built from various upstream sources. Links may be broken and some version information may be out of date. Pardon the mess as we get things cleaned up!" %}
+{% capture under_construction %}
+The contents of this documentation site are currently being re-built from various upstream sources.
+Links may be broken and some version information may be out of date.
+Pardon the mess as we get things cleaned up!
+{% endcapture %}
+
+{% include alert.html type="warning" title="Under Construction" content=under_construction %}


### PR DESCRIPTION
Closes #179.

## Summary

- Adds a new `ecosystem` collection with five pages: overview/index, project map, learning paths, migration orientation, and community entry point
- Wires up collection config, navigation, nav map, latest symlink, and homepage feature entry
- Pages link to canonical product docs rather than duplicating them

## Test plan

- [x] `bundle exec jekyll build` completes without errors
- [x] Ecosystem pages render at `/ecosystem/latest/`
- [x] Internal links resolve to generated `.html` pages, not `.md` sources
- [x] No duplicated product reference content in the new pages
- [x] Tone matches existing docs: factual, concise, no emoji headings or informal commentary
- [x] New pages pass markdownlint