### PR TITLE
Add proper landing page for OpenFact docs

### DIFF
--- a/_data/nav/openfact_5x.yaml
+++ b/_data/nav/openfact_5x.yaml
@@ -1,7 +1,7 @@
 ---
 - text: OpenFact
   items:
-  - text: Documentation index
+  - text: Overview
     link: index.html
   - text: Release notes
     link: release_notes.html

--- a/docs/_openfact_5x/index.md
+++ b/docs/_openfact_5x/index.md
@@ -1,13 +1,48 @@
 ---
 layout: default
-title: "Documentation index"
+title: "OpenFact 5"
 ---
 
-OpenFact is OpenVox's cross-platform system profiling library. It discovers and reports per-node facts, which are available in your OpenVox manifests as variables.
+OpenFact is a cross-platform system profiling library that discovers and reports per-node facts —
+structured data about a node's operating system, hardware, networking, and more. Facts are available
+in OpenVox manifests as top-scope variables (e.g. `$facts['os']['family']`) and are used by the
+catalog compiler to make node-specific decisions.
 
-* [The OpenFact release notes](./release_notes.html) document OpenFact's history.
-* [The CLI](./cli.html) lists and describes the command line interface usage and options for OpenFact (auto-generated).
-* [The list of core facts](./core_facts.html) lists and describes every built-in fact that ships with OpenFact (auto-generated).
-* [The custom fact reference](./fact_overview.html) serves as an example-driven primer and quick reference for fact authors.
-* [The custom facts walkthrough](./custom_facts.html) explains in detail how to write and distribute your own custom or external facts.
-* [The configuration file options](./configuring_openfact.html) explains in detail how to configure the behavior of OpenFact.
+> **Note:** Legacy flat facts (e.g. `$::osfamily`) are hidden from `facter`'s default CLI output
+> and are not collected or sent to OpenVox Server in OpenVox 8. From the CLI you can still view
+> them with `facter --show-legacy`. In the agent, they can be re-enabled by setting
+> `include_legacy_facts=true` in the agent's `puppet.conf`, but this is not recommended.
+> Use the structured `$facts` hash instead.
+
+OpenFact is the community-maintained continuation of Puppet's Facter, originally adopted under
+[Vox Pupuli](https://voxpupuli.org/) stewardship alongside OpenVox. It is downstream-compatible
+with Facter — existing custom facts and external facts work unchanged.
+
+## How it works
+
+OpenFact runs on each managed node and resolves facts by querying the system directly: reading
+`/proc` entries, running shell commands, calling OS APIs, and so on. Results are returned as a
+structured hash. When a fact can be resolved in multiple ways (for example, differently on Linux
+versus Windows), OpenFact picks the first applicable resolution and discards the rest.
+
+**In an agent/server deployment**, OpenFact runs automatically at the start of each agent run.
+The collected facts are sent to OpenVox Server, where they are available to the catalog compiler
+and stored for reporting.
+
+**Standalone**, the `facter` CLI lets you query facts directly on any node — useful for
+ad-hoc inspection, debugging, or scripting without triggering a full agent run.
+
+## Included in openvox-agent
+
+OpenFact ships inside the `openvox-agent` package and does not need to be installed separately.
+The version bundled with a given agent release is listed in
+[Component versions in openvox-agent](../../openvox/latest/about_agent.html).
+
+## Getting started
+
+- [Core facts reference](./core_facts.html) — every built-in fact that ships with OpenFact (auto-generated)
+- [Custom facts walkthrough](./custom_facts.html) — step-by-step guide to writing and distributing your own facts
+- [Custom facts reference](./fact_overview.html) — example-driven quick reference for fact authors
+- [Configuring OpenFact](./configuring_openfact.html) — `facter.conf` options
+- [CLI reference](./cli.html) — command-line flags and options (auto-generated)
+- [Release notes](./release_notes.html) — OpenFact version history

--- a/docs/_openfact_5x/index.md
+++ b/docs/_openfact_5x/index.md
@@ -8,12 +8,6 @@ structured data about a node's operating system, hardware, networking, and more.
 in OpenVox manifests as top-scope variables (e.g. `$facts['os']['family']`) and are used by the
 catalog compiler to make node-specific decisions.
 
-> **Note:** Legacy flat facts (e.g. `$::osfamily`) are hidden from `facter`'s default CLI output
-> and are not collected or sent to OpenVox Server in OpenVox 8. From the CLI you can still view
-> them with `facter --show-legacy`. In the agent, they can be re-enabled by setting
-> `include_legacy_facts=true` in the agent's `puppet.conf`, but this is not recommended.
-> Use the structured `$facts` hash instead.
-
 OpenFact is the community-maintained continuation of Puppet's Facter, originally adopted under
 [Vox Pupuli](https://voxpupuli.org/) stewardship alongside OpenVox. It is downstream-compatible
 with Facter — existing custom facts and external facts work unchanged.
@@ -23,11 +17,14 @@ with Facter — existing custom facts and external facts work unchanged.
 OpenFact runs on each managed node and resolves facts by querying the system directly: reading
 `/proc` entries, running shell commands, calling OS APIs, and so on. Results are returned as a
 structured hash. When a fact can be resolved in multiple ways (for example, differently on Linux
-versus Windows), OpenFact picks the first applicable resolution and discards the rest.
+versus Windows), OpenFact runs the highest-weighted applicable resolution.
 
 **In an agent/server deployment**, OpenFact runs automatically at the start of each agent run.
-The collected facts are sent to OpenVox Server, where they are available to the catalog compiler
-and stored for reporting.
+The collected facts are sent to OpenVox Server and made available to the catalog compiler.
+Facts are not persisted without OpenVoxDB — they are used during catalog compilation and then
+discarded. The agent run produces a report, which OpenVox Server stores on local disk by default;
+without periodic cleanup, report storage will grow unbounded. OpenVoxDB is an optional component
+that provides durable storage for facts, catalogs, and reports.
 
 **Standalone**, the `facter` CLI lets you query facts directly on any node — useful for
 ad-hoc inspection, debugging, or scripting without triggering a full agent run.
@@ -36,7 +33,7 @@ ad-hoc inspection, debugging, or scripting without triggering a full agent run.
 
 OpenFact ships inside the `openvox-agent` package and does not need to be installed separately.
 The version bundled with a given agent release is listed in
-[Component versions in openvox-agent](../../openvox/latest/about_agent.html).
+[Component versions in openvox-agent](/openvox/latest/about_agent.html).
 
 ## Getting started
 


### PR DESCRIPTION
Fixes #182

Replaces the bare link-list index at `/openfact/latest/` with a structured landing page.

## Changes

- `docs/_openfact_5x/index.md` — full rewrite: what OpenFact is, Facter lineage, how it works (agent/server and standalone `facter` CLI), legacy facts behaviour in OpenVox 8, getting-started links
- `_data/nav/openfact_5x.yaml` — rename "Documentation index" → "Overview"

## Test plan

- [x] `bundle exec jekyll build` — passes
- [x] markdownlint on changed `.md` files — clean