### PR TITLE
Add CVE fixes to OpenVox release notes

### DIFF
--- a/docs/_openvox_8x/release_notes.markdown
+++ b/docs/_openvox_8x/release_notes.markdown
@@ -22,7 +22,7 @@ You can either upgrade to Puppet 7 and then switch to OpenVox 7 and then upgrade
 
 Released April 18, 2026.
 
-This is a bug-fix and security release of OpenVox.
+This is a bug-fix release of OpenVox.
 
 All bug fixes, new features and other changes are provided on the [project's github release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.26.2).
 
@@ -30,7 +30,7 @@ All bug fixes, new features and other changes are provided on the [project's git
 
 Released April 16, 2026.
 
-This is a bug-fix and security release of OpenVox.
+This is a bug-fix release of OpenVox.
 
 All bug fixes, new features and other changes are provided on the [project's github release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.26.1).
 
@@ -42,6 +42,35 @@ This is a bug-fix and security release of OpenVox.
 
 All bug fixes, new features and other changes are provided on the [project's github release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.26.0).
 
+### Security Issues Resolved in 8.26.0
+
+|===================================================================|============|=====================================|
+|                            Identifier                             | CVSS Score |             Resolved By             |
+|===================================================================|============|=====================================|
+| [CVE-2026-27820](https://nvd.nist.gov/vuln/detail/CVE-2026-27820) |     N/A    |        `pkg:gem/zlib@3.0.1`         |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-3805](https://nvd.nist.gov/vuln/detail/CVE-2026-3805)   |     7.5    |    `pkg:github/curl/curl@8.19.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-1965](https://nvd.nist.gov/vuln/detail/CVE-2026-1965)   |     6.5    |    `pkg:github/curl/curl@8.19.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-3784](https://nvd.nist.gov/vuln/detail/CVE-2026-3784)   |     6.5    |    `pkg:github/curl/curl@8.19.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-3783](https://nvd.nist.gov/vuln/detail/CVE-2026-3783)   |     5.3    |    `pkg:github/curl/curl@8.19.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789) |     9.8    | `pkg:github/openssl/openssl@3.0.20` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-28387](https://nvd.nist.gov/vuln/detail/CVE-2026-28387) |     8.1    | `pkg:github/openssl/openssl@3.0.20` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-28389](https://nvd.nist.gov/vuln/detail/CVE-2026-28389) |     7.5    | `pkg:github/openssl/openssl@3.0.20` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390) |     7.5    | `pkg:github/openssl/openssl@3.0.20` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-28388](https://nvd.nist.gov/vuln/detail/CVE-2026-28388) |     7.5    | `pkg:github/openssl/openssl@3.0.20` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-31790](https://nvd.nist.gov/vuln/detail/CVE-2026-31790) |     7.5    | `pkg:github/openssl/openssl@3.0.20` |
+|===================================================================|============|=====================================|
+
+
 ## OpenVox 8.25.0
 
 Released February 17, 2026.
@@ -49,3 +78,41 @@ Released February 17, 2026.
 This is a bug-fix and security release of OpenVox.
 
 All bug fixes, new features and other changes are provided on the [project's github release page](https://github.com/OpenVoxProject/openvox/releases/tag/8.25.0).
+
+### Security Issues Resolved in 8.25.0
+
+|===================================================================|============|=====================================|
+|                            Identifier                             | CVSS Score |             Resolved By             |
+|===================================================================|============|=====================================|
+| [CVE-2025-24294](https://nvd.nist.gov/vuln/detail/CVE-2025-24294) |     5.3    |       `pkg:gem/resolv@0.2.3`        |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-61594](https://nvd.nist.gov/vuln/detail/CVE-2025-61594) |     7.5    |        `pkg:gem/uri@0.12.5`         |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-14017](https://nvd.nist.gov/vuln/detail/CVE-2025-14017) |     6.3    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-13034](https://nvd.nist.gov/vuln/detail/CVE-2025-13034) |     5.9    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-14819](https://nvd.nist.gov/vuln/detail/CVE-2025-14819) |     5.3    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-15079](https://nvd.nist.gov/vuln/detail/CVE-2025-15079) |     5.3    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-14524](https://nvd.nist.gov/vuln/detail/CVE-2025-14524) |     5.3    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-15224](https://nvd.nist.gov/vuln/detail/CVE-2025-15224) |     3.1    |    `pkg:github/curl/curl@8.18.0`    |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-15467](https://nvd.nist.gov/vuln/detail/CVE-2025-15467) |     8.8    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-69420](https://nvd.nist.gov/vuln/detail/CVE-2025-69420) |     7.5    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-69421](https://nvd.nist.gov/vuln/detail/CVE-2025-69421) |     7.5    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-69419](https://nvd.nist.gov/vuln/detail/CVE-2025-69419) |     7.4    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-22795](https://nvd.nist.gov/vuln/detail/CVE-2026-22795) |     5.5    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2026-22796](https://nvd.nist.gov/vuln/detail/CVE-2026-22796) |     5.3    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-68160](https://nvd.nist.gov/vuln/detail/CVE-2025-68160) |     4.7    | `pkg:github/openssl/openssl@3.0.19` |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| [CVE-2025-69418](https://nvd.nist.gov/vuln/detail/CVE-2025-69418) |      4     | `pkg:github/openssl/openssl@3.0.19` |
+|===================================================================|============|=====================================|


### PR DESCRIPTION
This commit adds tables of CVE fixes to the `openvox-agent` release notes for releases made in 2026. These nodes were created by diffing library versions recorded in the Vanagon component info:

  https://github.com/OpenVoxProject/puppet-runtime/blob/main/component_info.json

And then cross-referencing the results against notices published to https://nvd.nist.gov.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
