### PR TITLE
Add collection-level .gitignore for generated reference docs

### DIFF
--- a/docs/_openfact_5x/.gitignore
+++ b/docs/_openfact_5x/.gitignore
@@ -1,0 +1,3 @@
+# Generated reference pages — copied here by CI (bundle exec rake references:openfact)
+core_facts.md
+cli.md

--- a/docs/_openvox_8x/.gitignore
+++ b/docs/_openvox_8x/.gitignore
@@ -1,0 +1,15 @@
+# Generated reference pages — copied here by CI (bundle exec rake references:openvox)
+configuration.md
+function.md
+indirection.md
+metaparameter.md
+report.md
+type.md
+type.json
+type_strings.md
+type_strings.json
+raw_strings_data_output.json
+strings.json
+man/
+types/
+types_strings/


### PR DESCRIPTION
## Summary

- Adds `docs/_openvox_8x/.gitignore` and `docs/_openfact_5x/.gitignore` modelled after the existing `docs/_openbolt_5x/.gitignore`
- Generated reference files from `rake references:openvox` and `rake references:openfact` no longer appear as untracked files when running those tasks locally with `INSTALLPATH=docs`

Fixes #211

## Test plan

- [x] Run `bundle exec rake references:openvox INSTALLPATH=docs` locally and confirm no generated files appear in `git status`
- [x] Run `bundle exec rake references:openfact INSTALLPATH=docs` locally and confirm no generated files appear in `git status`