### PR TITLE
markdownlint: allow consistent table style instead of enforcing compact

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -20,5 +20,5 @@ no-inline-html:
 descriptive-link-text: false
 
 table:
-  style: 'compact'
+  style: 'consistent'
   aligned_delimiter: true


### PR DESCRIPTION
Allow consistent table column style instead of enforcing compact.

Compact style disallows extra spaces used to visually align table columns in source. Consistent style permits either compact or padded tables as long as each file is internally uniform — preserving readability for wide or complex tables without giving up all lint enforcement.

Closes #226
