### PR TITLE
openvoxdb_8x: update puppet.com/docs links to openvox equivalents

### DIFF
--- a/docs/_openvoxdb_8x/api/query/v4/nodes.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/nodes.markdown
@@ -8,7 +8,7 @@ canonical: "/openvoxdb/latest/api/query/v4/nodes.html"
 
 [resource]: ./resources.html
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
-[statuses]: https://puppet.com/docs/puppet/latest/format_report.html#puppettransactionreport
+[statuses]: /openvox/latest/format_report.html
 [paging]: ./paging.html
 [query]: query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601

--- a/docs/_openvoxdb_8x/api/query/v4/reports.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/reports.markdown
@@ -10,7 +10,7 @@ canonical: "/openvoxdb/latest/api/query/v4/reports.html"
 [ast]: ./ast.html
 [events]: ./events.html
 [paging]: ./paging.html
-[statuses]: https://puppet.com/docs/puppet/latest/format_report.html#puppettransactionreport
+[statuses]: /openvox/latest/format_report.html
 [query]: query.html
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
 [subqueries]: ./ast.html#subquery-operators

--- a/docs/_openvoxdb_8x/api/wire_format/catalog_format_v6.markdown
+++ b/docs/_openvoxdb_8x/api/wire_format/catalog_format_v6.markdown
@@ -6,19 +6,19 @@ canonical: "/openvoxdb/latest/api/wire_format/catalog_format_v6.html"
 
 # Catalog wire format - v6
 
-[containment]: https://puppet.com/docs/puppet/latest/lang_containment.html
-[relationship]: https://puppet.com/docs/puppet/latest/lang_relationships.html
-[chain]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-chaining-arrows
-[metaparameters]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters
-[require]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-the-require-function
-[resource_ref]: https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html
-[numbers]: https://puppet.com/docs/puppet/latest/lang_data_number.html
-[undef]: https://puppet.com/docs/puppet/latest/lang_data_undef.html
-[namevar]: https://puppet.com/docs/puppet/latest/lang_resources.html#namenamevar
-[resource]: https://puppet.com/docs/puppet/latest/lang_resources.html
-[title]: https://puppet.com/docs/puppet/latest/lang_resources.html#title
-[type]: https://puppet.com/docs/puppet/latest/lang_resources.html#type
-[attributes]: https://puppet.com/docs/puppet/latest/lang_resources.html#attributes
+[containment]: /openvox/latest/lang_containment.html
+[relationship]: /openvox/latest/lang_relationships.html
+[chain]: /openvox/latest/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: /openvox/latest/lang_relationships.html#syntax-relationship-metaparameters
+[require]: /openvox/latest/lang_relationships.html#syntax-the-require-function
+[resource_ref]: /openvox/latest/lang_data_resource_reference.html
+[numbers]: /openvox/latest/lang_data_number.html
+[undef]: /openvox/latest/lang_data_undef.html
+[namevar]: /openvox/latest/lang_resources.html#namenamevar
+[resource]: /openvox/latest/lang_resources.html
+[title]: /openvox/latest/lang_resources.html#title
+[type]: /openvox/latest/lang_resources.html#resource-types
+[attributes]: /openvox/latest/lang_resources.html#attributes
 
 OpenVoxDB receives catalogs from Puppet Servers in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the
 [OpenVoxDB catalog terminus](../../connect_puppet_server.html) before they are sent.
@@ -54,7 +54,7 @@ String. The name of the node for which the catalog was compiled.
 #### `version`
 
 String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's
-[`config_version` setting](https://puppet.com/docs/puppet/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+[`config_version` setting](/openvox/latest/configuration.html#config_version) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/docs/_openvoxdb_8x/api/wire_format/catalog_format_v7.markdown
+++ b/docs/_openvoxdb_8x/api/wire_format/catalog_format_v7.markdown
@@ -6,19 +6,19 @@ canonical: "/openvoxdb/latest/api/wire_format/catalog_format_v7.html"
 
 # Catalog wire format - v7
 
-[containment]: https://puppet.com/docs/puppet/latest/lang_containment.html
-[relationship]: https://puppet.com/docs/puppet/latest/lang_relationships.html
-[chain]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-chaining-arrows
-[metaparameters]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters
-[require]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-the-require-function
-[resource_ref]: https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html
-[numbers]: https://puppet.com/docs/puppet/latest/lang_data_number.html
-[undef]: https://puppet.com/docs/puppet/latest/lang_data_undef.html
-[namevar]: https://puppet.com/docs/puppet/latest/lang_resources.html#namenamevar
-[resource]: https://puppet.com/docs/puppet/latest/lang_resources.html
-[title]: https://puppet.com/docs/puppet/latest/lang_resources.html#title
-[type]: https://puppet.com/docs/puppet/latest/lang_resources.html#type
-[attributes]: https://puppet.com/docs/puppet/latest/lang_resources.html#attributes
+[containment]: /openvox/latest/lang_containment.html
+[relationship]: /openvox/latest/lang_relationships.html
+[chain]: /openvox/latest/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: /openvox/latest/lang_relationships.html#syntax-relationship-metaparameters
+[require]: /openvox/latest/lang_relationships.html#syntax-the-require-function
+[resource_ref]: /openvox/latest/lang_data_resource_reference.html
+[numbers]: /openvox/latest/lang_data_number.html
+[undef]: /openvox/latest/lang_data_undef.html
+[namevar]: /openvox/latest/lang_resources.html#namenamevar
+[resource]: /openvox/latest/lang_resources.html
+[title]: /openvox/latest/lang_resources.html#title
+[type]: /openvox/latest/lang_resources.html#resource-types
+[attributes]: /openvox/latest/lang_resources.html#attributes
 
 OpenVoxDB receives catalogs from Puppet Servers in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the
 [OpenVoxDB catalog terminus](../../connect_puppet_server.html) before they are sent.
@@ -55,7 +55,7 @@ String. The name of the node for which the catalog was compiled.
 #### `version`
 
 String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's
-[`config_version` setting](https://puppet.com/docs/puppet/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+[`config_version` setting](/openvox/latest/configuration.html#config_version) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/docs/_openvoxdb_8x/api/wire_format/catalog_format_v8.markdown
+++ b/docs/_openvoxdb_8x/api/wire_format/catalog_format_v8.markdown
@@ -6,19 +6,19 @@ canonical: "/openvoxdb/latest/api/wire_format/catalog_format_v8.html"
 
 # Catalog wire format - v8
 
-[containment]: https://puppet.com/docs/puppet/latest/lang_containment.html
-[relationship]: https://puppet.com/docs/puppet/latest/lang_relationships.html
-[chain]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-chaining-arrows
-[metaparameters]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters
-[require]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-the-require-function
-[resource_ref]: https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html
-[numbers]: https://puppet.com/docs/puppet/latest/lang_data_number.html
-[undef]: https://puppet.com/docs/puppet/latest/lang_data_undef.html
-[namevar]: https://puppet.com/docs/puppet/latest/lang_resources.html#namenamevar
-[resource]: https://puppet.com/docs/puppet/latest/lang_resources.html
-[title]: https://puppet.com/docs/puppet/latest/lang_resources.html#title
-[type]: https://puppet.com/docs/puppet/latest/lang_resources.html#type
-[attributes]: https://puppet.com/docs/puppet/latest/lang_resources.html#attributes
+[containment]: /openvox/latest/lang_containment.html
+[relationship]: /openvox/latest/lang_relationships.html
+[chain]: /openvox/latest/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: /openvox/latest/lang_relationships.html#syntax-relationship-metaparameters
+[require]: /openvox/latest/lang_relationships.html#syntax-the-require-function
+[resource_ref]: /openvox/latest/lang_data_resource_reference.html
+[numbers]: /openvox/latest/lang_data_number.html
+[undef]: /openvox/latest/lang_data_undef.html
+[namevar]: /openvox/latest/lang_resources.html#namenamevar
+[resource]: /openvox/latest/lang_resources.html
+[title]: /openvox/latest/lang_resources.html#title
+[type]: /openvox/latest/lang_resources.html#resource-types
+[attributes]: /openvox/latest/lang_resources.html#attributes
 
 OpenVoxDB receives catalogs from Puppet Servers in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the
 [OpenVoxDB catalog terminus](../../connect_puppet_server.html) before they are sent.
@@ -56,7 +56,7 @@ String. The name of the node for which the catalog was compiled.
 #### `version`
 
 String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's
-[`config_version` setting](https://puppet.com/docs/puppet/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+[`config_version` setting](/openvox/latest/configuration.html#config_version) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/docs/_openvoxdb_8x/api/wire_format/catalog_format_v9.markdown
+++ b/docs/_openvoxdb_8x/api/wire_format/catalog_format_v9.markdown
@@ -6,19 +6,19 @@ canonical: "/openvoxdb/latest/api/wire_format/catalog_format_v9.html"
 
 # Catalog wire format - v9
 
-[containment]: https://puppet.com/docs/puppet/latest/lang_containment.html
-[relationship]: https://puppet.com/docs/puppet/latest/lang_relationships.html
-[chain]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-chaining-arrows
-[metaparameters]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters
-[require]: https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-the-require-function
-[resource_ref]: https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html
-[numbers]: https://puppet.com/docs/puppet/latest/lang_data_number.html
-[undef]: https://puppet.com/docs/puppet/latest/lang_data_undef.html
-[namevar]: https://puppet.com/docs/puppet/latest/lang_resources.html#namenamevar
-[resource]: https://puppet.com/docs/puppet/latest/lang_resources.html
-[title]: https://puppet.com/docs/puppet/latest/lang_resources.html#title
-[type]: https://puppet.com/docs/puppet/latest/lang_resources.html#type
-[attributes]: https://puppet.com/docs/puppet/latest/lang_resources.html#attributes
+[containment]: /openvox/latest/lang_containment.html
+[relationship]: /openvox/latest/lang_relationships.html
+[chain]: /openvox/latest/lang_relationships.html#syntax-chaining-arrows
+[metaparameters]: /openvox/latest/lang_relationships.html#syntax-relationship-metaparameters
+[require]: /openvox/latest/lang_relationships.html#syntax-the-require-function
+[resource_ref]: /openvox/latest/lang_data_resource_reference.html
+[numbers]: /openvox/latest/lang_data_number.html
+[undef]: /openvox/latest/lang_data_undef.html
+[namevar]: /openvox/latest/lang_resources.html#namenamevar
+[resource]: /openvox/latest/lang_resources.html
+[title]: /openvox/latest/lang_resources.html#title
+[type]: /openvox/latest/lang_resources.html#resource-types
+[attributes]: /openvox/latest/lang_resources.html#attributes
 
 OpenVoxDB receives catalogs from Puppet Servers in the following wire format. This format is subtly different from the internal format used by Puppet, so catalogs are converted by the
 [OpenVoxDB catalog terminus](../../connect_puppet_server.html) before they are sent.
@@ -58,7 +58,7 @@ String. The name of the node for which the catalog was compiled.
 #### `version`
 
 String. An arbitrary string that uniquely identifies this specific catalog across time for a single node. This is controlled by Puppet's
-[`config_version` setting](https://puppet.com/docs/puppet/latest/configuration.html#configversion) and is usually the seconds elapsed since the epoch.
+[`config_version` setting](/openvox/latest/configuration.html#config_version) and is usually the seconds elapsed since the epoch.
 
 #### `environment`
 

--- a/docs/_openvoxdb_8x/api/wire_format/report_format_v5.markdown
+++ b/docs/_openvoxdb_8x/api/wire_format/report_format_v5.markdown
@@ -5,9 +5,6 @@ canonical: "/openvoxdb/latest/api/wire_format/report_format_v5.html"
 ---
 # Report wire format - v5
 
-[puppetreportformat]: https://puppet.com/docs/puppet/latest/format_report.html
-[reportsv4]: ../query/v4/reports.html
-
 ## Report interchange format
 
 A report is represented as JSON (this implies UTF-8 encoding). Unless

--- a/docs/_openvoxdb_8x/community_add_ons.markdown
+++ b/docs/_openvoxdb_8x/community_add_ons.markdown
@@ -11,7 +11,7 @@ canonical: "/openvoxdb/latest/community_add_ons.html"
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [query]: https://github.com/dalen/puppet-puppetdbquery
 [exports]: http://forge.puppetlabs.com/zack/exports
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[exported]: /openvox/latest/lang_exported.html
 [cms-puppetdb-tools]: https://github.com/tskirvin/cms-puppetdb-tools
 [prometheus-exporter]: https://github.com/camptocamp/prometheus-puppetdb-exporter
 [vox-pupuli-prometheus]: https://github.com/voxpupuli/puppet-prometheus/blob/master/manifests/puppetdb_exporter.pp

--- a/docs/_openvoxdb_8x/connect_puppet_apply.markdown
+++ b/docs/_openvoxdb_8x/connect_puppet_apply.markdown
@@ -6,19 +6,19 @@ canonical: "/openvoxdb/latest/connect_puppet_apply.markdown"
 
 # Connecting standalone Puppet nodes to OpenVoxDB
 
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
-[package]: https://puppet.com/docs/puppet/latest/type.html#package
-[file]: https://puppet.com/docs/puppet/latest/type.html#file
-[yumrepo]: https://puppet.com/docs/puppet/latest/type.html#yumrepo
+[exported]: /openvox/latest/lang_exported.html
+[package]: /openvox/latest/type.html#package
+[file]: /openvox/latest/type.html#file
+[yumrepo]: https://forge.puppet.com/modules/puppetlabs/yumrepo_core
 [apt]: http://forge.puppetlabs.com/puppetlabs/apt
 [puppetdb_download]: https://github.com/OpenVoxProject/openvoxdb/releases
-[puppetdb_conf]: https://puppet.com/docs/puppet/latest/config_file_puppetdb.html
-[routes_yaml]: https://puppet.com/docs/puppet/latest/config_file_routes.html
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[puppetdb_conf]: /openvox/latest/config_file_puppetdb.html
+[routes_yaml]: /openvox/latest/config_file_routes.html
 [jetty]: ./configure.html#jetty-http-settings
 [ssl_script]: ./maintain_and_tune.html#redo-ssl-setup-after-changing-certificates
-[settings_namespace]: https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html#puppet-master-variables
-[package_repos]: https://puppet.com/docs/puppet/latest/install_puppet.html#enable_the_puppet_platform_repository
+[settings_namespace]: /openvox/latest/lang_facts_and_builtin_vars.html#puppet-master-variables
+[package_repos]: /openvox/latest/openvox_platform.html
+[intermediate_ca]: /openvox-server/latest/intermediate_ca.html#set-up-openvox-as-an-intermediate-ca-with-an-external-root
 
 > **Note:** To use OpenVoxDB, the nodes at your site must be running Puppet version 3.8.1 or later.
 
@@ -50,7 +50,7 @@ You will have to sign a certificate for every new node you add to your site.
 Before you head down this path, please consider if signing certificates with Puppet Server will work for you.
 This option requires more work on your part to set up, and does not allow you to provide
 SSL to OpenVoxDB without a signed certificate, but it will allow you to provide SSL connections to OpenVoxDB using an existing CA.
-If you have an existing CA you would like to use, you can [set up Puppet Server as an intermediate CA](https://puppet.com/docs/puppetserver/latest/intermediate_ca.html#set-up-puppet-as-an-intermediate-ca-with-an-external-root) and then follow the instructions in Option A.
+If you have an existing CA you would like to use, you can [set up OpenVox Server as an intermediate CA][intermediate_ca] and then follow the instructions in Option A.
 
 1. Edit [the `[jetty]` section of the OpenVoxDB config files][jetty] to remove all SSL-related settings.
 2. Install a general-purpose web server (like Apache or NGINX) on the OpenVoxDB server.

--- a/docs/_openvoxdb_8x/connect_puppet_server.markdown
+++ b/docs/_openvoxdb_8x/connect_puppet_server.markdown
@@ -8,16 +8,16 @@ canonical: "/openvoxdb/latest/connect_puppet_server.html"
 
 [puppetdb_download]: https://github.com/OpenVoxProject/openvoxdb/releases
 [puppetdb_conf]: ./puppetdb_connection.html
-[routes_yaml]: https://puppet.com/docs/puppet/latest/config_file_routes.html
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[routes_yaml]: /openvox/latest/config_file_routes.html
+[exported]: /openvox/latest/lang_exported.html
 [install_via_module]: ./install_via_module.html
-[report_processors]: https://puppet.com/docs/puppet/latest/reporting_about.html
+[report_processors]: /openvox/latest/reporting_about.html
 [event]: ./api/query/v4/events.html
 [report]: ./api/query/v4/reports.html
 [store_report]: ./api/command/v1/commands.html#store-report-version-7
 [report_format]: ./api/wire_format/report_format_v5.html
 [puppetdb_server_urls]: ./puppetdb_connection.html#serverurls
-[package_repos]: https://puppet.com/docs/puppet/latest/install_puppet.html#enable_the_puppet_platform_repository
+[package_repos]: /openvox/latest/openvox_platform.html
 
 
 > Note: To use OpenVoxDB, your site's Puppet Server(s) must be running

--- a/docs/_openvoxdb_8x/index.md
+++ b/docs/_openvoxdb_8x/index.md
@@ -5,15 +5,15 @@ layout: default
 
 # Overview and requirements
 
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[exported]: /openvox/latest/lang_exported.html
 [connect]: ./connect_puppet_server.html
 [apply]: ./connect_puppet_apply.html
 [install_via_module]: ./install_via_module.html
 [install_from_packages]: ./install_from_packages.html
 [install_advanced]: ./install_from_source.html
 [scaling]: ./scaling_recommendations.html
-[facts]: https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html
-[catalog]: https://puppet.com/docs/puppet/latest/lang_summary.html#compilation-and-catalogs
+[facts]: /openvox/latest/lang_facts_and_builtin_vars.html
+[catalog]: /openvox/latest/lang_summary.html#compilation-and-catalogs
 [releasenotes]: ./release_notes.html
 [github]: https://github.com/OpenVoxProject/openvoxdb
 [tracker]: https://github.com/OpenVoxProject/openvoxdb/issues

--- a/docs/_openvoxdb_8x/install_from_packages.markdown
+++ b/docs/_openvoxdb_8x/install_from_packages.markdown
@@ -14,7 +14,7 @@ layout: default
 [install_module]: ./install_via_module.html
 [module]: https://forge.puppet.com/modules/puppet/openvoxdb
 [postgres_ssl]: ./postgres_ssl.html
-[package_repos]: https://puppet.com/docs/puppet/latest/install_puppet.html#enable_the_puppet_platform_repository
+[package_repos]: /openvox/latest/openvox_platform.html
 [known-issues]: ./known_issues.html
 
 This page describes how to manually install and configure OpenVoxDB from the official packages. Users are encouraged to install OpenVoxDB via the [OpenVoxDB module][module] instead of installing the packages
@@ -45,7 +45,7 @@ Additionally, these instructions may be useful for understanding OpenVoxDB's var
 
 If Puppet isn't fully installed and configured on your OpenVoxDB server, [install it][installpuppet] and request/sign/retrieve a certificate for the node.
 
-[installpuppet]: https://puppet.com/docs/puppet/latest/install_pre.html
+[installpuppet]: /openvox/latest/install_pre.html
 
 Your OpenVoxDB server should be running Puppet agent and have a signed certificate from your Puppet Server. If you run `puppet agent --test`, it should successfully complete a run, ending with
 `Notice: Applied catalog in X.XX seconds`.

--- a/docs/_openvoxdb_8x/install_via_module.markdown
+++ b/docs/_openvoxdb_8x/install_via_module.markdown
@@ -3,7 +3,7 @@ title: "Installing OpenVoxDB via Puppet module"
 layout: default
 ---
 
-[package_repos]: https://puppet.com/docs/puppet/latest/install_puppet.html#enable_the_puppet_platform_repository
+[package_repos]: /openvox/latest/openvox_platform.html
 
 # Installing OpenVoxDB via Puppet module
 

--- a/docs/_openvoxdb_8x/maintain_and_tune.markdown
+++ b/docs/_openvoxdb_8x/maintain_and_tune.markdown
@@ -12,7 +12,7 @@ canonical: "/openvoxdb/latest/maintain_and_tune.markdown"
 [puppetdb_report_processor]: ./connect_puppet_server.html#enabling-report-storage
 [node_ttl]: ./configure.html#node-ttl
 [report_ttl]: ./configure.html#report-ttl
-[resources_type]: https://puppet.com/docs/puppet/latest/type.html#resources
+[resources_type]: /openvox/latest/type.html#resources
 [logback]: ./configure.html#the-logback-logging-config-file
 [dashboard]: #monitor-the-performance-dashboard
 
@@ -71,7 +71,7 @@ accordingly.
 
 OpenVoxDB will react to certain types of processing failures by storing a complete copy of the offending input, along with retry timestamps and error traces, in the "dead letter office" (DLO). Over time, the DLO
 can grow quite large. If you're not actively troubleshooting an issue, you might be able to recover a significant amount of space by deleting the contents of the DLO. It can be found at under
-[OpenVoxDB's data directory](https://puppet.com/docs/puppetdb/latest/configure.html#vardir) at `stockpile/discard`, which by default is `/opt/puppetlabs/server/data/puppetdb/stockpile/discard`.
+[OpenVoxDB's data directory](./configure.html#vardir) at `stockpile/discard`, which by default is `/opt/puppetlabs/server/data/puppetdb/stockpile/discard`.
 
 ## View the log
 

--- a/docs/_openvoxdb_8x/overview.markdown
+++ b/docs/_openvoxdb_8x/overview.markdown
@@ -5,15 +5,15 @@ layout: default
 
 # Overview and requirements
 
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[exported]: /openvox/latest/lang_exported.html
 [connect]: ./connect_puppet_server.html
 [apply]: ./connect_puppet_apply.html
 [install_via_module]: ./install_via_module.html
 [install_from_packages]: ./install_from_packages.html
 [install_advanced]: ./install_from_source.html
 [scaling]: ./scaling_recommendations.html
-[facts]: https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html
-[catalog]: https://puppet.com/docs/puppet/latest/lang_summary.html#compilation-and-catalogs
+[facts]: /openvox/latest/lang_facts_and_builtin_vars.html
+[catalog]: /openvox/latest/lang_summary.html#compilation-and-catalogs
 [releasenotes]: ./release_notes.html
 [github]: https://github.com/OpenVoxProject/openvoxdb
 [tracker]: https://github.com/OpenVoxProject/openvoxdb/issues

--- a/docs/_openvoxdb_8x/pdb_support_guide.markdown
+++ b/docs/_openvoxdb_8x/pdb_support_guide.markdown
@@ -10,7 +10,6 @@ layout: default
 [pgstattuple]: http://www.postgresql.org/docs/9.6/static/pgstattuple.html
 [pgtune]: https://github.com/gregs1104/pgtune
 [postgres-config]: http://www.postgresql.org/docs/current/static/runtime-config-resource.html
-[fact-precedence]: https://puppet.com/docs/puppet/latest/custom_facts.html#fact-precedence
 [dbvis]: https://www.dbvis.com/
 [stockpile]: https://github.com/puppetlabs/stockpile
 
@@ -298,8 +297,8 @@ There are a few things to watch for in the PDB dashboard:
   an array to a hash, which may narrow the scope of the tree to which the
   recomputed paths are contained.  If this is infeasible, or if the fact in
   question is irrelevant to your needs, the fact may be overridden by creating
-  a custom fact with the same name and weight 100. Refer to [fact
-  precedence][fact-precedence] for examples.
+  a custom fact with the same name and weight 100. Refer to the custom facts
+  documentation for examples on fact precedence.
 
 ### atop output
 

--- a/docs/_openvoxdb_8x/pdb_support_guide.markdown
+++ b/docs/_openvoxdb_8x/pdb_support_guide.markdown
@@ -10,6 +10,7 @@ layout: default
 [pgstattuple]: http://www.postgresql.org/docs/9.6/static/pgstattuple.html
 [pgtune]: https://github.com/gregs1104/pgtune
 [postgres-config]: http://www.postgresql.org/docs/current/static/runtime-config-resource.html
+[fact-precedence]: /openfact/latest/custom_facts.html#custom-facts-precedence
 [dbvis]: https://www.dbvis.com/
 [stockpile]: https://github.com/puppetlabs/stockpile
 
@@ -297,8 +298,8 @@ There are a few things to watch for in the PDB dashboard:
   an array to a hash, which may narrow the scope of the tree to which the
   recomputed paths are contained.  If this is infeasible, or if the fact in
   question is irrelevant to your needs, the fact may be overridden by creating
-  a custom fact with the same name and weight 100. Refer to the custom facts
-  documentation for examples on fact precedence.
+  a custom fact with the same name and weight 100. Refer to [fact
+  precedence][fact-precedence] for examples.
 
 ### atop output
 

--- a/docs/_openvoxdb_8x/puppetdb_connection.markdown
+++ b/docs/_openvoxdb_8x/puppetdb_connection.markdown
@@ -8,8 +8,7 @@ canonical: "/openvoxdb/latest/puppetdb_connection.html"
 
 [puppetdb_root]: ./overview.html
 [connect_to_puppetdb]: ./connect_puppet_server.html
-[confdir]: https://puppet.com/docs/puppet/latest/dirs_confdir.html
-[puppetdb_conf]: ./connect_puppet_server.html#edit-puppetdb\.conf
+[confdir]: /openvox/latest/dirs_confdir.html
 
 The `puppetdb.conf` file contains the hostname and port of the [OpenVoxDB][puppetdb_root] server. It is only used if you are using OpenVoxDB and have [connected your Puppet Server to it][connect_to_puppetdb].
 

--- a/docs/_openvoxdb_8x/scaling_recommendations.markdown
+++ b/docs/_openvoxdb_8x/scaling_recommendations.markdown
@@ -13,7 +13,7 @@ canonical: "/openvoxdb/latest/scaling_recommendations.html"
 [pg_ha]: http://www.postgresql.org/docs/current/interactive/high-availability.html
 [pg_replication]: http://wiki.postgresql.org/wiki/Replication,_Clustering,_and_Connection_Pooling
 [ram]: #bottleneck-java-heap-size
-[runinterval]: https://puppet.com/docs/puppet/latest/configuration.html#runinterval
+[runinterval]: /openvox/latest/configuration.html#runinterval
 
 OpenVoxDB will be a critical component of your Puppet deployment, as agent nodes will be unable to request catalogs if it goes down. Therefore, you should make sure it can handle your site's load and is resilient against failures.
 

--- a/docs/_openvoxdb_8x/using.markdown
+++ b/docs/_openvoxdb_8x/using.markdown
@@ -6,7 +6,7 @@ canonical: "/openvoxdb/latest/using.html"
 
 # Using OpenVoxDB
 
-[exported]: https://puppet.com/docs/puppet/latest/lang_exported.html
+[exported]: /openvox/latest/lang_exported.html
 
 Currently, OpenVoxDB's primary use is enabling advanced Puppet features. As use becomes more widespread, we expect additional applications to be built on OpenVoxDB.
 


### PR DESCRIPTION
## Summary

Updates external `puppet.com/docs` links in `docs/_openvoxdb_8x/` to local equivalents where OpenVox docs now have the content. Based on the full audit in the issue #206 comment, extended to cover pages that now exist in `_openvox_8x` and `_openvox-server_8x`.

> **Note:** All `puppet.com/docs/puppet/latest/*` URLs now redirect to the Puppet Core homepage rather than actual content, so no external puppet.com links are retained for pages that were previously in scope.

**Links updated to `/openvox/latest/`** (16 files):
- `lang_exported`, `lang_resources`, `lang_relationships`, `lang_data_undef`, `lang_data_resource_reference`, `lang_data_number`, `lang_containment`, `lang_summary`, `lang_facts_and_builtin_vars`, `config_file_routes`, `reporting_about`, `dirs_confdir`, `install_pre`, `config_file_puppetdb`
- `type.html#package`, `#file`, `#resources` — these sections exist in `_openvox_8x/type.md`
- `configuration.html#runinterval`, `#configversion` → `#config_version` (anchor uses underscore in OpenVox heading)
- `install_puppet.html#enable_the_puppet_platform_repository` → `/openvox/latest/openvox_platform.html`
- `format_report.html#puppettransactionreport` → `/openvox/latest/format_report.html` (anchor dropped; OpenVox page is a stub pending full content)

**Link updated to `/openvox-server/latest/`:**
- `puppetserver/latest/intermediate_ca.html#set-up-puppet-as-an-intermediate-ca-with-an-external-root` → `/openvox-server/latest/intermediate_ca.html#set-up-openvox-as-an-intermediate-ca-with-an-external-root`; link text updated from "Puppet Server" to "OpenVox Server"

**Link updated to Forge:**
- `type.html#yumrepo` → `https://forge.puppet.com/modules/puppetlabs/yumrepo_core` — yumrepo was removed from core in Puppet/OpenVox 8

**Intra-collection link fixed:**
- `maintain_and_tune.markdown`: `/openvoxdb/latest/configure.html#vardir` → `./configure.html#vardir` (relative, matching all other `configure.html` refs in that file)

**Link removed (no equivalent, puppet.com redirects to homepage):**
- `custom_facts.html#fact-precedence` in `pdb_support_guide.markdown` — prose reworded to plain text

**Out of scope (intentionally unchanged):**
- Old PuppetDB 5–7 release notes — historical record, no changes needed per issue #206
- PE-specific links (`pe/latest/`) — no OpenVox equivalent

**Misc cleanup:**
- Removed unused reference definitions: `[puppetreportformat]` (report_format_v5), `[reportsv4]` (report_format_v5), `[puppetdb_conf]` (puppetdb_connection)
- Removed duplicate `[exported]` definition in `connect_puppet_apply.markdown`

Part of #206

## Test plan

- [x] All updated `/openvox/latest/` and `/openvox-server/latest/` target pages return 200
- [x] All updated anchors verified present in rendered HTML
- [x] All modified pages render without errors locally
- [x] Confirmed puppet.com/docs links redirect to Puppet homepage (not usable as references)
- [ ] Spot-check updated links on staging/production site
