### PR TITLE
Add known issue about openssl in server 8.13.0

### DIFF
--- a/docs/_openvox-server_8x/release_notes.markdown
+++ b/docs/_openvox-server_8x/release_notes.markdown
@@ -12,6 +12,23 @@ This is an enhancement and bug-fix release of OpenVox Server.
 
 All bug fixes, new features and other changes are provided on the [project's GitHub release page](https://github.com/OpenVoxProject/openvox-server/releases/tag/8.13.0).
 
+### Known Issues
+
+#### `jruby-openssl` 0.15.4 Fails to Parse EC Keys
+
+The `openssl` JRuby library included in this release may fail to parse some PEM
+files that previous versions were able to parse, resulting in errors such as:
+
+```console
+java.lang.NoSuchMethodError: 'org.bouncycastle.asn1.ASN1Primitive org.bouncycastle.asn1.sec.ECPrivateKey.getParameters()'
+```
+Not all files are affected, the error seems to be triggered by specific patterns in
+ASN.1 content. See [OpenVoxProject/openvox-server#322][openvox-server-322]
+for more details and subscribe for updates on a fix. Recommended workaround is
+to downgrade the `openvox-server` package to version 8.12.1.
+
+[openvox-server-322]: https://github.com/OpenVoxProject/openvox-server/issues/322
+
 ## OpenVox Server 8.12.1
 
 Released January 21, 2025.


### PR DESCRIPTION
This commit adds a known issue to the OpenVox Server release notes about `jruby-opensJsl` failing to parse some PEM files, notably some EC private keys.

See: https://github.com/OpenVoxProject/openvox-server/issues/322


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
