### PR TITLE
adds more obvious menu highlighting

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -7,3 +7,15 @@ table.resolution > tbody > tr:last-child {
 table.resolution > tbody > tr:last-child > td:first-child {
   text-align: right;
 }
+
+/* Highlight the active page more visibly */
+.VPSidebarItem.level-0.is-active > .item .link > .text,
+.VPSidebarItem.level-1.is-active > .item .link > .text,
+.VPSidebarItem.level-2.is-active > .item .link > .text,
+.VPSidebarItem.level-3.is-active > .item .link > .text,
+.VPSidebarItem.level-4.is-active > .item .link > .text,
+.VPSidebarItem.level-5.is-active > .item .link > .text {
+  background-color: var(--vp-c-brand-soft);
+  border-radius: 0.25em;
+  padding-left: 1em;
+}


### PR DESCRIPTION
This makes the active page more visible in the menu.

<img width="246" height="203" alt="Screenshot 2026-05-20 at 2 51 54 PM" src="https://github.com/user-attachments/assets/ac954e83-9d6c-44fe-9c96-d039d7941e33" />

Signed-off-by: Ben Ford <binford2k@overlookinfratech.com>

