### PR TITLE
build from the latest release tag

### DIFF
--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -44,7 +44,7 @@ module PuppetReferences
     ]
     config = PuppetReferences::Config.read
     repo = PuppetReferences::Repo.new('openvox', PUPPET_DIR, nil, config['puppet']['repo'])
-    @version_commit = commit || repo.describe.split('-')[0]
+    @version_commit = commit || repo.newest_release
     puts "Using tag #{@version_commit}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle
@@ -55,7 +55,7 @@ module PuppetReferences
     config = PuppetReferences::Config.read
     bolt_config = config.fetch('openbolt', {})
     repo = PuppetReferences::Repo.new('openbolt', BOLT_DIR, nil, bolt_config.fetch('repo', {}))
-    @version_commit = commit || repo.describe.split('-')[0]
+    @version_commit = commit || repo.newest_release
     puts "Using tag #{@version_commit}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle
@@ -75,7 +75,7 @@ module PuppetReferences
     # we need the CLI docs for 3.y. We can remove this when we stop building 3.y.
     version4 = Gem::Version.create('4.0.0')
     repo = PuppetReferences::Repo.new('openfact', FACTER_DIR)
-    @version_commit = commit || repo.describe.split('-')[0]
+    @version_commit = commit || repo.newest_release
     puts "Using tag #{@version_commit}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle

--- a/lib/puppet_references/repo.rb
+++ b/lib/puppet_references/repo.rb
@@ -45,6 +45,12 @@ module PuppetReferences
       @repo.tags
     end
 
+    def newest_release
+      @repo.tags.map { |t| Gem::Version.new(t.name) rescue Gem::Version.new(0) } # rubocop:disable Style/RescueModifier
+                .reject(&:prerelease?)
+                .max.version                                                     # rubocop:disable Layout/MultilineMethodCallIndentation
+    end
+
     def update_bundle
       Dir.chdir(@directory) do
         if Dir.exist?(@directory + '.bundle/stuff')


### PR DESCRIPTION
This expects all versions to match semver specifications. It will throw
away all tags that don't properly parse and filter out pre-releases.
