### PR TITLE
Add CVSS 3.1 score for CVE-2026-27820

### DIFF
--- a/docs/_openvox_8x/release_notes.markdown
+++ b/docs/_openvox_8x/release_notes.markdown
@@ -74,7 +74,7 @@ All bug fixes, new features and other changes are provided on the [project's git
 
 |                            Identifier                             | CVSS 3.1 Score |             Resolved By             |
 | ----------------------------------------------------------------- | :------------: | ----------------------------------- |
-| [CVE-2026-27820](https://nvd.nist.gov/vuln/detail/CVE-2026-27820) |      N/A       | `pkg:gem/zlib@3.0.1`                |
+| [CVE-2026-27820](https://nvd.nist.gov/vuln/detail/CVE-2026-27820) |      9.8       | `pkg:gem/zlib@3.0.1`                |
 | [CVE-2026-3805](https://nvd.nist.gov/vuln/detail/CVE-2026-3805)   |      7.5       | `pkg:github/curl/curl@8.19.0`       |
 | [CVE-2026-1965](https://nvd.nist.gov/vuln/detail/CVE-2026-1965)   |      6.5       | `pkg:github/curl/curl@8.19.0`       |
 | [CVE-2026-3784](https://nvd.nist.gov/vuln/detail/CVE-2026-3784)   |      6.5       | `pkg:github/curl/curl@8.19.0`       |


### PR DESCRIPTION
The NVD updated their record for CVE-2026-27820 today and assigned a CVSS 3.1 score of "9.8". This commit replaces the `N/A` value in the release notes with this published score.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
