### PR TITLE
openvox 8x: document custom CA for HTTPS-inspecting proxies

### DIFF
--- a/_data/nav/openvox_8x.yml
+++ b/_data/nav/openvox_8x.yml
@@ -457,6 +457,8 @@
     link: "ssl_attributes_extensions.html"
   - text: Regenerating all certificates in a deployment
     link: "ssl_regenerate_certificates.html"
+  - text: Adding a custom CA for HTTPS-inspecting proxies
+    link: "ssl_custom_ca_proxy.html"
 - text: Details about OpenVox's internals
   items:
   - text: Agent/server HTTPS communications

--- a/docs/_openvox_8x/ssl_custom_ca_proxy.md
+++ b/docs/_openvox_8x/ssl_custom_ca_proxy.md
@@ -19,17 +19,29 @@ OpenVox ships its own Ruby runtime with a vendored CA bundle compiled in at
 and is what Ruby uses — not the OS trust store — when validating TLS certificates for
 outbound connections such as gem downloads and `puppet module install`.
 
-## Quick fix: append the CA to the bundle
+## Quick fix: add the CA to the `certs/` directory
 
-Appending your proxy CA to `cert.pem` works immediately and requires no additional
-configuration:
+Copy your proxy CA into OpenVox's `certs/` directory and run `openssl rehash` to generate
+the fingerprint symlinks that OpenSSL uses to look up certificates:
+
+```console
+cp /path/to/proxy-ca.pem /opt/puppetlabs/puppet/ssl/certs/proxy-ca.pem
+/opt/puppetlabs/puppet/bin/openssl rehash /opt/puppetlabs/puppet/ssl/certs/
+```
+
+This directory is OpenVox Ruby's `DEFAULT_CERT_DIR` and is included by `set_default_paths`
+on every connection. The directory is empty by default — the `openvox-agent` package does
+not place any files there — so user-added files survive package upgrades.
+
+> **Note:** `openssl rehash` is not supported on Windows as of OpenVox 8. Use the
+> `SSL_CERT_FILE` approach below on Windows nodes.
+
+If you prefer a one-liner that skips rehash, appending directly to `cert.pem` also works,
+but that file is replaced on upgrade:
 
 ```console
 cat /path/to/proxy-ca.pem >> /opt/puppetlabs/puppet/ssl/cert.pem
 ```
-
-The downside is that `cert.pem` is owned by the `openvox-agent` package and may be
-overwritten during upgrades, removing your CA and breaking the proxy again.
 
 ## Persistent fix: `ssl_trust_store` (module downloads only)
 
@@ -79,10 +91,41 @@ SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem puppet agent -t
 
 ## Managing with Puppet
 
+### `certs/` + rehash (simplest)
+
+Deploy the CA with a `file` resource and trigger `openssl rehash` on change:
+
+```puppet
+file { '/opt/puppetlabs/puppet/ssl/certs/proxy-ca.pem':
+  ensure  => file,
+  owner   => 'root',
+  group   => 'root',
+  mode    => '0644',
+  content => lookup('profile::proxy_ca_cert'),
+  notify  => Exec['rehash-puppet-ssl-certs'],
+}
+
+exec { 'rehash-puppet-ssl-certs':
+  command     => '/opt/puppetlabs/puppet/bin/openssl rehash /opt/puppetlabs/puppet/ssl/certs/',
+  refreshonly => true,
+}
+```
+
+Store the proxy CA certificate as a multiline string in Hiera:
+
+```yaml
+profile::proxy_ca_cert: |
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+### `SSL_CERT_FILE` merged bundle (covers gem installs on Windows or when rehash is unavailable)
+
 Use [puppetlabs/concat](https://forge.puppet.com/modules/puppetlabs/concat) to assemble
-and maintain the merged bundle. The `file:///` source scheme reads `cert.pem` directly from
-the local filesystem at catalog apply time, so the bundle automatically picks up the fresh
-Mozilla certs after an `openvox-agent` upgrade:
+the merged bundle. The `file:///` source scheme reads `cert.pem` from the local filesystem
+at catalog apply time, so the bundle automatically picks up fresh Mozilla certs after an
+`openvox-agent` upgrade:
 
 ```puppet
 concat { '/etc/ssl/certs/puppet-custom-bundle.pem':
@@ -118,18 +161,6 @@ exec { 'systemd-daemon-reload':
   refreshonly => true,
 }
 ```
-
-Store the proxy CA certificate as a multiline string in Hiera:
-
-```yaml
-profile::proxy_ca_cert: |
-  -----BEGIN CERTIFICATE-----
-  ...
-  -----END CERTIFICATE-----
-```
-
-Because `concat::fragment` reads `cert.pem` on every Puppet run, the merged bundle stays
-current after upgrades with no additional steps.
 
 ## Verifying the configuration
 

--- a/docs/_openvox_8x/ssl_custom_ca_proxy.md
+++ b/docs/_openvox_8x/ssl_custom_ca_proxy.md
@@ -91,8 +91,6 @@ SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem puppet agent -t
 
 ## Managing with Puppet
 
-### `certs/` + rehash (simplest)
-
 Deploy the CA with a `file` resource and trigger `openssl rehash` on change:
 
 ```puppet
@@ -120,47 +118,6 @@ profile::proxy_ca_cert: |
   -----END CERTIFICATE-----
 ```
 
-### `SSL_CERT_FILE` merged bundle (covers gem installs on Windows or when rehash is unavailable)
-
-Use [puppetlabs/concat](https://forge.puppet.com/modules/puppetlabs/concat) to assemble
-the merged bundle. The `file:///` source scheme reads `cert.pem` from the local filesystem
-at catalog apply time, so the bundle automatically picks up fresh Mozilla certs after an
-`openvox-agent` upgrade:
-
-```puppet
-concat { '/etc/ssl/certs/puppet-custom-bundle.pem':
-  ensure => present,
-  owner  => 'root',
-  group  => 'root',
-  mode   => '0644',
-}
-
-concat::fragment { 'openvox-mozilla-bundle':
-  target => '/etc/ssl/certs/puppet-custom-bundle.pem',
-  source => 'file:///opt/puppetlabs/puppet/ssl/cert.pem',
-  order  => '01',
-}
-
-concat::fragment { 'proxy-ca':
-  target  => '/etc/ssl/certs/puppet-custom-bundle.pem',
-  content => lookup('profile::proxy_ca_cert'),
-  order   => '02',
-}
-
-file { '/etc/systemd/system/puppet.service.d/ssl_cert_file.conf':
-  ensure  => file,
-  owner   => 'root',
-  group   => 'root',
-  mode    => '0644',
-  content => "[Service]\nEnvironment=SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem\n",
-  notify  => Exec['systemd-daemon-reload'],
-}
-
-exec { 'systemd-daemon-reload':
-  command     => '/bin/systemctl daemon-reload',
-  refreshonly => true,
-}
-```
 
 ## Verifying the configuration
 

--- a/docs/_openvox_8x/ssl_custom_ca_proxy.md
+++ b/docs/_openvox_8x/ssl_custom_ca_proxy.md
@@ -1,0 +1,144 @@
+---
+layout: default
+title: "SSL configuration: Adding a custom CA for HTTPS-inspecting proxies"
+---
+
+Some network environments use HTTPS-inspecting proxies (such as Squid with SSL Bump) that
+re-sign outbound TLS connections using a local CA. OpenVox's Ruby runtime uses its own
+bundled CA certificate store rather than the system trust store, so the proxy CA must be
+added explicitly before OpenVox will trust connections the proxy intercepts.
+
+Common symptoms: `gem install` or module downloads (`puppet module install`) fail with
+certificate verification errors even though the system CA trust store already includes the
+proxy CA.
+
+## How OpenVox validates outbound TLS
+
+OpenVox ships its own Ruby runtime with a vendored CA bundle compiled in at
+`/opt/puppetlabs/puppet/ssl/cert.pem`. This path is OpenVox's `OpenSSL::X509::DEFAULT_CERT_FILE`
+and is what Ruby uses — not the OS trust store — when validating TLS certificates for
+outbound connections such as gem downloads and `puppet module install`.
+
+## Quick fix: append the CA to the bundle
+
+Appending your proxy CA to `cert.pem` works immediately and requires no additional
+configuration:
+
+```console
+cat /path/to/proxy-ca.pem >> /opt/puppetlabs/puppet/ssl/cert.pem
+```
+
+The downside is that `cert.pem` is owned by the `openvox-agent` package and may be
+overwritten during upgrades, removing your CA and breaking the proxy again.
+
+## Persistent fix: `ssl_trust_store` (module downloads only)
+
+For `puppet module install` and https file sources, the cleanest option is the
+`ssl_trust_store` setting in `puppet.conf`. OpenVox loads this file as an additional trust
+store on top of the built-in bundle, so your proxy CA survives upgrades and no environment
+variables are required:
+
+```console
+puppet config set ssl_trust_store /etc/ssl/certs/proxy-ca.pem
+```
+
+**Important:** `ssl_trust_store` only applies to Puppet's own outbound HTTPS requests. It
+does not affect gem installs performed via the `puppet_gem` package provider, because those
+run `gem` as a subprocess that does not read `puppet.conf`. Use the `SSL_CERT_FILE` approach
+below if you also need gem installs to work.
+
+## Persistent fix: `SSL_CERT_FILE` pointing at a merged bundle
+
+The `SSL_CERT_FILE` environment variable overrides OpenSSL's default cert path and works
+for both `puppet module install` and gem installs. Create a merged bundle that combines the
+original Mozilla certs with your proxy CA:
+
+```console
+cat /opt/puppetlabs/puppet/ssl/cert.pem /path/to/proxy-ca.pem \
+  > /etc/ssl/certs/puppet-custom-bundle.pem
+```
+
+**Make it permanent for the Puppet agent service** by adding the variable to the service
+environment. On systemd systems, create a drop-in:
+
+```console
+mkdir -p /etc/systemd/system/puppet.service.d
+cat > /etc/systemd/system/puppet.service.d/ssl_cert_file.conf <<'EOF'
+[Service]
+Environment=SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem
+EOF
+systemctl daemon-reload
+systemctl restart puppet
+```
+
+For one-off commands, export the variable in the same shell:
+
+```console
+SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem puppet agent -t
+```
+
+## Managing with Puppet
+
+Use [puppetlabs/concat](https://forge.puppet.com/modules/puppetlabs/concat) to assemble
+and maintain the merged bundle. The `file:///` source scheme reads `cert.pem` directly from
+the local filesystem at catalog apply time, so the bundle automatically picks up the fresh
+Mozilla certs after an `openvox-agent` upgrade:
+
+```puppet
+concat { '/etc/ssl/certs/puppet-custom-bundle.pem':
+  ensure => present,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0644',
+}
+
+concat::fragment { 'openvox-mozilla-bundle':
+  target => '/etc/ssl/certs/puppet-custom-bundle.pem',
+  source => 'file:///opt/puppetlabs/puppet/ssl/cert.pem',
+  order  => '01',
+}
+
+concat::fragment { 'proxy-ca':
+  target  => '/etc/ssl/certs/puppet-custom-bundle.pem',
+  content => lookup('profile::proxy_ca_cert'),
+  order   => '02',
+}
+
+file { '/etc/systemd/system/puppet.service.d/ssl_cert_file.conf':
+  ensure  => file,
+  owner   => 'root',
+  group   => 'root',
+  mode    => '0644',
+  content => "[Service]\nEnvironment=SSL_CERT_FILE=/etc/ssl/certs/puppet-custom-bundle.pem\n",
+  notify  => Exec['systemd-daemon-reload'],
+}
+
+exec { 'systemd-daemon-reload':
+  command     => '/bin/systemctl daemon-reload',
+  refreshonly => true,
+}
+```
+
+Store the proxy CA certificate as a multiline string in Hiera:
+
+```yaml
+profile::proxy_ca_cert: |
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+Because `concat::fragment` reads `cert.pem` on every Puppet run, the merged bundle stays
+current after upgrades with no additional steps.
+
+## Verifying the configuration
+
+Confirm Ruby can reach an intercepted host:
+
+```console
+/opt/puppetlabs/puppet/bin/ruby -rnet/http -ruri \
+  -e 'Net::HTTP.get(URI("https://forgeapi.puppet.com")); puts "OK"'
+```
+
+A successful response prints `OK`. A certificate verification error means the proxy CA is
+still not trusted by OpenVox's Ruby environment.

--- a/docs/_openvox_8x/ssl_custom_ca_proxy.md
+++ b/docs/_openvox_8x/ssl_custom_ca_proxy.md
@@ -118,6 +118,23 @@ profile::proxy_ca_cert: |
   -----END CERTIFICATE-----
 ```
 
+If the certificate is already deployed on the node at a known path (for example, by the
+[puppet/trusted_ca](https://forge.puppet.com/modules/puppet/trusted_ca) module into the OS
+trust store), use a symlink instead to avoid keeping a second copy:
+
+```puppet
+file { '/opt/puppetlabs/puppet/ssl/certs/proxy-ca.pem':
+  ensure => link,
+  target => '/etc/pki/ca-trust/source/anchors/proxy-ca.pem',
+  notify => Exec['rehash-puppet-ssl-certs'],
+}
+
+exec { 'rehash-puppet-ssl-certs':
+  command     => '/opt/puppetlabs/puppet/bin/openssl rehash /opt/puppetlabs/puppet/ssl/certs/',
+  refreshonly => true,
+}
+```
+
 
 ## Verifying the configuration
 


### PR DESCRIPTION
## Summary

- Adds a new doc page covering how to add a custom CA to OpenVox's vendored cert bundle for environments using HTTPS-inspecting proxies (Squid SSL Bump, etc.)
- Explains why OpenVox ignores the OS trust store (it uses its own `DEFAULT_CERT_FILE` at `/opt/puppetlabs/puppet/ssl/cert.pem` and `DEFAULT_CERT_DIR` at `/opt/puppetlabs/puppet/ssl/certs/`)
- Covers three approaches: `certs/` + `openssl rehash` (recommended — survives upgrades), `ssl_trust_store` (module downloads only), and `SSL_CERT_FILE` with a merged bundle (universal, including gem installs and Windows)
- Puppet management example: `file` + `exec rehash` for the `certs/` approach, with a symlink variant for nodes where the cert is already deployed by `puppet/trusted_ca`
- Adds nav entry under "SSL and certificates"

## Motivation

Reported by a community member: gem installs and `puppet module install` fail behind Squid SSL Bump even when the proxy CA is in the system trust store.

## Source verification

Claims verified against the OpenVox source:

- `OpenSSL::X509::DEFAULT_CERT_FILE` = `/opt/puppetlabs/puppet/ssl/cert.pem` and `DEFAULT_CERT_DIR` = `/opt/puppetlabs/puppet/ssl/certs/` confirmed on a live `openvox-agent-8.27.0` install
- `puppet module install` uses `Puppet::SSL::SSLProvider#create_system_context` → `create_x509_store(include_system_store: true)` → `store.set_default_paths`, which respects both `DEFAULT_CERT_FILE` and `DEFAULT_CERT_DIR` ([ssl_provider.rb:258](https://github.com/voxpupuli/openvox/blob/main/lib/puppet/ssl/ssl_provider.rb))
- `ssl_trust_store` scope confirmed via [defaults.rb:1020](https://github.com/voxpupuli/openvox/blob/main/lib/puppet/defaults.rb) — applies to forge/https only, not gem subprocesses
- `puppet_gem` provider runs `gem` as a subprocess ([puppet_gem.rb](https://github.com/voxpupuli/openvox/blob/main/lib/puppet/provider/package/puppet_gem.rb)), so only inherits `SSL_CERT_FILE` from the service environment

## Test results

Tested on `openvox-agent-8.27.0` (CentOS Stream 9, aarch64) via Vagrant. Generated a self-signed test CA, started a Python HTTPS server using that CA, and verified each approach:

```
=== TEST 1: Default cert.pem (should FAIL) ===
ERROR: OpenSSL::SSL::SSLError: certificate verify failed (unable to get local issuer certificate)

=== TEST 2: certs/ + openssl rehash ===
OK

=== TEST 3: SSL_CERT_FILE merged bundle ===
OK

=== TEST 4: Docs verification command ===
OK
```

Puppet `file` + `exec rehash` approach also verified — idempotent, hash symlink created, Ruby connects without `SSL_CERT_FILE`:

```
Notice: /File[...proxy-ca.pem]/ensure: defined content as '{sha256}cda6...'
Notice: /Exec[rehash-puppet-ssl-certs]: Triggered 'refresh' from 1 event
# second run:
Notice: Applied catalog in 0.02 seconds  ← no changes
```

## Test plan

- [ ] Review doc prose for accuracy
- [ ] Confirm nav link resolves correctly on built site
