### PR TITLE
fix: correct code fence language guidance in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,8 @@ Use the following terms for the individual components:
 ### Formatting
 
 - File names and paths: `monospace`
-- Commands and code: `monospace`; short commands inline, longer blocks in fenced code blocks with a language identifier (`bash`, `yaml`, `text`, etc.)
-- Use `command` language identifier in favor of `shell`
+- Commands and code: `monospace`; short commands inline, longer blocks in fenced code blocks with a language identifier (`console`, `yaml`, `text`, etc.)
+- Use `console` for commands to run in a terminal; use `bash` or `puppet` for scripts and manifests
 
 ### Linking
 


### PR DESCRIPTION
## Summary

- Fixes the `Formatting` section of `CONTRIBUTING.md`
- `command` is not a valid Rouge lexer — Jekyll silently falls back to no highlighting; replace with `console`, which Rouge supports
- Update the example in the same bullet from `bash` to `console`
- Clarify when `bash` and `puppet` are appropriate (scripts and manifests) vs `console` (interactive terminal commands)

## Test plan

- [x] Confirmed `console` fences render with `language-console` class and prompt highlighting in a local `jekyll build`
