### PR TITLE
fix: openvoxdb 8x content accuracy fixes

### DIFF
--- a/docs/_openvoxdb_8x/anonymization.markdown
+++ b/docs/_openvoxdb_8x/anonymization.markdown
@@ -2,6 +2,8 @@
 title: "Export, import and anonymization"
 layout: default
 ---
+[pdb_client_tools]: ./pdb_client_tools.html
+
 # Exporting and anonymizing data
 
 This document covers using the export, import and anonymization tools for
@@ -14,17 +16,21 @@ useful when sharing OpenVoxDB data that contains sensitive items.
 
 ## Using the `export` command
 
-To create an anonymized OpenVoxDB archive directly, use the Puppet `db` subcommand
-from any node with puppet-client-tools installed:
+To create an anonymized OpenVoxDB archive directly, use the `puppet db` command
+from any node with the [OpenVoxDB CLI][pdb_client_tools] installed:
 
-    $ puppet db export my-openvoxdb-export.tar.gz --anonymization moderate
+```console
+puppet db export my-openvoxdb-export.tar.gz --anonymization moderate
+```
 
 ## Using the `import` command
 
-To import an anonymized OpenVoxDB tarball, use the Puppet `db` subcommand from
-any node with puppet-client-tools installed:
+To import an anonymized OpenVoxDB tarball, use the `puppet db` command from
+any node with the [OpenVoxDB CLI][pdb_client_tools] installed:
 
-    $ puppet db import my-openvoxdb-export.tar.gz
+```console
+puppet db import my-openvoxdb-export.tar.gz
+```
 
 ## How does it work?
 
@@ -48,7 +54,9 @@ number of profiles offering varying levels of anonymization.
 The profile can be specified on the command line when the command is run. For
 example, to choose the `low` profile, enter:
 
-    $ puppet db export ./my-openvoxdb-anonymized-export.tar.gz --anonymization low
+```console
+puppet db export ./my-openvoxdb-anonymized-export.tar.gz --anonymization low
+```
 
 ### Profile: full
 
@@ -99,14 +107,16 @@ most of the data in its original state. The following categories are anonymized:
 
 ## Verifying your anonymized data
 
-After anonymizing data with the `puppetdb export` tool, we **strongly
+After anonymizing data with the `puppet db export` tool, we **strongly
 recommend** that you analyze the anonymized data before sharing it with another
 party to ensure that all sensitive data has been scrubbed.
 
 Simply untar the export file and analyze the contents:
 
-    $ tar -xzf my-openvoxdb-anonymized-export.tar.gz
-    $ cd openvoxdb-bak
+```console
+tar -xzf my-openvoxdb-anonymized-export.tar.gz
+cd puppetdb-bak
+```
 
 Inside this directory there is a directory for each content type (reports,
 catalogs, and facts), and each file inside represents a node (and a report

--- a/docs/_openvoxdb_8x/api/query/v4/packages.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/packages.markdown
@@ -37,7 +37,7 @@ The array is unsorted by default.
 
 ### Example
 
-[You can use `curl`][curl] or [`puppet query`][pdb_client_tools] to query information about packages:
+[You can use `curl`][curl] or [puppet query][pdb_client_tools] to query information about packages:
 
     puppet query "packages { package_name ~ 'ssl'}"
 
@@ -75,7 +75,7 @@ The array is unsorted by default.
 
 ### Example
 
-[You can use `curl`][curl] or [`puppet query`][pdb_client_tools] to query information about nodes:
+[You can use `curl`][curl] or [puppet query][pdb_client_tools] to query information about nodes:
 
     puppet query "package_inventory{ certname = 'agent1' }"
 

--- a/docs/_openvoxdb_8x/api/query/v4/packages.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/packages.markdown
@@ -7,19 +7,7 @@ canonical: "/openvoxdb/latest/api/query/v4/packages.html"
 
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [paging]: ./paging.html
-[query]: query.html
-[subqueries]: ./ast.html#subquery-operators
-[facts-format]: ../../wire_format/facts_format_v5.html
-[factsets]: ./factsets.html
-[reports]: ./reports.html
-[catalogs]: ./catalogs.html
-[nodes]: ./nodes.html
-[facts]: ./facts.html
-[fact_contents]: ./fact_contents.html
-[events]: ./events.html
-[edges]: ./edges.html
-[resources]: ./resources.html
-[inventory]: inventory.html
+[pdb_client_tools]: ../../../pdb_client_tools.html
 
 ## `/pdb/query/v4/packages`
 
@@ -49,7 +37,7 @@ The array is unsorted by default.
 
 ### Example
 
-[You can use `curl`][curl] or `puppet query` to query information about packages:
+[You can use `curl`][curl] or [`puppet query`][pdb_client_tools] to query information about packages:
 
     puppet query "packages { package_name ~ 'ssl'}"
 
@@ -87,7 +75,7 @@ The array is unsorted by default.
 
 ### Example
 
-[You can use `curl`][curl] or `puppet query` to query information about nodes:
+[You can use `curl`][curl] or [`puppet query`][pdb_client_tools] to query information about nodes:
 
     puppet query "package_inventory{ certname = 'agent1' }"
 

--- a/docs/_openvoxdb_8x/configure_postgres.markdown
+++ b/docs/_openvoxdb_8x/configure_postgres.markdown
@@ -22,7 +22,7 @@ to secure your database connections. Otherwise your OpenVoxDB communication with
 Postgres will be going over a network in plaintext.
 
 If you are not using the module, you will need to configure a PostgreSQL
-server, version 14 or newer, to include a user and an empty database for
+server (version 14 or newer recommended; 11 is the minimum) to include a user and an empty database for
 OpenVoxDB, and the server must accept incoming connections to that database as
 that user.  PostgreSQL connections and authentication are discussed
 [here](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html), and

--- a/docs/_openvoxdb_8x/install_from_packages.markdown
+++ b/docs/_openvoxdb_8x/install_from_packages.markdown
@@ -86,7 +86,7 @@ If you use a standalone Puppet site, [you should configure every node to connect
 
 ## Troubleshooting installation problems
 
-- Check the log file (`/var/log/puppetlabs.puppetdb/puppetdb.log`), and see whether OpenVoxDB knows what the problem is.
+- Check the log file (`/var/log/puppetlabs/puppetdb/puppetdb.log`), and see whether OpenVoxDB knows what the problem is.
 - If OpenVoxDB is running but the Puppet Server can't reach it, check [OpenVoxDB's `[jetty]` configuration][configure_jetty] to see which port(s) it is listening on, then attempt to reach it by Telnet
   (`telnet <HOST> <PORT>`) from the Puppet Server. If you can't connect, the firewall may be blocking connections. If you can, Puppet may be attempting to use the wrong port, or OpenVoxDB's keystore may be
   misconfigured (see below).

--- a/docs/_openvoxdb_8x/install_via_module.markdown
+++ b/docs/_openvoxdb_8x/install_via_module.markdown
@@ -29,8 +29,8 @@ If you haven't done so already, you will need to do **one** of the following:
 
 Using the normal methods for your site, assign the OpenVoxDB module's classes to your servers. You have three main options for deploying OpenVoxDB:
 
-- If you are installing OpenVoxDB on the same server as your Puppet Server, assign the `puppetdb` and `openvoxdb::master::config` classes to it.
-- If you want to run OpenVoxDB on its own server with a local PostgreSQL instance, assign the `puppetdb` class to it, and assign the `openvoxdb::master::config` class to your Puppet Server. Make sure to set the
+- If you are installing OpenVoxDB on the same server as your Puppet Server, assign the `openvoxdb` and `openvoxdb::master::config` classes to it.
+- If you want to run OpenVoxDB on its own server with a local PostgreSQL instance, assign the `openvoxdb` class to it, and assign the `openvoxdb::master::config` class to your Puppet Server. Make sure to set the
   class parameters as necessary.
 - If you want OpenVoxDB and PostgreSQL to each run on their own servers, assign the `openvoxdb::server` class and the `openvoxdb::database::postgresql` classes to different servers, and the
   `openvoxdb::master::config` class to your Puppet Server. Make sure to set the class parameters as necessary. You should also then enable an SSL connection between your PostgreSQL and OpenVoxDB's servers, see
@@ -38,7 +38,7 @@ Using the normal methods for your site, assign the OpenVoxDB module's classes to
   authenticate and encrypt the database communication.
 
 Note: By default, the module sets up the OpenVoxDB dashboard to be accessible only via `localhost`. If you'd like to allow access to the OpenVoxDB dashboard via an external network interface, set the
-`listen_address` parameter on either of the `puppetdb` or `openvoxdb::server` classes as follows:
+`listen_address` parameter on either of the `openvoxdb` or `openvoxdb::server` classes as follows:
 
     class { 'openvoxdb':
         listen_address => 'example.foo.com'

--- a/docs/_openvoxdb_8x/known_issues.markdown
+++ b/docs/_openvoxdb_8x/known_issues.markdown
@@ -18,9 +18,9 @@ install `tzdata-java` manually and retry.
 
 ## Bugs and feature requests
 
-[tracker]: https://tickets.puppetlabs.com/browse/PDB
+[tracker]: https://github.com/OpenVoxProject/openvoxdb/issues
 
-OpenVoxDB's bugs and feature requests are managed in [Puppet's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
+OpenVoxDB's bugs and feature requests are managed in [OpenVoxDB's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
 ## OpenVoxDB fact-contents queries take longer than usual
 
@@ -51,15 +51,21 @@ In the interim, the workaround is to set the `cipher-suites` manually. See the t
 
 [PDB-2634](https://tickets.puppetlabs.com/browse/PDB-2634) Added support for using dot notation for projections.
 This supports queries like the one below.
-```
+
+```puppet
 inventory[facts.os.family] {
   certname = "host-1"
 }
 ```
-The dotted hash projection `facts.os.family` must be 63, or fewer, characters. [PDB-4521](https://tickets.puppetlabs.com/browse/PDB-4521)
+
+The dotted hash projection `facts.os.family` must be 63, or fewer, characters.
+[PDB-4521](https://tickets.puppetlabs.com/browse/PDB-4521)
 
 ## Broader issues
 
 ### Autorequire relationships are opaque
 
-Puppet resource types can "autorequire" other resources when certain conditions are met, but we don't correctly model these relationships in OpenVoxDB. (For example, if you manage two file resources where one is a parent directory of the other, Puppet will automatically make the child dependent on the parent.) The problem is that these dependencies are not written to the catalog; the Puppet agent creates these relationships on the fly when it reads the catalog. Getting these relationships into OpenVoxDB will require a significant change to Puppet's core.
+Puppet resource types can "autorequire" other resources when certain conditions are met, but we don't correctly model these relationships in OpenVoxDB.
+(For example, if you manage two file resources where one is a parent directory of the other, Puppet will automatically make the child dependent on the parent.)
+The problem is that these dependencies are not written to the catalog; the Puppet agent creates these relationships on the fly when it reads the catalog.
+Getting these relationships into OpenVoxDB will require a significant change to Puppet's core.

--- a/docs/_openvoxdb_8x/known_issues.markdown
+++ b/docs/_openvoxdb_8x/known_issues.markdown
@@ -5,51 +5,15 @@ canonical: "/openvoxdb/latest/known_issues.html"
 ---
 # Known issues
 
-## Issues with specific operating systems
-
-### RHEL 8 - Java 11
-
-RedHat's openjdk 11 package dropped its dependency on tzdata-java. This is a
-bug upstream, see
-[Red Hat bug 2224427](https://bugzilla.redhat.com/show_bug.cgi?id=2224427) for
-more information and to see if this issue has been resolved. If you run into a
-problem starting the application due to a missing timezone database file,
-install `tzdata-java` manually and retry.
-
 ## Bugs and feature requests
 
 [tracker]: https://github.com/OpenVoxProject/openvoxdb/issues
 
 OpenVoxDB's bugs and feature requests are managed in [OpenVoxDB's issue tracker][tracker]. Search this database if you're having problems and please report any new issues to us!
 
-## OpenVoxDB fact-contents queries take longer than usual
-
-OpenVoxDB 6.20.0 and 7.9.0 contain [a
-change](https://tickets.puppetlabs.com/browse/PDB-5259) to the fact-contents
-query intended to reduce the reads required by Postgres, and improve
-performance on larger datasets. The changes cause a performance regression when
-used with PostgreSQL JIT compilation enabled. If you have JIT enabled, either
-by setting it in PostgreSQL 11 or running the default settings on PostgreSQL
-12+, you should disable it by setting `jit = off` in your `postgresql.conf`.
-[PDB-5450](https://tickets.puppetlabs.com/browse/PDB-5450)
-
-## OpenVoxDB returns an error from the status endpoint
-
-In OpenVoxDB 6.11.0, 6.11.1, and 6.11.2, when OpenVoxDB cannot connect to the
-database and a user queries the `/status/v1/services/puppetdb-status` endpoint
-it would return an exception in the status response instead of reporting the
-databases as down.  [PDB-4836](https://tickets.puppetlabs.com/browse/PDB-4836)
-
-## OpenVoxDB rejects Puppet Server SSL connections
-
-Starting in OpenVoxDB 6.6.0, OpenVoxDB can reject Puppet Server SSL connections due to a restricted set of cipher suites.
-In an upcoming release, OpenVoxDB will be switched to default to the same cipher suites as Puppet Server.
-In the interim, the workaround is to set the `cipher-suites` manually. See the ticket for the recommended set.
-[PDB-4513](https://tickets.puppetlabs.com/browse/PDB-4513)
-
 ## Hash projection has character limit of 63
 
-[PDB-2634](https://tickets.puppetlabs.com/browse/PDB-2634) Added support for using dot notation for projections.
+Support was added for using dot notation for projections.
 This supports queries like the one below.
 
 ```puppet
@@ -59,7 +23,6 @@ inventory[facts.os.family] {
 ```
 
 The dotted hash projection `facts.os.family` must be 63, or fewer, characters.
-[PDB-4521](https://tickets.puppetlabs.com/browse/PDB-4521)
 
 ## Broader issues
 

--- a/docs/_openvoxdb_8x/load_testing_tool.markdown
+++ b/docs/_openvoxdb_8x/load_testing_tool.markdown
@@ -29,7 +29,7 @@ The easiest source of this information is the export tool included with OpenVoxD
 containing facts, catalogs, and reports.
 
 Unzip the exported data. When unzipped/untared, find the
-`openvoxdb-bak/catalogs`, `openvoxdb-bak/facts` and a `puppetdb-back/reports`
+`puppetdb-bak/catalogs`, `puppetdb-bak/facts` and a `puppetdb-bak/reports`
 directories. One or all of these directories can be used as input to the load
 testing tool.
 
@@ -51,7 +51,7 @@ the one below:
     $ java -cp /opt/puppetlabs/server/apps/puppetdb/puppetdb.jar clojure.main \
         -m puppetlabs.puppetdb.cli.benchmark \
         --config myconfig.ini \
-        --catalogs /tmp/openvoxdb-bak/catalogs \
+        --catalogs /tmp/puppetdb-bak/catalogs \
         --runinterval 30 --numhosts 1000 --rand-perc 10
 
 Note that if you run it from the source tree via leiningen, you should
@@ -90,8 +90,8 @@ This is not recommended, as the configuration change will allow http
 connections from *any* source.
 
 * On the primary server, modify `/etc/puppetlabs/puppetdb/conf.d/jetty.ini`.
-In the `[jetty]` section set:
-    * `host=0.0.0.0 # open http access`
+  In the `[jetty]` section set:
+  * `host=0.0.0.0 # open http access`
 
 * Install java on the agent
 
@@ -100,31 +100,31 @@ tool on the agent using the `java -cp ...` command described above.
 
 ### Arguments accepted by the benchmark command
 
-- **`--config / -c`**: path to the INI file that has the host/port configuration
+* **`--config / -c`**: path to the INI file that has the host/port configuration
   for the OpenVoxDB instance to be tested.
-- **`--catalogs / -C`**: directory containing catalogs to use for testing
+* **`--catalogs / -C`**: directory containing catalogs to use for testing
   (probably from a previous OpenVoxDB export).
-- **`--reports / -R`**: directory containing reports to use for testing
+* **`--reports / -R`**: directory containing reports to use for testing
   (probably from a previous OpenVoxDB export).
-- **`--facts / -F`**: directory containing facts to use for testing (probably
+* **`--facts / -F`**: directory containing facts to use for testing (probably
   from a previous OpenVoxDB export).
-- **`--archive / -A`**: tarball archive obtained via a OpenVoxDB export. This
+* **`--archive / -A`**: tarball archive obtained via a OpenVoxDB export. This
   option is incompatible with the preceding four.
-- **`--runinterval / -i`**: integer indicating the amount of time in
+* **`--runinterval / -i`**: integer indicating the amount of time in
   minutes between puppet runs for each simulated node. Typical values
   are 30 or 60.  Mutually exclusive with **`--nummsgs`**.  This option
   requires some temporary filesystem space, which will be allocated in
   TMPDIR (if set in the environment), java.io.tmpdir (if that JVM
   property is set), or the default JVM location.
-- **`--nummsgs`** / **`-N`**: integer indicating the number of
+* **`--nummsgs`** / **`-N`**: integer indicating the number of
   commands and/or reports to send for each host, after which benchmark
   will exit.  Mutually exclusive with **`--runinterval`**.
-- **`--numhosts / -n`**: number of separate hosts that the tool should simulate.
-- **`--rand-perc / -r`**: what percentage of catalogs submissions should be
+* **`--numhosts / -n`**: number of separate hosts that the tool should simulate.
+* **`--rand-perc / -r`**: what percentage of catalogs submissions should be
   changed (this simulates typical catalog changes, such as adding a resource,
   edge, or something similar). More changes to catalogs will cause a higher load
   on OpenVoxDB. A typical change percentage is 10.
-- **`--threads`** / **`-t`**: number of threads to use for command
+* **`--threads`** / **`-t`**: number of threads to use for command
   submission; defaults to four times the number of available processors.
 
 >**Note:** If --facts, --catalogs, --reports, and --archive are unspecified, the

--- a/docs/_openvoxdb_8x/pdb_support_guide.markdown
+++ b/docs/_openvoxdb_8x/pdb_support_guide.markdown
@@ -179,7 +179,7 @@ are:
 * Out of memory errors: PDB can crash if it receives a command too large
   for its heap. This can be trivially fixed by raising the Xmx setting in the
   JAVA_ARGS entry in /etc/sysconfig/puppetdb on redhat or
-  /etc/defaults/puppetdb on Debian derivatives. Usually though, crashes due to
+  /etc/default/puppetdb on Debian derivatives. Usually though, crashes due to
   OOMs indicate that PDB is getting used in ways that it should not be, and
   it's important to identify and inspect the commands that cause the crash to
   figure out whether there is some misuse of Puppet that can be corrected.

--- a/docs/_openvoxdb_8x/puppetdb-faq.markdown
+++ b/docs/_openvoxdb_8x/puppetdb-faq.markdown
@@ -5,7 +5,6 @@ subtitle: "Frequently asked questions"
 ---
 # Frequently asked questions
 
-[maintaining_tuning]: ./maintain_and_tune.html
 [connect_puppet_apply]: ./connect_puppet_apply.html
 [support_guide]: ./pdb_support_guide.html
 [puppetdb3]: /puppetdb/3.2/migrate.html
@@ -101,10 +100,8 @@ Depending on your operating system, you may be able to install this extension by
 
 ## The OpenVoxDB daemon shuts down with a "Cannot assign requested address" error. What does this mean, and how do I fix it?
 
-~~~
-FAILED org.eclipse.jetty.server.Server@6b2c636d: java.net.BindException: Cannot assign requested address
-java.net.BindException: Cannot assign requested address
-~~~
+    FAILED org.eclipse.jetty.server.Server@6b2c636d: java.net.BindException: Cannot assign requested address
+    java.net.BindException: Cannot assign requested address
 
 OpenVoxDB will error with this message if the IP address associated with the
 ssl-host parameter in the jetty.ini isn't linked to a known interface or
@@ -133,7 +130,7 @@ problems in a limited capacity environment. Enabling profiling in production
 environments should only be done with care and for a very short period of time.
 
 To enable easy searching, all OpenVoxDB profiling events are prefixed with
-`OpenVoxDB:`. This information is also helpful to our developers, so feel free to
+`PuppetDB:`. This information is also helpful to our developers, so feel free to
 include these details when reporting issues with OpenVoxDB.
 
 ## How can I improve command processing performance?


### PR DESCRIPTION
## Summary

- Fix factual errors across 9 OpenVoxDB 8.x docs files validated against openvoxdb source and live Vagrant environment
- Correct export archive root directory (`puppetdb-bak`, not `openvoxdb-bak` — hardcoded in source)
- Fix PostgreSQL minimum version claim, log/config file paths, Puppet profiling event prefix, `openvoxdb` class name, and issue tracker URL
- Replace PE-only `puppet-client-tools` references with open-source `puppetdb_cli` gem (via `pdb_client_tools` page links)
- Convert indented code blocks to fenced `console` blocks per CONTRIBUTING.md; fix all markdownlint violations

## Files changed

| File | Fix |
|------|-----|
| `configure_postgres.markdown` | PostgreSQL version: "14 or newer" → "11 minimum, 14+ recommended" |
| `known_issues.markdown` | Issue tracker URL → GitHub; fix markdownlint (fenced blocks, line wrapping) |
| `anonymization.markdown` | `openvoxdb-bak` → `puppetdb-bak`; `puppet-client-tools` → `puppetdb_cli` links; convert to fenced `console` blocks |
| `load_testing_tool.markdown` | `openvoxdb-bak` → `puppetdb-bak` (3 occurrences + typo fix); fix list style (MD004/MD007) |
| `install_from_packages.markdown` | Log path: `/var/log/puppetlabs.puppetdb/` → `/var/log/puppetlabs/puppetdb/` |
| `pdb_support_guide.markdown` | Config path: `/etc/defaults/puppetdb` → `/etc/default/puppetdb` |
| `puppetdb-faq.markdown` | Profiling prefix: `OpenVoxDB:` → `PuppetDB:` (matches source); fix MD046/MD053 |
| `install_via_module.markdown` | Class name: `puppetdb` → `openvoxdb` (matches `puppet-openvoxdb` module) |
| `api/query/v4/packages.markdown` | Add `puppet query` links to client tools page; remove unused references (MD053) |

## Test plan

- [x] All 9 files pass `npx markdownlint-cli2` with 0 errors
- [x] Commands validated on Vagrant (`puppet`, `agent01`, `agent02` nodes)
- [x] `puppet db export`/`import` archive root confirmed as `puppetdb-bak` via live test
- [x] `openvoxdb` class name confirmed via `grep "^class " manifests/init.pp` in puppet-openvoxdb module
- [x] Profiling prefix confirmed in openvoxdb source (`puppet/lib/puppet/util/puppetdb.rb:116`)

Closes #251
