### PR TITLE
docs: fix PE-era absolute links in openvox 8x (#262 D)

### DIFF
--- a/docs/_openvox_8x/config_file_environment.markdown
+++ b/docs/_openvox_8x/config_file_environment.markdown
@@ -5,9 +5,9 @@ title: "Config files: environment.conf"
 
 [environment]: ./environments_about.html
 [environmentpath]: ./environments_creating.html#environmentpath
-[modulepath]: /puppet/3.8/configuration.html#modulepath
+[modulepath]: configuration.html#modulepath
 [puppet.conf]: ./config_file_main.html
-[basemodulepath]: /puppet/3.8/configuration.html#basemodulepath
+[basemodulepath]: configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
 [configuring_timeout]: ./environments_configuring.html#environmenttimeout
 

--- a/docs/_openvox_8x/custom_types.markdown
+++ b/docs/_openvox_8x/custom_types.markdown
@@ -3,17 +3,17 @@ layout: default
 title: Custom Types
 ---
 
-[package_type]: /puppet/latest/type.html#package
-[module]: /puppet/latest/modules_fundamentals.html
-[custom_functions]: /puppet/latest/lang_write_functions_in_puppet.html
+[package_type]: type.html#package
+[module]: modules_fundamentals.html
+[custom_functions]: lang_write_functions_in_puppet.html
 [custom_facts]: /openfact/latest/custom_facts.html
-[pluginsync]: /puppet/latest/configuration.html#pluginsync
+[pluginsync]: configuration.html#pluginsync
 [symbol]: http://www.ruby-doc.org/core/Symbol.html
 [ruby_block]: http://www.robertsosinski.com/2008/12/21/understanding-ruby-blocks-procs-and-lambdas/
 [markdown]: http://commonmark.org/
-[metaparameters]: /puppet/latest/lang_resources.html#metaparameters
+[metaparameters]: lang_resources.html#metaparameters
 [inpage_whitespace]: #type-documentation
-[namevar]: /puppet/latest//lang_resources.html#namenamevar
+[namevar]: lang_resources.html#namenamevar
 
 Custom Types
 ============

--- a/docs/_openvox_8x/functions_basics.md
+++ b/docs/_openvox_8x/functions_basics.md
@@ -17,7 +17,6 @@ title: "Writing custom functions: Introduction"
 [func_modern]: ./functions_ruby_overview.html
 
 [lambda]: ./lang_lambdas.html
-[future parser]: /puppet/3.8/experiments_future.html
 
 ## What are functions?
 
@@ -50,7 +49,7 @@ Interface | Description
 ----------|------------
 [The Puppet language][func_puppet]                                         | The easiest way to write functions, which you can use without knowing any Ruby. However, it's less powerful than the Ruby API: pure Puppet functions can only have one signature per function, and can't take a [lambda][] (block of Puppet code).
 [The modern Ruby functions API][func_modern] (`Puppet::Functions`)         | The most powerful and flexible way to write functions. It requires some knowledge of Ruby.
-[The legacy Ruby functions API][func_legacy] (`Puppet::Parser::Functions`) | **Avoid unless you must support Puppet 3.** This API has major problems, but it is the only way to fully support both Puppet 4.x and Puppet 3.x. (Note that Puppet 3.x can use the modern API when the [future parser][] is enabled.)
+[The legacy Ruby functions API][func_legacy] (`Puppet::Parser::Functions`) | **Avoid unless you must support Puppet 3.** This API has major problems, but it is the only way to fully support both Puppet 4.x and Puppet 3.x. (Note that Puppet 3.x can use the modern API when the future parser is enabled.)
 
 ## Guidelines for writing custom functions
 

--- a/docs/_openvox_8x/lang_windows_file_paths.markdown
+++ b/docs/_openvox_8x/lang_windows_file_paths.markdown
@@ -58,7 +58,7 @@ Backslashes **MUST** be used in:
 
 ### Using backslashes in double-quoted strings
 
-Puppet supports two kinds of string quoting. See [the reference section about strings](/puppet/latest/lang_data_string.html) for full details.
+Puppet supports two kinds of string quoting. See [the reference section about strings](lang_data_string.html) for full details.
 
 Strings surrounded by double quotes (`"`) allow many escape sequences that begin with backslashes. (For example, `\n` for a newline.) Any lone backslashes will be interpreted as part of an escape sequence.
 

--- a/docs/_openvox_8x/modules_installing.markdown
+++ b/docs/_openvox_8x/modules_installing.markdown
@@ -13,12 +13,7 @@ title: "Installing modules"
 [fundamentals]: ./modules_fundamentals.html
 [plugins]: ./plugins_in_modules.html
 [documentation]: ./modules_documentation.html
-[errors]: {{pe}}/troubleshooting_windows.html#error-messages
 [metadata.json]: ./modules_metadata.html
-
-[code_mgr]: {{pe}}/code_mgr.html
-[r10k]: {{pe}}/r10k.html
-[puppetfile]: {{pe}}/cmgmt_puppetfile.html
 
 [approved]: https://forge.puppet.com/approved
 [supported]: https://forge.puppet.com/supported
@@ -31,7 +26,7 @@ Install, upgrade, and uninstall Forge modules from the command line with the `pu
 
 The `puppet module` command provides an interface for managing modules from the Puppet Forge. Its interface is similar to other common package managers, such as `gem`, `apt-get`, or `yum`. You can install, upgrade, uninstall, list, and search for modules with this command.
 
-> **Important:** If you are using [Code Manager][code_mgr] or [r10k][r10k], do not use the `puppet module` command. With code management, you must install modules with a Puppetfile. Code management purges modules that were installed with the `puppet module` command. See the [Puppetfile][puppetfile] documentation for instructions.
+> **Important:** If you are using a code-management tool such as r10k, do not use the `puppet module` command. With code management, you install modules with a Puppetfile; code management purges any modules that were installed with the `puppet module` command.
 
 > **Solaris Note:** To use `puppet module` commands on Solaris systems, you must first install gtar.
 
@@ -174,30 +169,6 @@ sudo puppet module install ~/puppetlabs-apache-0.10.0.tar.gz --ignore-dependenci
 ```
 
 > **Note:** You can manually install modules without the `puppet module` command. If you do, you must name your module's directory appropriately. Module directory names can only contain letters, numbers, and underscores. Dashes and periods are **not valid** and cause errors when attempting to use the module.
-
-{:.section}
-### Installing and upgrading Puppet Enterprise modules
-
-Some premium Puppet modules are available only to Puppet Enterprise users. Generally, you manage these modules in the same way you would manage other modules, but you must have a valid PE license on the machine on which you download the module.
-
-To install or upgrade a [Puppet Enterprise module](/forge/puppetenterprisemodules) with the `puppet module` command, you must:
-
-* Be logged in as the root user.
-* Install the module on a properly licensed Puppet node.
-* Have internet access on the node you are using to download the module.
-
-> **Note**: If you use `librarian-puppet` to manage Puppet Enterprise modules, you must first install the module, and then commit the module to your version control repository.
-
-{:.task}
-#### Install PE modules on nodes without internet
-
-If you need to install a PE-only module on a node with no internet, you can download the module on a connected machine, and then move the module package to the disconnected node.
-
-1. Run `puppet module install puppetlabs-<MODULE>` on a licensed node with internet access.
-2. Run `puppet module build` to build a package from the newly installed module.
-3. Move the *.tar.gz wherever you choose.
-4. Run `puppet module install` against the tar.gz.
-5. Manually install the module's dependencies. Without internet access, the `puppet module` command cannot install dependencies automatically.
 
 {:.concept}
 ### Uninstalling modules

--- a/docs/_openvox_8x/resources_file_windows.markdown
+++ b/docs/_openvox_8x/resources_file_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: File on Windows"
 ---
 
 [file]: ./type.html#file
-[relationships]: /puppet/latest/lang_relationships.html
+[relationships]: lang_relationships.html
 [acl_module]: https://forge.puppetlabs.com/puppetlabs/acl
 [mode]: ./type.html#file-attribute-mode
 

--- a/docs/_openvox_8x/resources_service.markdown
+++ b/docs/_openvox_8x/resources_service.markdown
@@ -3,14 +3,14 @@ layout: default
 title: "Resource tips and examples: Service"
 ---
 
-[service]: /puppet/3.8/type.html#service
-[ensure]: /puppet/3.8/type.html#service-attribute-ensure
-[enable]: /puppet/3.8/type.html#service-attribute-enable
-[start]: /puppet/3.8/type.html#service-attribute-start
-[binary]: /puppet/3.8/type.html#service-attribute-binary
-[stop]: /puppet/3.8/type.html#service-attribute-stop
-[status]: /puppet/3.8/type.html#service-attribute-status
-[pattern]: /puppet/3.8/type.html#service-attribute-pattern
+[service]: type.html#service
+[ensure]: type.html#service-attribute-ensure
+[enable]: type.html#service-attribute-enable
+[start]: type.html#service-attribute-start
+[binary]: type.html#service-attribute-binary
+[stop]: type.html#service-attribute-stop
+[status]: type.html#service-attribute-status
+[pattern]: type.html#service-attribute-pattern
 
 
 Puppet can manage [services][service] on nearly all operating systems.

--- a/docs/_openvox_8x/resources_user_group_windows.markdown
+++ b/docs/_openvox_8x/resources_user_group_windows.markdown
@@ -5,11 +5,11 @@ title: "Resource tips and examples: User and group on Windows"
 
 [user]: ./type.html#user
 [groups]: ./type.html#user-attribute-groups
-[auth_membership_user]: /puppet/latest/type.html#user-attribute-auth_membership
+[auth_membership_user]: type.html#user-attribute-auth_membership
 [group]: ./type.html#group
 [members]: ./type.html#group-attribute-members
-[auth_membership_group]: /puppet/latest/type.html#group-attribute-auth_membership
-[relationships]: /puppet/latest/lang_relationships.html
+[auth_membership_group]: type.html#group-attribute-auth_membership
+[relationships]: lang_relationships.html
 
 Puppet's built-in [`user`][user] and [`group`][group] resource types can manage user and group accounts on Windows.
 

--- a/docs/_openvox_8x/services_device.markdown
+++ b/docs/_openvox_8x/services_device.markdown
@@ -6,7 +6,7 @@ title: "Puppet's services: Puppet device"
 
 [man]: ./man/device.html
 [device.conf]: ./config_file_device.html
-[deviceconfig]: /configuration.html#deviceconfig
+[deviceconfig]: configuration.html#deviceconfig
 [PUP-1391]: https://tickets.puppetlabs.com/browse/PUP-1391
 [report]: ./reporting_about.html
 

--- a/docs/_openvox_8x/ssl_attributes_extensions.markdown
+++ b/docs/_openvox_8x/ssl_attributes_extensions.markdown
@@ -158,7 +158,7 @@ Visibility of extensions is somewhat limited:
   under the "X509v3 extensions" section.
 
 Puppet's authorization system (`auth.conf`) does not use certificate extensions, but
-[Puppet Server's authorization system](/puppetserver/latest/config_file_auth.html), which is
+[Puppet Server's authorization system](/openvox-server/latest/config_file_auth.html), which is
 based on `trapperkeeper-authorization`, can use extensions in the ppAuthCertExt OID range, and
 requires them for requests to write access rules.
 


### PR DESCRIPTION
## What

Fixes the leftover Puppet/PE-era absolute links in the `openvox` 8.x collection — workstream **D** of #262. Repoint to OpenVox equivalents where one exists, otherwise remove.

## Changes

- **`/puppet/<ver>/…` → in-collection relative links** (`config_file_environment`, `custom_types`, `lang_windows_file_paths`, `resources_file_windows`, `resources_service`, `resources_user_group_windows`). Targets and anchors verified against the generated `type.html` / `configuration.html` and the authored `lang_*` pages — including the `Name/namevar` heading whose kramdown id is `#namenamevar`. Also fixes the malformed double-slash `/puppet/latest//lang_resources.html`.
- **Root-relative** `/configuration.html#deviceconfig` → `configuration.html#deviceconfig` (`services_device`).
- **Cross-collection** `/puppetserver/latest/config_file_auth.html` → `/openvox-server/latest/config_file_auth.html` (`ssl_attributes_extensions`).
- **De-link a dead page**: the Puppet 3.8 "future parser" reference in `functions_basics` (no OpenVox equivalent) — text kept.
- **`modules_installing`**: drop the broken `{{pe}}` template-var reference defs (`code_mgr` / `r10k` / `puppetfile` / `troubleshooting_windows`, which render to dead root paths) and the PE-only "Installing and upgrading Puppet Enterprise modules" section; reword the code-management note for OpenVox. `{{pdk}}/pdk.html` is **kept** — it resolves to the `/pdk.html` stub.

## Verification

`htmlproofer _site/openvox/latest --disable-external --checks Links`: **all D-scope paths resolve** — no remaining `/puppet`, `/puppetserver`, `/forge`, `/r10k`, `/code_mgr`, or `/cmgmt_puppetfile` failures. `jekyll build` clean.

## Notes / follow-ups (separate "modernize stale Puppet-3.x/PE content" PR)

This PR is link-only. A follow-up will handle the related editorial cleanup:
- Retire `lang_updating_manifests.markdown` — orphaned (no nav entry, no inbound links) Puppet-3.x→4/5 migration page; resolves the last D-listed link, `/puppet/4.0/release_notes.html`. (Its purge caveat is already in the generated `resources` type reference.)
- Reword the `functions_basics` legacy Ruby functions API row to drop the Puppet-3.x / future-parser framing (this PR only de-links it).
- Remove the orphaned PE-only "Troubleshooting Puppet Enterprise module errors" section in `modules_installing`.

Also left as-is here: pre-existing unused reference-defs and long-line lint in some touched files (advisory on modified files; out of scope for this link fix).

Part of #262
