### PR TITLE
docs: fix drifted anchors to existing pages in openvox 8x (#262 F)

### DIFF
--- a/docs/_openvox_8x/bgtm.md
+++ b/docs/_openvox_8x/bgtm.md
@@ -305,7 +305,7 @@ This allows you to create a list of dependencies in the `metadata.json` file of 
 
 We recommend that you document your module with a README explaining how your module works and a Reference section detailing information about your module's classes, defined types, functions, and resource types and providers.
 
-For guidance, see our modules documentation [guide](./modules_documentation.html) and the [documentation](./style_guide.html#module-documentation) section of the OpenVox Language Style Guide.
+For guidance, see our modules documentation [guide](./modules_documentation.html) and the [documentation](./style_guide.html#documentation) section of the OpenVox Language Style Guide.
 
 ## Releasing your module
 

--- a/docs/_openvox_8x/config_file_fileserver.markdown
+++ b/docs/_openvox_8x/config_file_fileserver.markdown
@@ -4,7 +4,7 @@ title: "Config files: fileserver.conf"
 ---
 
 [file]: ./type.html#file
-[module_files]: ./modules_fundamentals.html#files
+[module_files]: ./modules_fundamentals.html#files-in-modules
 [fileserverconfig]: ./configuration.html#fileserverconfig
 [auth_conf]: /openvox-server/latest/config_file_auth.html
 [deprecated]: ./deprecated_settings.html#authorization-rules-in-fileserverconf

--- a/docs/_openvox_8x/config_important_settings.markdown
+++ b/docs/_openvox_8x/config_important_settings.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Configuration: Short list of important settings"
 ---
 
-[cli_settings]: ./config_about_settings.html#settings-can-be-set-on-the-command-line
+[cli_settings]: ./config_about_settings.html#settings-on-the-command-line
 [trusted_and_facts]: ./lang_facts_and_builtin_vars.html
 [config_reference]: ./configuration.html
 [environments]: ./environments_about.html
@@ -18,7 +18,7 @@ title: "Configuration: Short list of important settings"
 [write_reports]: ./reporting_write_processors.html
 [passenger_headers]: ./passenger.html#notes-on-ssl-verification
 [puppetdb_install]: /openvoxdb/latest/connect_puppet_master.html
-[static_compiler]: ./indirection.html#staticcompiler-terminus
+[static_compiler]: ./static_catalogs.html
 [ssl_autosign]: ./ssl_autosign.html
 [structured_facts]: ./lang_facts_and_builtin_vars.html#data-types
 
@@ -82,7 +82,7 @@ title: "Configuration: Short list of important settings"
 [jvm_heap_config]: /openvox-server/latest/install_from_packages.html#memory-allocation
 [puppetserver_ca]: /openvox-server/latest/puppet_conf_setting_diffs.html#cahttpsdocspuppetcompuppetlatestreferenceconfigurationhtmlca
 [service_bootstrap]: /openvox-server/latest/configuration.html#service-bootstrapping
-[trusted_server_facts]: ./lang_facts_and_builtin_vars.html#serverfacts-variable
+[trusted_server_facts]: ./lang_facts_and_builtin_vars.html#server_facts-variable
 [always_retry_plugins]: ./configuration.html#always_retry_plugins
 [sourceaddress]: ./configuration.html#sourceaddress
 
@@ -175,7 +175,7 @@ These features configure add-ons and optional features.
 
 * [`node_terminus`][node_terminus] and [`external_nodes`][external_nodes] --- The ENC settings. If you're using an [ENC][], set these to `exec` and the path to your ENC script, respectively.
 * [`storeconfigs`][storeconfigs] and [`storeconfigs_backend`][storeconfigs_backend] --- Used for setting up PuppetDB. See [the PuppetDB docs for details.][puppetdb_install]
-* [`catalog_terminus`][catalog_terminus] --- This can enable the optional static compiler. If you have lots of `file` resources in your manifests, the static compiler lets you sacrifice some extra CPU work on your OpenVox Server to gain faster configuration and reduced HTTPS traffic on your agents. [See the "static compiler" section of the indirection reference][static_compiler] for details.
+* [`catalog_terminus`][catalog_terminus] --- This can enable the optional static compiler. If you have lots of `file` resources in your manifests, the static compiler lets you sacrifice some extra CPU work on your OpenVox Server to gain faster configuration and reduced HTTPS traffic on your agents. [See the static catalogs page][static_compiler] for details.
 
 ### CA settings
 

--- a/docs/_openvox_8x/file_serving.markdown
+++ b/docs/_openvox_8x/file_serving.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "Adding file server mount points"
 ---
 
-[module_files]: ./modules_fundamentals.html#files
+[module_files]: ./modules_fundamentals.html#files-in-modules
 [fileserver.conf]: ./config_file_fileserver.html
 [deprecated]: ./deprecated_settings.html#authorization-rules-in-fileserverconf
 [auth.conf]: /openvox-server/latest/config_file_auth.html

--- a/docs/_openvox_8x/functions_ruby_implementation.md
+++ b/docs/_openvox_8x/functions_ruby_implementation.md
@@ -10,7 +10,7 @@ title: "Writing functions in Ruby: Using special features in implementation meth
 [variables]: ./lang_variables.html
 [facts]: ./lang_facts_and_builtin_vars.html
 [trusted data]: ./lang_facts_and_builtin_vars.html#trusted-facts
-[server data]: ./lang_facts_and_builtin_vars.html#serverfacts-variable
+[server data]: ./lang_facts_and_builtin_vars.html#server_facts-variable
 [lambdas]: ./lang_lambdas.html
 [proc]: https://ruby-doc.org/core/Proc.html
 

--- a/docs/_openvox_8x/hiera_merging.md
+++ b/docs/_openvox_8x/hiera_merging.md
@@ -7,9 +7,9 @@ title: "Creating and editing data"
 [automatic]: ./hiera_automatic.html
 [data types]: ./lang_data.html
 [interpolation_puppet]: ./lang_data_string.html#interpolation
-[facts_hash]: ./lang_facts_and_builtin_vars.html#the-factsfactname-hash
+[facts_hash]: ./lang_facts_and_builtin_vars.html#the-factsfact_name-hash
 [trusted]: ./lang_facts_and_builtin_vars.html#trusted-facts
-[server_facts]: ./lang_facts_and_builtin_vars.html#serverfacts-variable
+[server_facts]: ./lang_facts_and_builtin_vars.html#server_facts-variable
 [environment]: ./environments_about.html
 
 ## Setting the merge behavior for a lookup

--- a/docs/_openvox_8x/lang_data_type.md
+++ b/docs/_openvox_8x/lang_data_type.md
@@ -10,7 +10,7 @@ title: "Language: Data types: Data type syntax"
 [selector expressions]: ./lang_conditional.html#selectors
 [match_operator]: ./lang_expressions.html#regex-or-data-type-match
 [strings]: ./lang_data_string.html
-[assert_type]: ./function.html#asserttype
+[assert_type]: ./function.html#assert_type
 [number]: ./lang_data_number.html
 [boolean]: ./lang_data_boolean.html
 [array]: ./lang_data_array.html

--- a/docs/_openvox_8x/lang_expressions.markdown
+++ b/docs/_openvox_8x/lang_expressions.markdown
@@ -162,7 +162,7 @@ Comparisons of [string][strings] values are case insensitive for characters in t
 
 Characters are compared based on their encoding. This means that for characters in the US ASCII range, punctuation comes before digits, digits are in the order 0, 1, 2, ... 9, and letters are in alphabetical order. For characters outside US ASCII, ordering is defined by their UTF-8 character code, which might not always place them in alphabetical order for a given locale.
 
-### `==` (equality)
+### `==` (equality) {#equality}
 
 Resolves to `true` if the operands are equal. Accepts the following data types as operands:
 
@@ -204,7 +204,7 @@ Resolves to `true` if the left operand is bigger than or equal to the right oper
 
 When acting on data types, `>=` is true if the left operand is the same as the right operand or a _superset_ of it.
 
-### `=~` (regex or data type match)
+### `=~` (regex or data type match) {#regex-or-data-type-match}
 
 Resolves to `true` if the left operand **matches** the right operand. "Match" can mean two different things, depending on what the right operand is.
 
@@ -316,7 +316,7 @@ Arithmetic Operators have the following traits:
 
 Resolves to the sum of the two operands.
 
-### `-` (subtraction and negation)
+### `-` (subtraction and negation) {#subtraction-and-negation}
 
 Resolves to the difference of the two operands.
 
@@ -347,7 +347,7 @@ Array Operators
 
 Array operators take [arrays][] as operands; with the exception of `*` (unary splat), they resolve to array values.
 
-### `*` (splat)
+### `*` (splat) {#splat}
 
 This unary operator accepts a single [array][arrays] value. (If given a scalar value, it will convert it to a single-element array first.)
 
@@ -435,7 +435,7 @@ Hash operators take:
 
 They resolve to hash values.
 
-### `+` (merging)
+### `+` (merging) {#merging}
 
 Resolves to a hash containing the keys and values in the left operand _plus_ the keys and values in the right operand; if any keys are present in both operands, the final hash will use the value from the right. It does not merge hashes recursively; it only merges top-level keys.
 

--- a/docs/_openvox_8x/lang_summary.markdown
+++ b/docs/_openvox_8x/lang_summary.markdown
@@ -9,7 +9,7 @@ title: "Language: Basics"
 [autoload]: ./lang_namespaces.html#autoloader-behavior
 [config]: ./config_file_main.html
 [usecacheonfailure]: ./configuration.html#usecacheonfailure
-[fileserve]: ./modules_fundamentals.html#files
+[fileserve]: ./modules_fundamentals.html#files-in-modules
 [classes]: ./lang_classes.html
 [enc]: ./nodes_external.html
 [resources]: ./lang_resources.html

--- a/docs/_openvox_8x/modules_metadata.md
+++ b/docs/_openvox_8x/modules_metadata.md
@@ -88,7 +88,7 @@ After you've created your module and gone through the metadata dialog, you must 
 {:.section}
 ## Specifying Puppet version requirements in modules 
 
-[inpage_require]: #specifying-puppet-version-requirements-in-module
+[inpage_require]: #specifying-puppet-version-requirements-in-modules
 
 The `requirements` key specifies external requirements for the module, particularly the Puppet version required. Although you can express any requirement here, the Puppet Forge module pages and search function support only the "puppet" requirement for Puppet version.
 

--- a/docs/_openvox_8x/modules_publishing.markdown
+++ b/docs/_openvox_8x/modules_publishing.markdown
@@ -252,4 +252,4 @@ If you select the deleted release, a warning banner appears on the page with the
 
 Related topics:
 
-* [Installing modules](./modules_installing.html#installing-modules)
+* [Installing modules](./modules_installing.html#installing-modules-from-the-command-line)

--- a/docs/_openvox_8x/quick_start_firewall.markdown
+++ b/docs/_openvox_8x/quick_start_firewall.markdown
@@ -51,7 +51,7 @@ You should see output similar to the following:
 
 ## Write the `my_firewall` module
 
-[inpage_write]: #write-the-myfirewall-module
+[inpage_write]: #write-the-my_firewall-module
 
 Some modules can be large, complex, and require a significant amount of trial and error. This module, however, will be a very simple module to write. It contains just three classes.
 
@@ -172,7 +172,7 @@ Modules are directory trees. For this task, you'll create the following files:
 
 ## Enforce the desired state of the `my_firewall` class
 
-[inpage_enforce]: #enforce-the-desired-state-of-the-myfirewall-class
+[inpage_enforce]: #enforce-the-desired-state-of-the-my_firewall-class
 
 Lastly, let's take a look at how Puppet ensures the desired state of the `my_firewall` class on your agents. In the previous task, you applied your firewall class. Now imagine a scenario where a member of your team changes the contents of the `iptables` to allow connections on a random port that was not specified in `my_firewall`.
 

--- a/docs/_openvox_8x/resources_file_windows.markdown
+++ b/docs/_openvox_8x/resources_file_windows.markdown
@@ -43,7 +43,7 @@ Windows NTFS filesystems are case-insensitive (albeit case-preserving); Puppet i
 
 To manage files properly, Puppet needs the "Create symbolic links" (Vista/2008 and up), "Back up files and directories," and "Restore files and directories" privileges. The easiest way to handle this is:
 
-* When Puppet runs as a service, make sure its user account is a member of the local `Administrators` group.  When you use the [`PUPPET_AGENT_ACCOUNT_USER` parameter](./install_windows.html#puppetagentaccountuser) with the MSI installer, the user will automatically be added to the administrators group.
+* When Puppet runs as a service, make sure its user account is a member of the local `Administrators` group.  When you use the [`PUPPET_AGENT_ACCOUNT_USER` parameter](./install_windows.html#puppet_agent_account_user) with the MSI installer, the user will automatically be added to the administrators group.
 * Before running Puppet interactively (on Vista/2008 and up), be sure to start the command prompt window with elevated privileges by right-clicking on the start menu and choosing "Run as Administrator."
 
 ## Managing file permissions

--- a/docs/_openvox_8x/services_apply.markdown
+++ b/docs/_openvox_8x/services_apply.markdown
@@ -20,7 +20,7 @@ title: "Puppet's services: Puppet apply"
 [puppet.conf]: ./config_file_main.html
 [short_settings]: ./config_important_settings.html#settings-for-agents-all-nodes
 
-Puppet apply is an application that compiles and manages configurations on nodes. It acts like a self-contained combination of the OpenVox Server and OpenVox agent applications. For more info about Puppet's architecture, see [Overview of Puppet's Architecture](./architecture.html) --- in particular, read the note at the end about [differences and trade-offs between agent/master and puppet apply.](architecture.html#note-differences-between-agentmaster-and-puppet-apply)
+Puppet apply is an application that compiles and manages configurations on nodes. It acts like a self-contained combination of the OpenVox Server and OpenVox agent applications. For more info about Puppet's architecture, see [Overview of Puppet's Architecture](./architecture.html) --- in particular, read the note at the end about [differences and trade-offs between agent/master and puppet apply.](architecture.html#differences-between-agent-server-and-stand-alone)
 
 For details about invoking the Puppet apply command, see [the puppet apply man page][man].
 

--- a/docs/_openvox_8x/ssl_attributes_extensions.markdown
+++ b/docs/_openvox_8x/ssl_attributes_extensions.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "SSL configuration: CSR attributes and certificate extensions"
 ---
 
-[cert_request]: subsystem_agent_server_comm.html#check-for-keys-and-certificates
+[cert_request]: subsystem_agent_server_comm.html#the-process-of-agent-side-checks-and-https-requests-during-a-single-agent-run
 [csr_attributes]: configuration.html#csr_attributes
 [confdir]: configuration.html#confdir
 [autosign_policy]: ssl_autosign.html#policy-based-autosigning

--- a/docs/_openvox_8x/style_guide.markdown
+++ b/docs/_openvox_8x/style_guide.markdown
@@ -815,7 +815,7 @@ You should help indicate to the user which classes are which by making sure all 
 
 ### Chaining arrow syntax
 
-Most of the time, use [relationship metaparameters](./lang_relationships.html#relationship-metaparameters) rather than [chaining arrows](./lang_relationships.html#chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
+Most of the time, use [relationship metaparameters](./lang_relationships.html#syntax-relationship-metaparameters) rather than [chaining arrows](./lang_relationships.html#syntax-chaining-arrows). When you have many [interdependent or order-specific items](https://github.com/puppetlabs/puppetlabs-mysql/blob/3.1.0/manifests/server.pp#L64-L72), chaining syntax may be used. A chain operator should appear on the same line as its right-hand operand. Chaining arrows must be used left to right.
 
 **Good:**
 


### PR DESCRIPTION
## What

Fixes links whose **target page exists but whose `#fragment` drifted** — workstream **F** of #262. Each new anchor was verified against the built page's actual kramdown id (`htmlproofer … --checks Links`).

## Anchor renames (link → current id)

| Target page | Old | New |
|---|---|---|
| `lang_relationships` | `#chaining-arrows` / `#relationship-metaparameters` | `#syntax-chaining-arrows` / `#syntax-relationship-metaparameters` |
| `lang_facts_and_builtin_vars` | `#serverfacts-variable` / `#the-factsfactname-hash` | `#server_facts-variable` / `#the-factsfact_name-hash` |
| `modules_fundamentals` | `#files` | `#files-in-modules` |
| `function` | `#asserttype` | `#assert_type` |
| `install_windows` | `#puppetagentaccountuser` | `#puppet_agent_account_user` |
| `config_about_settings` | `#settings-can-be-set-on-the-command-line` | `#settings-on-the-command-line` |
| `architecture` | `#note-differences-between-agentmaster-and-puppet-apply` | `#differences-between-agent-server-and-stand-alone` |
| `style_guide` | `#module-documentation` | `#documentation` |
| `modules_metadata` | `…requirements-in-module` | `…requirements-in-modules` |
| `modules_installing` | `#installing-modules` | `#installing-modules-from-the-command-line` |
| `quick_start_firewall` | `…myfirewall…` | `…my_firewall…` |

Plus two repoints where the original section was removed/restructured:
- `ssl_attributes_extensions` → `subsystem_agent_server_comm.html#check-for-keys-and-certificates` repointed to the page's current section id (page rewritten in #256).
- `config_important_settings` → the static-compiler link repointed from the removed `indirection.html#staticcompiler-terminus` to the `static_catalogs` page (its modern home).

## lang_expressions operator headings

The comparison/arithmetic/hash operator headings start with a code span (e.g. `### \`==\` (equality)`), so kramdown auto-generated **leading-hyphen ids** (`-equality`, `--subtraction-and-negation`, `-splat`, …) that the clean-form inbound links never matched. Added explicit `{#equality}`, `{#regex-or-data-type-match}`, `{#subtraction-and-negation}`, `{#splat}`, `{#merging}` so the links resolve and the anchors are stable.

## Verification

`htmlproofer _site/openvox/latest --disable-external --checks Links`: **all F-scope anchor failures resolved.** `jekyll build` clean. Diff is anchor-only (16 files, 25/25 lines).

## Out of scope (remaining hash failures, for E / content cleanup)

- Moved core types — `type.html#cron` / `#host` / `#mount` / `#scheduledtask` + the `cron-attribute-*` family (now in the `puppetlabs-*_core` modules, not core `type.html`).
- Removed settings — `configuration.html#ca` / `#ordering` / `#capass` / etc.
- The removed LDAP node terminus (`indirection.html#ldap-terminus`).
- Two cross-collection `openvox-server` anchors.

Part of #262
