### PR TITLE
docs: migrate/repoint un-migrated links in openvox 8x (#262 E)

### DIFF
--- a/docs/_openvox_8x/architecture.markdown
+++ b/docs/_openvox_8x/architecture.markdown
@@ -6,7 +6,7 @@ title: "Overview of OpenVox's architecture"
 [agent_unix]: services_agent_unix.html
 [agent_win]: services_agent_windows.html
 [https_walkthrough]: subsystem_agent_server_comm.html
-[server_http]: http_api/http_api_index.html
+[server_http]: /openvox-server/latest/http_api_index.html
 [auth.conf]: config_file_auth.html
 [catalog_compilation]: subsystem_catalog_compilation.html
 [report handlers]: report.html

--- a/docs/_openvox_8x/cheatsheet_core_types.md
+++ b/docs/_openvox_8x/cheatsheet_core_types.md
@@ -8,7 +8,6 @@ title: Core types cheat sheet
 [package]: ./type.html#package
 [service]: ./type.html#service
 [exec]: ./type.html#exec
-[cron]: https://forge.puppet.com/modules/puppetlabs/cron_core/reference#cron
 [user]: ./type.html#user
 [group]: ./type.html#group
 [other]: ./type.html
@@ -187,32 +186,6 @@ Executes an arbitrary command on the agent node. When using execs, you must eith
 #### Other Notable Attributes:
 
 [`cwd`](./type.html#exec-attribute-cwd), [`group`](./type.html#exec-attribute-group), [`logoutput`](./type.html#exec-attribute-logoutput), , [`timeout`](./type.html#exec-attribute-timeout), [`tries`](./type.html#exec-attribute-tries), [`try_sleep`](./type.html#exec-attribute-try_sleep), [`user`](./type.html#exec-attribute-user).
-
-{:.concept}
-### [cron][]
-
-Manages cron jobs. Largely self-explanatory. On Windows, you should use [`scheduled_task`](https://forge.puppet.com/modules/puppetlabs/scheduled_task/reference#scheduled_task) instead.
-
-    cron { 'logrotate':
-      command => '/usr/sbin/logrotate',
-      user    => 'root',
-      hour    => 2,
-      minute  => 0,
-    }
-
-{:.section}
-#### Important Attributes
-
-* [`command`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#command) -- The command to execute.
-* [`ensure`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#ensure) -- Whether the job should exist.
-    * present
-    * absent
-* [`hour`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#hour), [`minute`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#minute), [`month`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#month), [`monthday`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#monthday), and [`weekday`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#weekday) -- The timing of the cron job.
-
-{:.section}
-#### Other Notable Attributes
-
-[`environment`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#environment), [`name`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#-cron--name), [`special`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#special), [`target`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#target), [`user`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#user).
 
 {:.concept}
 ### [user][]

--- a/docs/_openvox_8x/cheatsheet_core_types.md
+++ b/docs/_openvox_8x/cheatsheet_core_types.md
@@ -8,7 +8,7 @@ title: Core types cheat sheet
 [package]: ./type.html#package
 [service]: ./type.html#service
 [exec]: ./type.html#exec
-[cron]: ./type.html#cron
+[cron]: https://forge.puppet.com/modules/puppetlabs/cron_core/reference#cron
 [user]: ./type.html#user
 [group]: ./type.html#group
 [other]: ./type.html
@@ -191,7 +191,7 @@ Executes an arbitrary command on the agent node. When using execs, you must eith
 {:.concept}
 ### [cron][]
 
-Manages cron jobs. Largely self-explanatory. On Windows, you should use [`scheduled_task`](./type.html#scheduledtask) instead.
+Manages cron jobs. Largely self-explanatory. On Windows, you should use [`scheduled_task`](https://forge.puppet.com/modules/puppetlabs/scheduled_task/reference#scheduled_task) instead.
 
     cron { 'logrotate':
       command => '/usr/sbin/logrotate',
@@ -203,16 +203,16 @@ Manages cron jobs. Largely self-explanatory. On Windows, you should use [`schedu
 {:.section}
 #### Important Attributes
 
-* [`command`](./type.html#cron-attribute-command) -- The command to execute.
-* [`ensure`](./type.html#cron-attribute-ensure) -- Whether the job should exist.
+* [`command`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#command) -- The command to execute.
+* [`ensure`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#ensure) -- Whether the job should exist.
     * present
     * absent
-* [`hour`](./type.html#cron-attribute-hour), [`minute`](./type.html#cron-attribute-minute), [`month`](./type.html#cron-attribute-month), [`monthday`](./type.html#cron-attribute-monthday), and [`weekday`](./type.html#cron-attribute-weekday) -- The timing of the cron job.
+* [`hour`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#hour), [`minute`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#minute), [`month`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#month), [`monthday`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#monthday), and [`weekday`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#weekday) -- The timing of the cron job.
 
 {:.section}
 #### Other Notable Attributes
 
-[`environment`](./type.html#cron-attribute-environment), [`name`](./type.html#cron-attribute-name), [`special`](./type.html#cron-attribute-special), [`target`](./type.html#cron-attribute-target), [`user`](./type.html#cron-attribute-user).
+[`environment`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#environment), [`name`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#-cron--name), [`special`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#special), [`target`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#target), [`user`](https://forge.puppet.com/modules/puppetlabs/cron_core/reference#user).
 
 {:.concept}
 ### [user][]

--- a/docs/_openvox_8x/config_about_settings.markdown
+++ b/docs/_openvox_8x/config_about_settings.markdown
@@ -179,6 +179,6 @@ Set-WinSystemLocale en-US
 {:.task}
 ### Disabling internationalized strings
 
-Puppet 5.3.2 added the optional Boolean `disable_i18n` setting, which you can configure in `puppet.conf`. If set to `true`, Puppet disables localized strings in log messages, reports, and parts of the command-line interface. This can improve performance when using Puppet modules, especially if [environment caching](./environments_creating.markdown#environment_timeout) is disabled, and even if you don't need localized strings or the modules aren't localized. This setting is `false` by default in open source Puppet.
+Puppet 5.3.2 added the optional Boolean `disable_i18n` setting, which you can configure in `puppet.conf`. If set to `true`, Puppet disables localized strings in log messages, reports, and parts of the command-line interface. This can improve performance when using Puppet modules, especially if [environment caching](./configuration.html#environment_timeout) is disabled, and even if you don't need localized strings or the modules aren't localized. This setting is `false` by default in open source Puppet.
 
 If you're experiencing performance issues, configure this setting in the `[server]` section of the OpenVox Server's `puppet.conf` file. To force unlocalized messages, which are in English by default, configure this section in a node's `[main]` or `[user]` sections of `puppet.conf`.

--- a/docs/_openvox_8x/config_file_auth.markdown
+++ b/docs/_openvox_8x/config_file_auth.markdown
@@ -3,8 +3,7 @@ layout: default
 title: "Config files: auth.conf (LEGACY)"
 ---
 
-[rest_authconfig]: ./configuration.html#restauthconfig
-[api]: ./http_api/http_api_index.html
+[api]: /openvox-server/latest/http_api_index.html
 [default_file]: https://github.com/puppetlabs/puppet/blob/4.3.0/conf/auth.conf
 [environment]: ./environments_about.html
 [server_ca]: /openvox-server/latest/config_file_ca.html
@@ -40,7 +39,7 @@ Because some endpoints should have restricted access (for example, a node should
 
 ## Location
 
-The `auth.conf` file is located at `$confdir/auth.conf` by default. Its location is configurable with the [`rest_authconfig` setting][rest_authconfig].
+The `auth.conf` file is located at `$confdir/auth.conf` by default.
 
 The location of the `confdir` depends on your OS. [See the confdir documentation for details.][confdir]
 

--- a/docs/_openvox_8x/config_file_environment.markdown
+++ b/docs/_openvox_8x/config_file_environment.markdown
@@ -9,7 +9,7 @@ title: "Config files: environment.conf"
 [puppet.conf]: ./config_file_main.html
 [basemodulepath]: configuration.html#basemodulepath
 [main manifest]: ./dirs_manifest.html
-[configuring_timeout]: ./environments_configuring.html#environmenttimeout
+[configuring_timeout]: ./configuration.html#environment_timeout
 
 Any [environment][] can contain an `environment.conf` file. This file can override several settings whenever the OpenVox Server is serving nodes assigned to that environment.
 

--- a/docs/_openvox_8x/config_file_fileserver.markdown
+++ b/docs/_openvox_8x/config_file_fileserver.markdown
@@ -7,7 +7,6 @@ title: "Config files: fileserver.conf"
 [module_files]: ./modules_fundamentals.html#files-in-modules
 [fileserverconfig]: ./configuration.html#fileserverconfig
 [auth_conf]: /openvox-server/latest/config_file_auth.html
-[deprecated]: ./deprecated_settings.html#authorization-rules-in-fileserverconf
 [custom_mount]: ./file_serving.html
 [mount_auth_examples]: ./file_serving.html#controlling-access-to-a-custom-mount-point-in-authconf
 

--- a/docs/_openvox_8x/config_file_main.markdown
+++ b/docs/_openvox_8x/config_file_main.markdown
@@ -7,7 +7,7 @@ title: "Config files: The main config file (puppet.conf)"
 [about]: ./config_about_settings.html
 [short]: ./config_important_settings.html
 [config]: ./configuration.html#config
-[subcommands]: ./man/
+[subcommands]: ./man/overview.html
 [reports]: ./configuration.html#reports
 [modulepath]: ./configuration.html#modulepath
 [ssldir]: ./configuration.html#ssldir

--- a/docs/_openvox_8x/config_file_puppetdb.markdown
+++ b/docs/_openvox_8x/config_file_puppetdb.markdown
@@ -6,7 +6,7 @@ title: "Config files: puppetdb.conf"
 [puppetdb_connection]: /openvoxdb/latest/puppetdb_connection.html
 
 
-The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/openvoxdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your OpenVox Server to it](/openvoxdb/latest/connect_puppet_master.html).
+The `puppetdb.conf` file configures how Puppet should connect to one or more [PuppetDB](/openvoxdb/latest/) servers. It is only used if you are using PuppetDB and have [connected your OpenVox Server to it](/openvoxdb/latest/connect_puppet_server.html).
 
 ## PuppetDB documentation
 

--- a/docs/_openvox_8x/config_important_settings.markdown
+++ b/docs/_openvox_8x/config_important_settings.markdown
@@ -16,8 +16,7 @@ title: "Configuration: Short list of important settings"
 [manifest_dir]: ./dirs_manifest.html
 [report_reference]: ./report.html
 [write_reports]: ./reporting_write_processors.html
-[passenger_headers]: ./passenger.html#notes-on-ssl-verification
-[puppetdb_install]: /openvoxdb/latest/connect_puppet_master.html
+[puppetdb_install]: /openvoxdb/latest/connect_puppet_server.html
 [static_compiler]: ./static_catalogs.html
 [ssl_autosign]: ./ssl_autosign.html
 [structured_facts]: ./lang_facts_and_builtin_vars.html#data-types
@@ -26,7 +25,6 @@ title: "Configuration: Short list of important settings"
 [immutable_node_data]: ./configuration.html#immutablenodedata
 [strict_variables]: ./configuration.html#strict_variables
 [stringify_facts]: ./configuration.html#stringifyfacts
-[ordering]: ./configuration.html#ordering
 [reports]: ./configuration.html#reports
 [parser]: ./configuration.html#parser
 [server]: ./configuration.html#server
@@ -59,31 +57,26 @@ title: "Configuration: Short list of important settings"
 [basemodulepath]: ./configuration.html#basemodulepath
 [modulepath]: ./configuration.html#modulepath
 [manifest]: ./configuration.html#manifest
-[ssl_client_header]: ./configuration.html#ssl_client_header
-[ssl_client_verify_header]: ./configuration.html#ssl_client_verify_header
 [node_terminus]: ./configuration.html#node_terminus
 [external_nodes]: ./configuration.html#external_nodes
 [storeconfigs]: ./configuration.html#storeconfigs
 [storeconfigs_backend]: ./configuration.html#storeconfigs_backend
 [catalog_terminus]: ./configuration.html#catalog_terminus
 [config_version]: ./configuration.html#config_version
-[ca]: ./configuration.html#ca
 [ca_ttl]: ./configuration.html#ca_ttl
 [autosign]: ./configuration.html#autosign
 [environmentpath]: ./configuration.html#environmentpath
 [environment.conf]: ./config_file_environment.html
-[alwayscachefeatures]: ./configuration.html#alwayscachefeatures
 [environment_timeout]: ./configuration.html#environment_timeout
-[configuring_timeout]: ./environments_configuring.html#environmenttimeout
+[configuring_timeout]: ./configuration.html#environment_timeout
 [puppetserver_config_files]: /openvox-server/latest/configuration.html
 [settings_diffs]: /openvox-server/latest/puppet_conf_setting_diffs.html
 [puppet_admin]: /openvox-server/latest/config_file_puppetserver.html
 [jruby_puppet]: /openvox-server/latest/tuning_guide.html#puppet-server-and-jruby
-[jvm_heap_config]: /openvox-server/latest/install_from_packages.html#memory-allocation
-[puppetserver_ca]: /openvox-server/latest/puppet_conf_setting_diffs.html#cahttpsdocspuppetcompuppetlatestreferenceconfigurationhtmlca
+[jvm_heap_config]: /openvox-server/latest/install_from_packages.html
+[puppetserver_ca]: /openvox-server/latest/puppet_conf_setting_diffs.html
 [service_bootstrap]: /openvox-server/latest/configuration.html#service-bootstrapping
 [trusted_server_facts]: ./lang_facts_and_builtin_vars.html#server_facts-variable
-[always_retry_plugins]: ./configuration.html#always_retry_plugins
 [sourceaddress]: ./configuration.html#sourceaddress
 
 Puppet has about 200 settings, all of which are listed in the [configuration reference][config_reference]. Most users can ignore about 170 of those.
@@ -164,11 +157,6 @@ Puppet Server has [its own configuration files][puppetserver_config_files]; cons
 * [`jruby-puppet`][jruby_puppet] --- Provides details on tuning JRuby for better performance.
 * [`JAVA_ARGS`][jvm_heap_config] --- Instructions on tuning the Puppet Server memory allocation.
 
-### Rack related settings
-
-* [`ssl_client_header`][ssl_client_header] and [`ssl_client_verify_header`][ssl_client_verify_header] --- These are used when running OpenVox Server as a Rack application, a method deprecated in favor of running Puppet Server. See [the Passenger setup guide][passenger_headers] for more context about how these settings work; depending on how you configure your Rack server, you can usually leave these settings with their default values.
-* [`always_retry_plugins`][always_retry_plugins] --- If this setting is set to false, then types and features will only be checked once, and if they are not available, the negative result is cached and returned for all subsequent attempts to load the type or feature. This replaces the [`always_cache_features`][alwayscachefeatures] setting.
-
 ### Extensions
 
 These features configure add-ons and optional features.
@@ -179,9 +167,7 @@ These features configure add-ons and optional features.
 
 ### CA settings
 
-* [`ca`][ca] --- Whether to act as a CA. **There should only be one CA at a Puppet deployment.** If you're using [multiple OpenVox Servers][multi_master], you'll need to set `ca = false` on all but one of them.
-
-   Note that the `ca` setting is not valid for Puppet Server. Refer to these sections about the [Puppet Server `ca`][puppetserver_ca] and [service bootstrapping][service_bootstrap].
+* **Acting as a CA** --- OpenVox Server provides the certificate authority, run as a JRuby service rather than a `ca` setting. There should be only one CA in a deployment, so in a [multi-server][multi_master] setup you disable the CA service on all but one node via [service bootstrapping][service_bootstrap] (the `ca.cfg` file). See also the [OpenVox Server `ca` settings][puppetserver_ca].
 
 * [`ca_ttl`][ca_ttl] --- How long newly signed certificates should be valid for.
 * [`autosign`][autosign] --- Whether (and how) to autosign certificates. See [the autosigning page][ssl_autosign] for details.

--- a/docs/_openvox_8x/config_ssl_external_ca.markdown
+++ b/docs/_openvox_8x/config_ssl_external_ca.markdown
@@ -105,5 +105,5 @@ Root certificate revocation list  | `puppet config print hostcrl --section agent
 ## Option 2: Puppet Server functioning as an intermediate CA
 
 Puppet Server can operate as an intermediate CA to an external root CA. Please
-refer to [Using Puppet Server as an intermediate certificate authority](/openvox-server/latest/intermediate_ca_configuration.html)
+refer to [Using Puppet Server as an intermediate certificate authority](/openvox-server/latest/intermediate_ca.html)
 for a complete walk through of setting it up.

--- a/docs/_openvox_8x/dirs_codedir.markdown
+++ b/docs/_openvox_8x/dirs_codedir.markdown
@@ -48,5 +48,5 @@ Almost everything in the codedir has its own page of documentation.
 {:.section}
 ### Code and Data Directories
 
-* [`environments`](./environments_configuring.html) --- contains alternate versions of the `modules` and `manifests` directories, to allow code changes to be tested on smaller sets of nodes before entering production.
+* [`environments`](./environments_creating.html) --- contains alternate versions of the `modules` and `manifests` directories, to allow code changes to be tested on smaller sets of nodes before entering production.
 * [`modules`](./dirs_modulepath.html) --- the main directory for Puppet's modules.

--- a/docs/_openvox_8x/dirs_manifest.markdown
+++ b/docs/_openvox_8x/dirs_manifest.markdown
@@ -13,7 +13,7 @@ title: "Directories: The main manifest"
 [disable_per_environment_manifest]: ./configuration.html#disable_per_environment_manifest
 [environment.conf]: ./config_file_environment.html
 [puppet.conf]: ./config_file_main.html
-[configuring environments]: ./environments_configuring.html
+[configuring environments]: ./environments_creating.html
 [creating environments]: ./environments_creating.html
 
 Puppet always starts compiling with either a single manifest file or a directory of manifests that get treated like a single file. This main starting point is called the **main manifest** or **site manifest.**

--- a/docs/_openvox_8x/dirs_modulepath.markdown
+++ b/docs/_openvox_8x/dirs_modulepath.markdown
@@ -118,4 +118,4 @@ For most content, this earliest-module-wins behavior is on an all-or-nothing, **
 >
 > The upshot is, if you refactor a module's Ruby plugins and then maintain two versions of that module in your modulepath, it can sometimes result in weirdness.
 >
-> This is essentially the same Ruby loading problem that environments have, [as described elsewhere in this manual](./environments_limitations.html#plugins-running-on-the-puppet-master-are-weird). It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.
+> This is essentially the same Ruby loading problem that environments have. It's not intentional, but it's not likely to get fixed soon, since it's a byproduct of the way Ruby works and Puppet only has a limited amount of control over it.

--- a/docs/_openvox_8x/dirs_ssldir.markdown
+++ b/docs/_openvox_8x/dirs_ssldir.markdown
@@ -11,8 +11,6 @@ title: "Directories: SSLdir"
 [cakey]: ./configuration.html#cakey
 [capub]: ./configuration.html#capub
 [cert_inventory]: ./configuration.html#cert_inventory
-[caprivatedir]: ./configuration.html#caprivatedir
-[capass]: ./configuration.html#capass
 [csrdir]: ./configuration.html#csrdir
 [serial]: ./configuration.html#serial
 [signeddir]: ./configuration.html#signeddir
@@ -74,8 +72,8 @@ The `ssldir` has the following structure:
     * `ca_key.pem` --- The CA's private key. Tied for most security-critical file in the entire Puppet certificate infrastructure. Mode: 0640. Setting: [`cakey`][cakey].
     * `ca_pub.pem` --- The CA's public key. Mode: 0644. Setting: [`capub`][capub].
     * `inventory.txt` --- A list of all certificates the CA has signed, along with their serial numbers and validity periods. Mode: 0644. Setting: [`cert_inventory`][cert_inventory].
-    * `private` _(directory)_ --- Contains only one file. Mode: 0750. Setting: [`caprivatedir`][caprivatedir].
-        * `ca.pass` --- The (randomly generated) password to the CA's private key. Tied for most security-critical file in the entire Puppet certificate infrastructure. Mode: 0640. Setting: [`capass`][capass].
+    * `private` _(directory)_ --- Contains only one file. Mode: 0750. Setting: `caprivatedir`.
+        * `ca.pass` --- The (randomly generated) password to the CA's private key. Tied for most security-critical file in the entire Puppet certificate infrastructure. Mode: 0640. Setting: `capass`.
     * `requests` _(directory)_ --- Contains certificate signing requests (CSRs) that were received but have not yet been signed. The CA deletes CSRs from this directory after signing them. Mode: 0755. Setting: [`csrdir`][csrdir].
         * `<name>.pem` --- Individual CSR files.
     * `serial` --- A file containing the serial number for the next certificate the CA will sign. This is incremented with each new certificate signed. Mode: 0644. Setting: [`serial`][serial].

--- a/docs/_openvox_8x/dirs_vardir.markdown
+++ b/docs/_openvox_8x/dirs_vardir.markdown
@@ -64,7 +64,7 @@ The `vardir` directory has the following default structure. Most of the files an
 * [`facts.d` (`pluginfactdest`)][pluginfactdest]
 * [`lib` (`libdir`)][libdir] (also [plugindest][]) --- Puppet uses this as a cache for plugins (custom facts, types and providers, functions) synced from an OpenVox Server. Do not directly change it. If you delete it, the plugins will be restored on the next Puppet run.
 * [`puppet-module` (`module_working_dir`)][module_working_dir]
-    * [`skeleton` (`module_skeleton_dir`)][module_skeleton_dir]
+    * `skeleton` (`module_skeleton_dir`)
 * [`reports` (`reportdir`)][reportdir] --- When the `store` report is enabled, an OpenVox Server will store all reports received from agents as YAML files in this directory. These can be easily mined for analysis by an out-of-band process.
 * [`server_data` (`serverdatadir`)][serverdatadir]
 * [`state` (`statedir`)][statedir]
@@ -88,7 +88,6 @@ The `vardir` directory has the following default structure. Most of the files an
 [libdir]: ./configuration.html#libdir
 [plugindest]: ./configuration.html#plugindest
 [module_working_dir]: ./configuration.html#module_working_dir
-[module_skeleton_dir]: ./configuration.html#moduleskeletondir
 [logdir]: ./configuration.html#logdir
 [httplog]: ./configuration.html#httplog
 [masterhttplog]: ./configuration.html#masterhttplog

--- a/docs/_openvox_8x/file_serving.markdown
+++ b/docs/_openvox_8x/file_serving.markdown
@@ -5,7 +5,6 @@ title: "Adding file server mount points"
 
 [module_files]: ./modules_fundamentals.html#files-in-modules
 [fileserver.conf]: ./config_file_fileserver.html
-[deprecated]: ./deprecated_settings.html#authorization-rules-in-fileserverconf
 [auth.conf]: /openvox-server/latest/config_file_auth.html
 [auth_legacy]: ./config_file_auth.html
 [disable_legacy]: /openvox-server/latest/config_file_puppetserver.html
@@ -58,7 +57,7 @@ In the example above, a file at `/etc/puppetlabs/puppet/installer_files/oracle.p
 
 Make sure that the `puppet` user can access that directory and its contents.
 
-Always include the `allow *` line, since the default behavior is to deny all access. If you need to control access to a custom mount point, do so in [`auth.conf`][auth.conf]. [Putting authorization rules in `fileserver.conf` is deprecated.][deprecated]
+Always include the `allow *` line, since the default behavior is to deny all access. If you need to control access to a custom mount point, do so in [`auth.conf`][auth.conf]. Putting authorization rules in `fileserver.conf` is deprecated.
 
 > **Caution:** You should always restrict write access to mounted directories. The file server will follow any symlinks in a file server mount, including links to files that agent nodes should not access (like SSL keys).
 >

--- a/docs/_openvox_8x/functions_legacy.md
+++ b/docs/_openvox_8x/functions_legacy.md
@@ -175,7 +175,7 @@ manner to the `fail()` function:
 
 ## Referencing Custom Functions In Templates
 
-To call a custom function within a [Puppet Template](./templating.html), you can do:
+To call a custom function within a [Puppet Template](./lang_template.html), you can do:
 
     <%= scope.function_namegoeshere(["one","two"]) %>
 

--- a/docs/_openvox_8x/index.md
+++ b/docs/_openvox_8x/index.md
@@ -13,7 +13,7 @@ OpenVox is downstream-compatible with Puppet Open Source — existing manifests,
 
 OpenVox operates in two modes:
 
-**Agent/server** — Managed nodes run `openvox-agent` as a background service. Periodically, each agent sends facts (system inventory data) to an [OpenVox Server](../openvox-server/latest/), receives a compiled catalog, and enforces it. Results are reported back to the server. Communication is HTTPS with mutual TLS.
+**Agent/server** — Managed nodes run `openvox-agent` as a background service. Periodically, each agent sends facts (system inventory data) to an [OpenVox Server](/openvox-server/latest/), receives a compiled catalog, and enforces it. Results are reported back to the server. Communication is HTTPS with mutual TLS.
 
 **Standalone** — The `puppet apply` command compiles and applies a catalog locally, with no server required.
 

--- a/docs/_openvox_8x/lang_data_type.md
+++ b/docs/_openvox_8x/lang_data_type.md
@@ -207,4 +207,4 @@ Position | Parameter        | Data Type | Default Value | Description
 
 ## Related topics
 
--   [Type aliases](./lang_type_aliases.md)
+-   [Type aliases](./lang_type_aliases.html)

--- a/docs/_openvox_8x/lang_facts_and_builtin_vars.markdown
+++ b/docs/_openvox_8x/lang_facts_and_builtin_vars.markdown
@@ -10,12 +10,12 @@ title: "Language: Facts and built-in variables"
 [facter]: /openfact/latest
 [customfacts]: /openfact/latest/custom_facts.html
 [external facts]: /openfact/latest/custom_facts.html#external-facts
-[facterconfig]: /openfact/latest/configuring_facter.html
+[facterconfig]: /openfact/latest/configuring_openfact.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
 [noop]: ./configuration.html#noop
 [environment_setting]: ./configuration.html#environment
 [certname]: ./configuration.html#certname
-[puppetdb_facts]: /openvoxdb/latest/api/index.html
+[puppetdb_facts]: /openvoxdb/latest/api/overview.html
 [localscope]: ./lang_scope.html#local-scopes
 [trusted_on]: ./config_important_settings.html#getting-new-features-early
 [scope]: ./lang_scope.html

--- a/docs/_openvox_8x/lang_node_definitions.markdown
+++ b/docs/_openvox_8x/lang_node_definitions.markdown
@@ -14,7 +14,6 @@ title: "Language: Node definitions"
 [enc]: ./nodes_external.html
 [facts]: ./lang_variables.html#facts-and-built-in-variables
 [catalogs]: ./lang_summary.html#compilation-and-catalogs
-[strict]: ./configuration.html#stricthostnamechecking
 [conditional]: ./lang_conditional.html
 
 A **node definition** or **node statement** is a block of Puppet code that will only be included in matching nodes' [catalogs][]. This feature allows you to assign specific configurations to specific nodes.
@@ -124,20 +123,13 @@ A given node will only get the contents of **one** node definition, even if two 
 
 1. If there is a node definition with the node's exact name, Puppet will use it.
 2. If there is a regular expression node statement that matches the node's name, Puppet will use it. (If more than one regex node matches, Puppet will use one of them, with no guarantee as to which.)
-3. If the node's name looks like a fully qualified domain name (i.e. multiple period-separated groups of letters, numbers, underscores and dashes), Puppet will chop off the final group and start again at step 1. (That is, if a definition for `www01.example.com` isn't found, Puppet will look for a definition matching `www01.example`.)
-4. Puppet will use the `default` node.
+3. Puppet will use the `default` node.
 
 Thus, for the node `www01.example.com`, Puppet would try the following, in order:
 
 * `www01.example.com`
 * A regex that matches `www01.example.com`
-* `www01.example`
-* A regex that matches `www01.example`
-* `www01`
-* A regex that matches `www01`
 * `default`
-
-You can turn off this fuzzy name matching by changing the OpenVox Server's [`strict_hostname_checking`][strict] setting to `true`. This will cause Puppet to skip step 3 and only use the node's full name before resorting to `default`.
 
 ### Regex capture variables
 

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -12,7 +12,6 @@ title: "Language: Relationships and ordering"
 [service]: ./type.html#service
 [exec]: ./type.html#exec
 [type]: ./type.html
-[mount]: https://forge.puppet.com/modules/puppetlabs/mount_core/reference#mount
 [package]: ./type.html#package
 [metaparameters]: ./lang_resources.html#metaparameters
 [require_function]: ./lang_classes.html#using-require
@@ -232,7 +231,7 @@ By default, _unrelated_ resources are managed in the order in which they're writ
 
 Some resource types can do a special "refresh" action when a dependency changes. For example, some services must restart when their config files change, so `service` resources can refresh by restarting the service.
 
-(The built-in resource types that can refresh are [service][], [mount][], [exec][], and sometimes [package][]. See each type's docs for info about their refresh behavior.)
+(The built-in resource types that can refresh are [service][], [exec][], and sometimes [package][]. See each type's docs for info about their refresh behavior.)
 
 Puppet uses notifying relationships (`subscribe`, `notify`, and `~>`) to tell resources when they should refresh. A resource will perform its refresh action if Puppet changes any of the resources it subscribes to.
 

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -12,21 +12,15 @@ title: "Language: Relationships and ordering"
 [service]: ./type.html#service
 [exec]: ./type.html#exec
 [type]: ./type.html
-[mount]: ./type.html#mount
+[mount]: https://forge.puppet.com/modules/puppetlabs/mount_core/reference#mount
 [package]: ./type.html#package
 [metaparameters]: ./lang_resources.html#metaparameters
 [require_function]: ./lang_classes.html#using-require
-[moar]: ./configuration.html#ordering
 [lambdas]: ./lang_lambdas.html
 [containment]: ./lang_containment.html
 
 
 By default, Puppet applies resources in the order they're declared in their manifest. However, if a group of resources must _always_ be managed in a specific order, you should explicitly declare such relationships with relationship metaparameters, chaining arrows, and the `require` function.
-
-> **Aside: Default ordering**
->
-> To make Puppet apply unrelated resources in a more-or-less random order, set [the `ordering` setting][moar] to `title-hash` or `random`.
-
 
 ## Syntax: Relationship metaparameters
 

--- a/docs/_openvox_8x/lang_resources.markdown
+++ b/docs/_openvox_8x/lang_resources.markdown
@@ -18,7 +18,7 @@ title: "Language: Resources"
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
 [files]: ./type.html#file
-[cron jobs]: ./type.html#cron
+[cron jobs]: https://forge.puppet.com/modules/puppetlabs/cron_core/reference#cron
 [services]: ./type.html#service
 [custom_types]: ./custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
@@ -133,9 +133,8 @@ If multiple classes require the same resource, you can use a [class][] or a [vir
 
 ### Relationships and ordering
 
-[ordering]: ./configuration.html#ordering
 
-By default, OpenVox applies unrelated resources in the order in which they're written in the manifest. You can disable this with the [`ordering`][ordering] setting.
+By default, OpenVox applies unrelated resources in the order in which they're written in the manifest.
 
 However, if a resource must be applied before or after some other resource, you should declare a relationship between them, to show that their order isn't coincidental. You can also make changes in one resource cause a refresh of some other resource. See [the Relationships and Ordering page][relationships] for more information.
 

--- a/docs/_openvox_8x/lang_resources.markdown
+++ b/docs/_openvox_8x/lang_resources.markdown
@@ -18,7 +18,6 @@ title: "Language: Resources"
 [defined_type]: ./lang_defined_types.html
 [catalog]: ./lang_summary.html#compilation-and-catalogs
 [files]: ./type.html#file
-[cron jobs]: https://forge.puppet.com/modules/puppetlabs/cron_core/reference#cron
 [services]: ./type.html#service
 [custom_types]: ./custom_types.html
 [resource_advanced]: ./lang_resources_advanced.html
@@ -37,7 +36,7 @@ This page describes the basics of using resource declarations. For more advanced
 
 Every resource is associated with a **resource type,** which determines the kind of configuration it manages.
 
-OpenVox has many built-in resource types, like [files][], [cron jobs][], [services][], etc. [See the resource type reference][types] for information about the built-in resource types.
+OpenVox has many built-in resource types, like [files][] and [services][]. [See the resource type reference][types] for information about the built-in resource types.
 
 You can also add new resource types to OpenVox:
 

--- a/docs/_openvox_8x/lang_summary.markdown
+++ b/docs/_openvox_8x/lang_summary.markdown
@@ -63,7 +63,7 @@ Windows uses CRLF line endings instead of \*nix's LF line endings.
 
 * If the contents of a file are specified with the `content` attribute, OpenVox will write the content in "binary" mode. To create files with CRLF line endings, the `\r\n` escape sequence should be specified as part of the content.
 * If a file is being downloaded to a Windows node with the `source` attribute, OpenVox will transfer the file in "binary" mode, leaving the original newlines untouched.
-* Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
+* Non-`file` resource types that make partial edits to a system file (most notably the [`host`](https://forge.puppet.com/modules/puppetlabs/host_core/reference#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
 > **Note:** When writing your own resource types, you can get this behavior by using the `flat` filetype.
 

--- a/docs/_openvox_8x/lang_type_aliases.md
+++ b/docs/_openvox_8x/lang_type_aliases.md
@@ -83,5 +83,5 @@ When defining an alias to a resource type, use its short form (such as `File`) i
 
 ## Related topics
 
--   [Data types](./lang_data_type.md)
--   [Resources](./lang_resources.md)
+-   [Data types](./lang_data_type.html)
+-   [Resources](./lang_resources.html)

--- a/docs/_openvox_8x/lang_windows_file_paths.markdown
+++ b/docs/_openvox_8x/lang_windows_file_paths.markdown
@@ -4,7 +4,7 @@ title: "Language: Handling file paths on Windows"
 ---
 
 [template]: ./lang_template.html
-[scheduledtask]: ./type.html#scheduledtask
+[scheduledtask]: https://forge.puppet.com/modules/puppetlabs/scheduled_task/reference#scheduled_task
 [exec]: ./type.html#exec
 [package]: ./type.html#package
 [file]: ./type.html#file

--- a/docs/_openvox_8x/openvox_strings.md
+++ b/docs/_openvox_8x/openvox_strings.md
@@ -19,7 +19,7 @@ Markdown output includes the reference documentation only, and writes the inform
 
 **Related links**:
 
-* [Puppet Strings style guide](/openvox/latest/puppet_strings_style.html)
+* [Puppet Strings style guide](./openvox_strings_style.html)
 * [Module README Template](/openvox/latest/modules_documentation.html)
 * [YARD Getting Started Guide](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 * [YARD Tags Overview](http://www.rubydoc.info/gems/yard/file/docs/Tags.md)
@@ -211,8 +211,8 @@ Option   | Description   | Values      | Default
 * `@api`: Describes the resource as belonging to the private or public API. Specify as private, `# @api private`, to mark a module element, such as a class, as part of the private API.
 * `@example`: Shows an example snippet of code for an object. The first line is an optional title, and any subsequent lines are automatically formatted as a code snippet. Use for specific examples of a given component. One example tag per example.
 * `@param`: Documents a parameter with a given name, type and optional description.
-* `@!puppet.type.param`: Documents dynamic type parameters. See [Documenting resource types and providers](/openvox/latest/puppet_strings.html#resource-types).
-* `@!puppet.type.property`: Documents dynamic type properties. See [Documenting resource types and providers](/openvox/latest/puppet_strings.html#resource-types).
+* `@!puppet.type.param`: Documents dynamic type parameters.
+* `@!puppet.type.property`: Documents dynamic type properties.
 * `@option`: With a `@param` tag, defines what optional parameters the user can pass in an options hash to the method.
   For example:
   ```

--- a/docs/_openvox_8x/reporting_about.md
+++ b/docs/_openvox_8x/reporting_about.md
@@ -34,7 +34,7 @@ which stores them in the configured [`reportdir`][reportdir]. You can also turn 
 ## Practical reporting for beginners
 
 Puppet's reporting features are powerful, but there are simple ways to work with them. [PuppetDB](/openvoxdb/latest/),
-with [its report processor enabled](/openvoxdb/latest/connect_puppet_master.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard)
+with [its report processor enabled](/openvoxdb/latest/connect_puppet_server.html#enabling-report-storage), can interface with third-party tools such as [Puppetboard](https://github.com/puppet-community/puppetboard)
 or [PuppetExplorer](https://github.com/spotify/puppetexplorer).
 
 Puppet has several basic built-in [report processors](/openvox/latest/report.html). For example, the `http` processor sends YAML dumps of reports via POST requests to a designated URL, while `log` saves received

--- a/docs/_openvox_8x/resources_augeas.md
+++ b/docs/_openvox_8x/resources_augeas.md
@@ -32,7 +32,7 @@ with Augeas to the new version.
 Assuming you want to work with Augeas, this is a description of how
 to perform Augeas changes using Puppet. Augeas itself is included in the puppet-agent package, so you don't need to install any extra packages to use it. The command-line utility `augtool` will be used to demonstrate things here, but it is not required to use Augeas within Puppet. On most Linux distributions, `augtool` can be found in a separate package.
 
-The basic usage for the Augeas resource type is in the [resource type reference](./types/augeas.html).
+The basic usage for the Augeas resource type is in the [resource type reference](https://forge.puppet.com/modules/puppetlabs/augeas_core/reference#augeas).
 
 The somewhat more important, and unfortunately complicated, part is
 figuring out what the tree for a file looks like so you can

--- a/docs/_openvox_8x/resources_file_windows.markdown
+++ b/docs/_openvox_8x/resources_file_windows.markdown
@@ -88,7 +88,7 @@ Windows usually uses CRLF line endings instead of \*nix's LF line endings. In mo
 
 * If a file resource uses the `content` or `source` attributes, Puppet will write the file in "binary" mode, using whatever line endings are present in the content.
     * If the manifest, template, or source file is saved with CRLF line endings, Puppet will use those endings in the destination file.
-* Non-`file` resource types that make partial edits to a system file (most notably the [`host`](./type.html#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
+* Non-`file` resource types that make partial edits to a system file (most notably the [`host`](https://forge.puppet.com/modules/puppetlabs/host_core/reference#host) resource type, which manages the `%windir%\system32\drivers\etc\hosts` file) manage their files in text mode, and will automatically translate between Windows and \*nix line endings.
 
     > Note: When writing your own resource types, you can get this same behavior by using the `flat` filetype.
 

--- a/docs/_openvox_8x/resources_scheduled_task_windows.markdown
+++ b/docs/_openvox_8x/resources_scheduled_task_windows.markdown
@@ -4,7 +4,7 @@ title: "Resource tips and examples: Scheduled task on Windows"
 toc: false
 ---
 
-[scheduledtask]: ./type.html#scheduledtask
+[scheduledtask]: https://forge.puppet.com/modules/puppetlabs/scheduled_task/reference#scheduled_task
 
 Puppet can create, edit, and delete scheduled tasks, which are a Windows-only resource type.
 

--- a/docs/_openvox_8x/services_commands.markdown
+++ b/docs/_openvox_8x/services_commands.markdown
@@ -28,7 +28,6 @@ title: "Puppet's commands"
 [help_man]: ./man/help.html
 [all_manpages]: ./man/overview.html
 [about_server]: /openvox-server/latest/services_puppetserver.html
-[server_vs_passenger]: /openvox-server/latest/puppetserver_vs_passenger.html
 [subcommands]: /openvox-server/latest/subcommands.html
 
 Puppet's command line interface consists of a single `puppet` command with many subcommands.
@@ -60,7 +59,6 @@ For more information, see:
 
 * [Overview of Puppet's Architecture][arch]
 * [Puppet Server][about_server]
-* [Puppet Server vs. Apache/Passenger master][server_vs_passenger]
 * [Puppet Server Subcommands][subcommands]
 
 ### Puppet apply

--- a/docs/_openvox_8x/static_catalogs.md
+++ b/docs/_openvox_8x/static_catalogs.md
@@ -4,9 +4,9 @@ title: "Static catalogs"
 ---
 
 [catalogs]: ./subsystem_catalog_compilation.html
-[catalog endpoint]: ./http_api/http_catalog.html
-[file metadata]: ./http_api/http_file_metadata.html
-[`file_content`]: ./http_api/http_file_content.html
+[catalog endpoint]: /openvox-server/latest/http_catalog.html
+[file metadata]: /openvox-server/latest/http_file_metadata.html
+[`file_content`]: /openvox-server/latest/http_file_content.html
 [`static_file_content`]: /openvox-server/latest/puppet-api/v3/static_file_content.html
 [resource_declaration]: ./lang_resources.html
 [file resources]: ./types/file.html

--- a/docs/_openvox_8x/subsystem_agent_server_comm.markdown
+++ b/docs/_openvox_8x/subsystem_agent_server_comm.markdown
@@ -3,7 +3,7 @@ title: "Subsystems: Agent/server HTTPS communications"
 layout: default
 ---
 
-[http_api]: http_api/http_api_index.html
+[http_api]: /openvox-server/latest/http_api_index.html
 [authconf]: config_file_auth.html
 [facts]: lang_variables.html#facts-and-built-in-variables
 [catalog]: lang_summary.html#compilation-and-catalogs

--- a/docs/_openvox_8x/subsystem_catalog_compilation.markdown
+++ b/docs/_openvox_8x/subsystem_catalog_compilation.markdown
@@ -18,7 +18,6 @@ title: "Subsystems: Catalog compilation"
 [node terminus]: ./configuration.html#node_terminus
 [plain_node]: ./indirection.html#plain-terminus
 [exec_node]: ./indirection.html#exec-terminus
-[ldap_node]: ./indirection.html#ldap-terminus
 [ldap_guide]: ./nodes_ldap.html
 [trusted_on]: ./config_important_settings.html#getting-new-features-early
 [facts_builtin]: ./lang_facts_and_builtin_vars.html
@@ -46,7 +45,7 @@ Puppet manifests are concise because they can express variation between nodes wi
 * **Separate privileges:** Each individual node has little to no knowledge about other nodes. It only receives its own resources.
 * **Reduce the agent's resource consumption:** Since the agent doesn't have to compile, it can use less CPU and memory.
 * **Simulate changes:** Since the agent is just checking resources and not running arbitrary code, it has the option of simulating changes. If you do a Puppet run in _noop_ mode, the agent will check against its current state and report on what _would_ have changed without actually making any changes.
-* **Record and query configurations:** If you use PuppetDB, you can [query it for information about managed resources on any node](/openvoxdb/latest/api/index.html).
+* **Record and query configurations:** If you use PuppetDB, you can [query it for information about managed resources on any node](/openvoxdb/latest/api/overview.html).
 
 ### What about Puppet apply?
 
@@ -110,7 +109,7 @@ By default, OpenVox Server uses the [`plain` node terminus][plain_node], which j
 
 The next most common node terminus is the [`exec` node terminus][exec_node], which will request data from an [external node classifier (ENC)][enc]. This can return classes, variables, an environment, or some combination of the three, depending on how the ENC is designed.
 
-Less commonly, some people use the [`ldap` node terminus][ldap_node], which will fetch ENC-like information from an LDAP database. See the page on [LDAP nodes][ldap_guide] for more information.
+Less commonly, some people use the `ldap` node terminus, which will fetch ENC-like information from an LDAP database. See the page on [LDAP nodes][ldap_guide] for more information.
 
 Finally, it's possible to write a custom node terminus that retrieves classes, variables, and environments from any kind of external system.
 


### PR DESCRIPTION
## What

Resolves workstream **E** of #262 — links to pages/sections that don't exist in the `openvox` collection (migrated, repointed, or de-linked), plus content fixes surfaced while reviewing the de-links.

## Verification

`htmlproofer _site/openvox/latest --disable-external --checks Links` (run **with the generated reference pages present**, i.e. the CI-accurate state): **authored broken links 85 → 20.** All 20 remaining are tracked elsewhere:
- **13** hiera links → **#225**
- **1** `/puppet/4.0/release_notes.html` → **#270**
- **6** generator-emitted `custom_resources.html` / `cheatsheet_core_types.html` links on the type reference pages → generator follow-up (B-style)

So **authored E links are at zero.**

## Link migration

- **Moved core types → Forge module reference, deep-linked** — cron attributes → `cron_core/reference#<param>` (and `#-cron--name` for the explicit-anchor parameter); each moved type → its type anchor (`#cron`, `#host`, `#mount`, `#scheduled_task`, `#augeas`). Anchors verified against each module's `REFERENCE.md`; the `/reference` pages return 200. External links, so the scoped (`--disable-external`) proofer run doesn't check them.
- **`.md` → `.html`** (`lang_data_type`, `lang_resources`, `lang_type_aliases`).
- **`puppet_strings*` → `openvox_strings*`** (renamed pages).
- **Removed settings de-linked** (text kept) — `configuration.html#capass`/`#caprivatedir`/`#moduleskeletondir`/`#restauthconfig`. Removed **LDAP node terminus** de-linked.
- **`http_api/*` → `/openvox-server/latest/`** (`http_catalog`, `http_file_content`, `http_file_metadata`, `http_api_index`).
- **Cross-collection repoints** — `configuring_facter`→`configuring_openfact`; `connect_puppet_master`→`connect_puppet_server`; `api/index`→`api/overview`; `intermediate_ca_configuration`→`intermediate_ca`; dropped two malformed anchors; de-linked the dead `puppetserver_vs_passenger` comparison.
- **Misc** — `./man/`→`./man/overview.html`; `templating.html`→`lang_template.html`; `environments_configuring`→`environments_creating`; environment-timeout links → `configuration.html#environment_timeout`; `index.md` `../openvox-server`→`/openvox-server`.

New within-collection links keep each file's existing leading-`./` style (the site-wide `./` normalization is its own effort — #276).

## Content fixes (from review)

Removed settings/features confirmed against the OpenVox 8.26 source.

- **Reworded three sentences** that de-linking left pointing at nothing (`dirs_modulepath`, `openvox_strings`, `config_important_settings`).
- **`config_file_auth`** — dropped the claim that auth.conf's location is "configurable with the `rest_authconfig` setting" (removed in OpenVox 8).
- **`config_important_settings`** — removed the obsolete "Rack related settings" section (OpenVox Server is JRuby/puppetserver only), and reworked the **`ca`** bullet: the `ca` setting was removed (CA is an OpenVox Server service; you disable it on compilers via `ca.cfg` / service bootstrapping), so it points there instead of the dead `ca = false` toggle.
- **`lang_node_definitions`** — reworked the node-name **"Matching"** section: the fuzzy/progressive name shortening and `strict_hostname_checking` setting were both removed. Confirmed in source (`Puppet::Node#names` returns just `[name]`), so matching is exact name → regex → `default`.
- **`ordering`** — the `ordering` setting *and* the title-hash/random capability were removed (the catalog prioritizer is hardcoded to manifest order). Dropped the obsolete "Aside: Default ordering" callout (`lang_relationships`) and the "you can disable this with the `ordering` setting" sentence (`lang_resources`).

## Follow-ups surfaced (filed separately)

- **#274** — remove legacy Kramdown topic-type IAL markers (`{:.concept}`/`{:.section}`/…).
- **#275** — remove the remaining obsolete "Rack application" / Passenger / WEBrick deployment references.
- **#276** — normalize the leading `./` on within-collection relative links site-wide.
- **#277** — directory docs: CA documented under `ssldir` (moved to the puppetserver `cadir`) + removed-setting labels.

Part of #262
