### PR TITLE
docs: fix generator-emitted type-reference links (custom_types, cheatsheet)

### DIFF
--- a/lib/puppet_references/puppet/type_preamble.md
+++ b/lib/puppet_references/puppet/type_preamble.md
@@ -6,7 +6,7 @@ This is the documentation for OpenVox's built-in resource types and providers. A
 
 You can find and install modules by browsing the
 [Puppet Forge](http://forge.puppet.com). See each module's documentation for
-information on how to use its custom resource types. For more information about creating custom types, see [Custom resources](/openvox/latest/custom_resources.html).
+information on how to use its custom resource types. For more information about creating custom types, see [Custom types](/openvox/latest/custom_types.html).
 
 > As of Puppet 6.0, some resource types were removed from Puppet and repackaged as individual modules.
 > These supported type modules are still included in the `puppet-agent` package, so you don't have to download them from the Forge.
@@ -146,4 +146,4 @@ The following types were deprecated with Puppet 6.0.0. They are available in mod
 
 ## OpenVox core types
 
-For a list of core OpenVox types, see the [core types cheat sheet](cheatsheet_core_types.html).
+For a list of core OpenVox types, see the [core types cheat sheet](/openvox/latest/cheatsheet_core_types.html).


### PR DESCRIPTION
## What

Fixes two links emitted by the type-reference **preamble** (`lib/puppet_references/puppet/type_preamble.md`, prepended to the generated type pages — `type.html`, `type_strings.html`, `types/overview.html`, `types_strings/overview.html`). Both 404 on the live site.

- **`[Custom resources](/openvox/latest/custom_resources.html)`** → **`[Custom types](/openvox/latest/custom_types.html)`** — `custom_resources.html` doesn't exist in the collection; the OpenVox page is `custom_types.html`. (Aligned the link text too.)
- **`[core types cheat sheet](cheatsheet_core_types.html)`** → **absolute `/openvox/latest/cheatsheet_core_types.html`** — the relative form resolves from `type.html` (collection root) but 404s from the `types/` and `types_strings/` subdirectories. Absolute resolves at both depths.

## Verification

Regenerated references (`rake references:openvox INSTALLPATH=docs`), rebuilt, and re-ran `htmlproofer _site/openvox/latest --disable-external --checks Links`: the **6 generator-emitted failures** (4 `custom_resources` + 2 `cheatsheet`) are gone, and both targets build.

Generator-only change — the generated files are produced at build time in CI (`INSTALLPATH=docs`), so nothing generated is committed. Follows the same pattern as #264 (workstream B).

This clears the last non-tracked broken links in the openvox collection; the remainder are #225 (hiera) and #270 (`/puppet/4.0`, the `lang_updating_manifests` retirement).

Part of #262
