### PR TITLE
docs: fix broken internal links in the openvox-server collection

### DIFF
--- a/docs/_openvox-server_8x/ca-api/v1/http_certificate_status.md
+++ b/docs/_openvox-server_8x/ca-api/v1/http_certificate_status.md
@@ -163,4 +163,4 @@ Schema
 -----
 
 Find and search operations return objects which
-conform to [the host schema.](../schemas/host.json)
+conform to [the host schema.](/openvox/latest/schemas/host.json)

--- a/docs/_openvox-server_8x/config_file_auth.markdown
+++ b/docs/_openvox-server_8x/config_file_auth.markdown
@@ -4,7 +4,7 @@ title: "OpenVox Server Configuration Files: auth.conf"
 ---
 
 [deprecated]: ./deprecated_features.html
-[short names]: /openvox/latest/ssl_attributes_extensions.html#puppet_registered_ids
+[short names]: /openvox/latest/ssl_attributes_extensions.html#puppet-specific-registered-ids
 
 OpenVox Server's `auth.conf` file contains rules for authorizing access to OpenVox Server's HTTP API endpoints. For an overview, see [OpenVox Server Configuration](./configuration.html).
 

--- a/docs/_openvox-server_8x/deprecated_features.markdown
+++ b/docs/_openvox-server_8x/deprecated_features.markdown
@@ -237,7 +237,7 @@ The `resource_type` and `resource_types` HTTP APIs were removed in OpenVox Serve
 
 ### Previously
 
-The [`resource_type` and `resource_types` OpenVox HTTP API endpoints](/openvox/latest/http_api/http_resource_type.html) return information about classes, defined types, and node definitions.
+The `resource_type` and `resource_types` OpenVox HTTP API endpoints returned information about classes, defined types, and node definitions.
 
 The [`environment_classes` HTTP API in OpenVox Server](./puppet-api/v3/environment_classes.html) serves as a replacement for the OpenVox resource type API for classes.
 

--- a/docs/_openvox-server_8x/dev_running_from_source.markdown
+++ b/docs/_openvox-server_8x/dev_running_from_source.markdown
@@ -255,7 +255,7 @@ To run a source OpenVoxDB with OpenVox Server, OpenVox Server needs standard Ope
 OpenVox Server to load the OpenVoxDB terminus from the specified directory.
 
 From here, the instructions are similar to installing OpenVoxDB manually via packages. The OpenVox Server instance needs configuration for connecting to OpenVoxDB. See the
-[OpenVoxDB documentation](../../../openvoxdb/latest/connect_puppet_server.html) for details.
+[OpenVoxDB documentation](/openvoxdb/latest/connect_puppet_server.html) for details.
 
 Update `~/.puppetlabs/etc/puppet/puppet.conf` to include:
 

--- a/docs/_openvox-server_8x/http_api_index.markdown
+++ b/docs/_openvox-server_8x/http_api_index.markdown
@@ -6,8 +6,6 @@ title: "OpenVox Server HTTP API: Index"
 OpenVox Server provides several services via HTTP API, and the OpenVox agent application uses those services to resolve a node's credentials, retrieve a configuration catalog, retrieve file data, and submit
 reports.
 
-Many of these endpoints are the same as the [OpenVox HTTP API](/openvox/latest/http_api/http_api_index.html).
-
 ## V1/V2 HTTP APIs (removed)
 
 The V1 and V2 APIs were removed in Puppet 4.0.0. The routes that were previously under `/` or `/v2.0` can now be found under the [`/puppet/v3`](#openvox-v3-http-api) API or [`/puppet-ca/v1`](#ca-v1-http-api)

--- a/docs/_openvox-server_8x/puppet-api/v3/environment_classes.markdown
+++ b/docs/_openvox-server_8x/puppet-api/v3/environment_classes.markdown
@@ -6,7 +6,7 @@ title: "OpenVox Server: Puppet API: Environment Classes"
 [classes]: /openvox/latest/lang_classes.html
 [node definitions]: /openvox/latest/lang_node_definitions.html
 [defined types]: /openvox/latest/lang_defined_types.html
-[`environment_timeout`]: /openvox/latest/config_file_environment.html#environmenttimeout
+[`environment_timeout`]: /openvox/latest/config_file_environment.html#environment_timeout
 [`manifest` setting]: /openvox/latest/config_file_environment.html#manifest
 [`auth.conf`]: ../../config_file_auth.html
 [environment cache API]: ../../admin-api/v1/environment-cache.html

--- a/docs/_openvox-server_8x/puppet-api/v3/environment_transports.markdown
+++ b/docs/_openvox-server_8x/puppet-api/v3/environment_transports.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "OpenVox Server: Puppet API: Environment Transports"
 ---
 
-[HTTP API]: /openvox/latest/http_api/http_api_index.html
+[HTTP API]: /openvox-server/latest/http_api_index.html
 [environment cache API]: ../../admin-api/v1/environment-cache.html
 [environment classes API]: ./environment_classes.html
 [transports schema]: ./environment_transports.json

--- a/docs/_openvox-server_8x/puppet-api/v3/file_content.markdown
+++ b/docs/_openvox-server_8x/puppet-api/v3/file_content.markdown
@@ -7,7 +7,7 @@ The `file_content` endpoint returns contents of the specified file.
 
 ## `GET /puppet/v3/file_content/:mount_point/:module/:file-path?environment=:environment`
 
-When specifying environment see the [OpenVox API docs](/openvox/latest/http_api/http_file_content.html)
+When specifying environment see the [OpenVox API docs](/openvox-server/latest/http_file_content.html)
 
 ## `GET /puppet/v3/file_content/:mount_point/:module/:file-path?project=:project-ref
 

--- a/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
+++ b/docs/_openvox-server_8x/puppet_conf_setting_diffs.markdown
@@ -13,11 +13,11 @@ OpenVox Server enforces a max ttl of 50 standard years (up to 1576800000 seconds
 ## `cacert`
 
 If you enable OpenVox Server's certificate authority service, it uses the `cacert` setting in puppet.conf to determine the location of the CA certificate for such tasks as generating the CA certificate or
-using the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./configuration.html#webserverconf).
+using the CA to sign client certificates. This is true regardless of the configuration of the `ssl-` settings in [webserver.conf](./config_file_webserver.html).
 
 ## `cacrl`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./config_file_webserver.html), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
 clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, OpenVox Server will _not_ use a CRL to validate clients via SSL.
 
 If none of the `ssl-` settings in webserver.conf are set, OpenVox Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
@@ -28,7 +28,7 @@ of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
 ## `hostcert`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server presents the file at `ssl-cert` to clients as the server
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./config_file_webserver.html), OpenVox Server presents the file at `ssl-cert` to clients as the server
 certificate via SSL.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
@@ -39,7 +39,7 @@ to determine the location of the server host certificate to generate.
 
 ## `hostcrl`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./config_file_webserver.html), OpenVox Server uses the file at `ssl-crl-path` as the CRL for authenticating
 clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, OpenVox Server will _not_ use a CRL to validate clients via SSL.
 
 If none of the `ssl-` settings in webserver.conf are set, OpenVox Server uses the CRL file defined for the `hostcrl` setting---and not the file defined for the `cacrl` setting--in puppet.conf. At start time,
@@ -50,7 +50,7 @@ of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
 
 ## `hostprivkey`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-key` as the server private key during SSL
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in [webserver.conf](./config_file_webserver.html), OpenVox Server uses the file at `ssl-key` as the server private key during SSL
 transactions.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-key` is not, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf are set,
@@ -61,7 +61,7 @@ regardless of the configuration of the `ssl-` settings in webserver.conf.
 
 ## `localcacert`
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./configuration.html#webserverconf), OpenVox Server uses the file at `ssl-ca-cert` as the CA cert store for
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in [webserver.conf](./config_file_webserver.html), OpenVox Server uses the file at `ssl-ca-cert` as the CA cert store for
 authenticating clients via SSL.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-ca-cert` is not set, OpenVox Server gives an error and shuts down at startup. If none of the `ssl-` settings in webserver.conf is set,
@@ -70,7 +70,7 @@ OpenVox Server uses the CA file defined for the `localcacert` setting in puppet.
 ## `masterport`
 
 OpenVox Server does not use this setting. To set the port on which the server listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
-[webserver.conf](./configuration.html#webserverconf) file.
+[webserver.conf](./config_file_webserver.html) file.
 
 ## `ssl_client_header`
 
@@ -96,7 +96,7 @@ any requests that the server would make to the `reporturl` for the `http` report
 
 ## Overriding Puppet settings in OpenVox Server
 
-Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](./configuration.html#puppetserver.conf) contains five settings (`master-conf-dir`, `master-code-dir`, `master-var-dir`,
+Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](./config_file_puppetserver.html) contains five settings (`master-conf-dir`, `master-code-dir`, `master-var-dir`,
 `master-run-dir`, and `master-log-dir`) that allow you to override settings set in your `puppet.conf` file. On installation, these five settings will be set to the proper default values.
 
 While you are free to change these settings at will, please note that any changes made to the `master-conf-dir` and `master-code-dir` settings absolutely MUST be made to the corresponding Puppet settings

--- a/docs/_openvox-server_8x/scaling_puppet_server.markdown
+++ b/docs/_openvox-server_8x/scaling_puppet_server.markdown
@@ -149,9 +149,9 @@ server in order to see all of your agents' reports.
 If you use exported resources, use OpenVoxDB and point your primary server and all compilers at a shared
 OpenVoxDB instance. A reasonably robust OpenVoxDB server can handle many compilers and many thousands of agents.
 
-See the [OpenVoxDB documentation](../../../openvoxdb/latest/) for instructions on deploying an OpenVoxDB
+See the [OpenVoxDB documentation](/openvoxdb/latest/) for instructions on deploying an OpenVoxDB
 server, then configure every compiler to use it. Note that every server and compiler must have its own
-[certificate allowlist entry](../../../openvoxdb/latest/configure.html) if you're using HTTPS certificates
+[certificate allowlist entry](/openvoxdb/latest/configure.html) if you're using HTTPS certificates
 for authorization.
 
 ## Keeping manifests and modules synchronized across compilers

--- a/docs/_openvox-server_8x/services_puppetserver.markdown
+++ b/docs/_openvox-server_8x/services_puppetserver.markdown
@@ -48,7 +48,7 @@ The web server's settings can be modified in [`webserver.conf`](./config_file_we
 
 ### OpenVox API Service
 
-OpenVox Server includes a service that handles agent configuration requests. See [OpenVox HTTP API](/openvox/latest/http_api/http_api_index.html) for documentation on the core APIs.
+OpenVox Server includes a service that handles agent configuration requests. See [OpenVox HTTP API](/openvox-server/latest/http_api_index.html) for documentation on the core APIs.
 
 For OpenVox Server-specific APIs hosted by this service, see:
 
@@ -63,7 +63,7 @@ OpenVox Server includes a certificate authority (CA) service that:
 - Serves certificates and a certificate revocation list (CRL) to nodes
 - Optionally accepts commands to sign or revoke certificates (disabled by default)
 
-The relevant endpoints are `certificate`, `certificate_request`, `certificate_revocation_list`, and `certificate_status`. See [CA HTTP API](/openvox/latest/http_api/http_api_index.html) for details.
+The relevant endpoints are `certificate`, `certificate_request`, `certificate_revocation_list`, and `certificate_status`. See [CA HTTP API](/openvox-server/latest/http_api_index.html#ca-v1-http-api) for details.
 
 Signing and revoking certificates over the network is disallowed by default. You can use [`auth.conf`](./config_file_auth.html) to allow specific certificate owners to issue commands.
 

--- a/docs/_openvox-server_8x/subcommands.markdown
+++ b/docs/_openvox-server_8x/subcommands.markdown
@@ -51,7 +51,7 @@ Because these commands are shipped as a gem alongside Puppet Server, it can be u
 
 **Note:** These commands are available in Puppet 5, but in order to use them, you must update Puppet Server’s `auth.conf` to include a rule allowing the master’s certname to access the `certificate_status` and
 `certificate_statuses` endpoints. The same applies to upgrading in open source Puppet: if you're upgrading from Puppet 5 to Puppet 6 and are not regenerating your CA, you must whitelist the master’s certname.
-See [Puppet Server Configuration Files: auth.conf](/puppetserver/latest/config_file_auth.html) for details on how to use `auth.conf`.
+See [Puppet Server Configuration Files: auth.conf](/openvox-server/latest/config_file_auth.html) for details on how to use `auth.conf`.
 
 Example:
 

--- a/docs/_openvox-server_8x/tuning_guide.markdown
+++ b/docs/_openvox-server_8x/tuning_guide.markdown
@@ -42,7 +42,7 @@ Puppet Server.
 ### Number of JRubies
 
 The most important setting that you can use to improve the throughput of your
-Puppet Server installation is the [`max-active-instances`](./configuration.html#puppetserver_conf)
+Puppet Server installation is the [`max-active-instances`](./config_file_puppetserver.html)
 setting.  The value of this setting is used by Puppet Server to determine how
 many JRuby instances to create when the server starts up.
 


### PR DESCRIPTION
## What

Repoint or remove the ~13 distinct broken internal-link targets that htmlproofer found in the **openvox-server** collection. This is workstream **H** of #262 (the site-wide "true zero broken links" effort) — the sibling of the now-merged openvox collection sweep (#273).

- **`http_api/*` links** — the HTTP API pages live in the openvox-server collection at top level, not under `/openvox/latest/http_api/`. Repointed to `/openvox-server/latest/http_*.html`; unlinked the removed `resource_type` endpoint and removed the now-circular agent-API reference.
- **OpenVoxDB cross-collection links** — replaced overshooting `../../../` relative paths with absolute `/openvoxdb/latest/` paths.
- **auth.conf** — repointed `/puppetserver/latest/` → `/openvox-server/latest/`.
- **host schema** — repointed `../schemas/host.json` → `/openvox/latest/schemas/host.json`.
- **`configuration.html` anchors** — the `webserver.conf` and `puppetserver.conf` sections moved to their own `config_file_*` pages; repointed there.
- **Anchor drift** — `#environmenttimeout` → `#environment_timeout`, `#puppet_registered_ids` → `#puppet-specific-registered-ids`.

Also fixed the tense of the removed `resource_type` endpoint description (it no longer returns anything; verified absent in openvox 8.27.0).

## Verification

Full `jekyll build` + htmlproofer scoped to `_site/openvox-server/latest`: **0 broken internal links** (OpenBolt #202 sidebar pages excluded).

Closes #282 · Part of #262 (workstream H)
