### PR TITLE
docs: fix broken internal links in the openvoxdb collection

### DIFF
--- a/docs/_openvoxdb_8x/CONTRIBUTING.md
+++ b/docs/_openvoxdb_8x/CONTRIBUTING.md
@@ -3,7 +3,7 @@ title: "Contributing to OpenVoxDB"
 layout: default
 ---
 
-[configure_postgres]: ./configure.html#using-postgresql
+[configure_postgres]: ./configure_postgres.html
 
 # Contributing to OpenVoxDB
 
@@ -56,7 +56,7 @@ top of things.
 ### Testing
 
 > **Quick setup:** For a streamlined development workflow using the `ovdb` helper
-> script, see the [Local Development Guide](../dev-docs/local-dev.md).
+> script, see the [Local Development Guide](https://github.com/OpenVoxProject/openvoxdb/blob/main/dev-docs/local-dev.md).
 
 The easiest way to run the tests until you need to do it often is to
 use the built-in sandbox harness.  If you just want to check some

--- a/docs/_openvoxdb_8x/api/query/tutorial.markdown
+++ b/docs/_openvoxdb_8x/api/query/tutorial.markdown
@@ -8,7 +8,7 @@ canonical: "/openvoxdb/latest/api/query/tutorial.html"
 
 [array]: ./v4/ast.html#array
 [curl]: ./curl.html
-[select]: ./v4/ast.html#selectentity-subquery-statements
+[select]: ./v4/ast.html#select_entity-subquery-statements
 [config_jetty]: ../../configure.html#jetty-http-settings
 
 This page walks through the construction of several types of OpenVoxDB queries. We use the **version 4 API** in all examples.

--- a/docs/_openvoxdb_8x/api/query/v4/paging.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/paging.markdown
@@ -8,7 +8,7 @@ canonical: "/openvoxdb/latest/api/query/v4/paging.html"
 [api]: ../../overview.html
 [curl]: ../curl.html#using-curl-from-localhost-non-sslhttp
 [query]: query.html
-[ast]: ./ast.html#paging-operators-limit-offset-orderby
+[ast]: ./ast.html#paging-operators-limit-offset-order_by
 
 Most of OpenVoxDB's [query endpoints][api] support a general set of HTTP URL parameters that
 can be used for paging results. OpenVoxDB also supports paging via query

--- a/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
@@ -139,6 +139,6 @@ Each change below is marked with the corresponding release version.
   [subquery examples documentation](../../../api/query/v4/ast.html#explicit-subquery-examples).
 
 - (2.2.0) We have added the regexp array match operator `~>` for querying fact paths on the `fact-contents` or `fact-paths endpoints`. This is documented with the other
-  [operators](../../../api/query/v4/ast.html#regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](../../../api/query/v4/ast.html#explicit-subquery-examples).
+  [operators](../../../api/query/v4/ast.html#-regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](../../../api/query/v4/ast.html#explicit-subquery-examples).
 
 - (3.0) We have added the `group_by` and `function` operators, as well as support for the `count` function. For more information, see the [operators documentation](../../../api/query/v4/ast.html#function).

--- a/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
+++ b/docs/_openvoxdb_8x/api/query/v4/upgrading-from-v3.markdown
@@ -75,8 +75,8 @@ Each change below is marked with the corresponding release version.
 
 ### /pdb/cmd/v1 (formerly /v3/commands)
 
-- (3.0) For users posting commands directly to the /pdb/cmd/v1 endpoint, the only valid command submission versions will be [replace catalogs v6](../../../api/wire_format/catalog_format_v6.html),
-  [store report v5](../../../api/wire_format/report_format_v5.html), and [replace facts v4](../../../api/wire_format/facts_format_v4.html).
+- (3.0) For users posting commands directly to the /pdb/cmd/v1 endpoint, the only valid command submission versions will be [replace catalogs v6](../../wire_format/catalog_format_v6.html),
+  [store report v5](../../wire_format/report_format_v5.html), and [replace facts v4](../../wire_format/facts_format_v4.html).
 
 ### /pdb/meta/v1/version (formerly /v3/version)
 
@@ -109,24 +109,24 @@ Each change below is marked with the corresponding release version.
 
 ### Features affecting all endpoints
 
-- (3.0) Extract is available as a top-level query operator, useful for selecting only certain fields from a response. See the [documentation on the extract operator](../../../api/query/v4/ast.html#extract)
+- (3.0) Extract is available as a top-level query operator, useful for selecting only certain fields from a response. See the [documentation on the extract operator](ast.html#extract)
   for more information.
 
 - (2.2.0) The `in` and `extract` operators have been changed to accept multiple fields, allowing more concise subquerying as explained [here](https://github.com/OpenVoxProject/openvoxdb/pull/1053).
 
 ### /pdb/query/v4/events
 
-- (3.0) The v4 events endpoint does not require a query parameter, so `/pdb/query/v4/events` is now a valid query. See the [events endpoint documentation](../../../api/query/v4/events.html#pdbqueryv4events)
+- (3.0) The v4 events endpoint does not require a query parameter, so `/pdb/query/v4/events` is now a valid query. See the [events endpoint documentation](events.html#pdbqueryv4events)
   for more information.
 
 ### /pdb/query/v4/reports
 
 - (3.0) The response of the reports endpoint includes the new fields `noop`, `environment`, `status`, `resource_events`, `logs`, and `metrics`. For more information, see the
-  [documentation on the reports endpoint](../../../api/query/v4/reports.html). For comparison, see [an example of the new format](../../../api/query/v4/reports.html#examples), and
+  [documentation on the reports endpoint](reports.html). For comparison, see [an example of the new format](reports.html#examples), and
   [an example of the old format](https://github.com/OpenVoxProject/openvoxdb/blob/doc-2.3/documentation/api/query/v3/reports.html#response-format) (OpenVoxDB 2.3 docs).
 
 - (3.0) The reports endpoint takes a `latest_report?` query to return only reports associated with the most recent puppet run for their nodes. Similar to the corresponding events query, there is no
-  corresponding field in the response. For more information, see the [documentation on the report query fields](../../../api/query/v4/reports.html#query-fields).
+  corresponding field in the response. For more information, see the [documentation on the report query fields](reports.html#query-fields).
 
 ### /pdb/query/v4/catalogs
 
@@ -136,9 +136,9 @@ Each change below is marked with the corresponding release version.
 ### Operators
 
 - (2.2.0) The new `select_fact_contents` subquery operator allows for filtering the results of other endpoints based on detailed queries about structured fact values. This is exhibited on the bottom of the
-  [subquery examples documentation](../../../api/query/v4/ast.html#explicit-subquery-examples).
+  [subquery examples documentation](ast.html#explicit-subquery-examples).
 
 - (2.2.0) We have added the regexp array match operator `~>` for querying fact paths on the `fact-contents` or `fact-paths endpoints`. This is documented with the other
-  [operators](../../../api/query/v4/ast.html#-regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](../../../api/query/v4/ast.html#explicit-subquery-examples).
+  [operators](ast.html#-regexp-array-match). An example of usage is given at the bottom of the [subquery examples page](ast.html#explicit-subquery-examples).
 
-- (3.0) We have added the `group_by` and `function` operators, as well as support for the `count` function. For more information, see the [operators documentation](../../../api/query/v4/ast.html#function).
+- (3.0) We have added the `group_by` and `function` operators, as well as support for the `count` function. For more information, see the [operators documentation](ast.html#function).

--- a/docs/_openvoxdb_8x/configure.markdown
+++ b/docs/_openvoxdb_8x/configure.markdown
@@ -419,9 +419,9 @@ is done via plaintext.
 The database user specified for database migration operations, in
 particular the database validation and migration at startup.  Defaults
 to the `username`.  See the [PostgreSQL configuration
-section](configure-postgres) for some important requirements for the
+section][configure-postgres] for some important requirements for the
 privileges of this user (role), and the [migration coordination
-section](migration-coordination) for an overview of the process.
+section][migration-coordination] for an overview of the process.
 
 ### `connection-migrator-username`
 The database migrator user for special cases when the database connection username
@@ -446,9 +446,9 @@ When set to `true` (the default), OpenVoxDB will upgrade the data in
 the database to the latest format at startup.  When `false`, OpenVoxDB
 will exit with an error status if the format version is not the one it
 expects, whether newer or older.  See the [PostgreSQL configuration
-section](configure-postgres) for some important requirements for the
+section][configure-postgres] for some important requirements for the
 privileges of this user (role), and the [migration coordination
-section](migration-coordination) for an overview of the process.
+section][migration-coordination] for an overview of the process.
 
 ### `maximum-pool-size`
 
@@ -557,7 +557,7 @@ parameters, OpenVoxDB's database connections will communicate in plaintext.
 ### `username`
 
 This is the username to use when connecting.  See the [PostgreSQL
-configuration section](configure-postgres) for some important
+configuration section][configure-postgres] for some important
 requirements for the privileges of this user (role).
 
 ### `password`

--- a/docs/_openvoxdb_8x/connect_puppet_apply.markdown
+++ b/docs/_openvoxdb_8x/connect_puppet_apply.markdown
@@ -16,7 +16,7 @@ canonical: "/openvoxdb/latest/connect_puppet_apply.markdown"
 [routes_yaml]: /openvox/latest/config_file_routes.html
 [jetty]: ./configure.html#jetty-http-settings
 [ssl_script]: ./maintain_and_tune.html#redo-ssl-setup-after-changing-certificates
-[settings_namespace]: /openvox/latest/lang_facts_and_builtin_vars.html#puppet-master-variables
+[settings_namespace]: /openvox/latest/lang_facts_and_builtin_vars.html#openvox-server-variables
 [package_repos]: /openvox/latest/openvox_platform.html
 [intermediate_ca]: /openvox-server/latest/intermediate_ca.html#set-up-openvox-as-an-intermediate-ca-with-an-external-root
 

--- a/docs/_openvoxdb_8x/connect_puppet_server.markdown
+++ b/docs/_openvoxdb_8x/connect_puppet_server.markdown
@@ -16,7 +16,7 @@ canonical: "/openvoxdb/latest/connect_puppet_server.html"
 [report]: ./api/query/v4/reports.html
 [store_report]: ./api/command/v1/commands.html#store-report-version-7
 [report_format]: ./api/wire_format/report_format_v5.html
-[puppetdb_server_urls]: ./puppetdb_connection.html#serverurls
+[puppetdb_server_urls]: ./puppetdb_connection.html#server_urls
 [package_repos]: /openvox/latest/openvox_platform.html
 
 

--- a/docs/_openvoxdb_8x/install_from_source.markdown
+++ b/docs/_openvoxdb_8x/install_from_source.markdown
@@ -6,12 +6,12 @@ layout: default
 # Installing from source
 
 [leiningen]: https://github.com/technomancy/leiningen#installation
-[configure_postgres]: ./configure.html#using-postgresql
+[configure_postgres]: ./configure_postgres.html
 [configure_heap]: ./configure.html#configuring-the-java-heap-size
 [module]: ./install_via_module.html
 [postgres_ssl]: ./postgres_ssl.html
 [packages]: ./install_from_packages.html
-[running_tests]: ./CONTRIBUTING.md#running-the-tests
+[running_tests]: ./CONTRIBUTING.html#testing
 
 This page describes how to install OpenVoxDB from source code, and how to run OpenVoxDB directly from source without installing.
 

--- a/docs/_openvoxdb_8x/puppetdb-faq.markdown
+++ b/docs/_openvoxdb_8x/puppetdb-faq.markdown
@@ -7,21 +7,10 @@ subtitle: "Frequently asked questions"
 
 [connect_puppet_apply]: ./connect_puppet_apply.html
 [support_guide]: ./pdb_support_guide.html
-[puppetdb3]: /puppetdb/3.2/migrate.html
 [threads]: ./configure.html#threads
 [concurrent-writes]: ./configure.html#concurrent-writes
 [mq metrics]: ./api/metrics/v2/jolokia.html#message-queue-metrics
 [java heap]: ./configure.html#configuring-the-java-heap-size
-
-## Can I migrate my data from ActiveRecord storeconfigs?
-
-Yes, but you must use OpenVoxDB 3.x to do so. Please consult the
-[OpenVoxDB 3.x documentiation][puppetdb3] for more details.
-
-## Can I migrate from an HSQL OpenVoxDB to PostgreSQL OpenVoxDB instance?
-
-Yes, but you must use OpenVoxDB 3.x to do so. Please consult the
-[Migrating Data][puppetdb3] for more information.
 
 ## The OpenVoxDB dashboard gives me a weird SSL error when I visit it. What gives?
 

--- a/docs/_openvoxdb_8x/scaling_recommendations.markdown
+++ b/docs/_openvoxdb_8x/scaling_recommendations.markdown
@@ -9,7 +9,7 @@ canonical: "/openvoxdb/latest/scaling_recommendations.html"
 [dashboard]: ./maintain_and_tune.html#monitor-the-performance-dashboard
 [heap]: ./maintain_and_tune.html#tune-the-max-heap-size
 [threads]: ./maintain_and_tune.html#tune-the-number-of-threads
-[postgres]: ./configure.html#using-postgresql
+[postgres]: ./configure_postgres.html
 [pg_ha]: http://www.postgresql.org/docs/current/interactive/high-availability.html
 [pg_replication]: http://wiki.postgresql.org/wiki/Replication,_Clustering,_and_Connection_Pooling
 [ram]: #bottleneck-java-heap-size

--- a/docs/_openvoxdb_8x/upgrade.markdown
+++ b/docs/_openvoxdb_8x/upgrade.markdown
@@ -12,7 +12,6 @@ layout: default
 [start_source]: ./install_from_source.html#step-4-start-the-openvoxdb-service
 [plugin_source]: ./connect_puppet_server.html#on-platforms-without-packages
 [module]: ./install_via_module.html
-[puppetdb3]: /puppetdb/3.2/migrate.html
 [versioning]: ./versioning_policy.html#upgrades
 
 ## Checking for updates


### PR DESCRIPTION
## What

Repoint or remove the ~11 distinct broken internal-link targets that htmlproofer found in the **openvoxdb** collection. This is workstream **I** of #262 (the site-wide "true zero broken links" effort) — the sibling of the now-merged openvox collection sweep (#273).

- **Anchor drift** (corrected against the built HTML):
  - `puppetdb_connection.html#serverurls` → `#server_urls`
  - `lang_facts_and_builtin_vars.html#puppet-master-variables` → `#openvox-server-variables` (the master → server rename)
  - `v4/ast.html`: `#selectentity-subquery-statements` → `#select_entity-subquery-statements`, `#...-orderby` → `#...-order_by`, `#regexp-array-match` → `#-regexp-array-match`
- **"Using PostgreSQL" links** — the content moved from a `configure.html` section to its own `configure_postgres.html` page; pointed the `[configure_postgres]`/`[postgres]` references there.
- **`configure.markdown` bare-slug links** — the body used inline `(parens)` links where it meant reference `[brackets]` links; fixed the bracket typo so they resolve via the existing definitions.
- **CONTRIBUTING** — `./CONTRIBUTING.md#running-the-tests` → `./CONTRIBUTING.html#testing`; the unpublished `../dev-docs/local-dev.md` dev guide → its GitHub source URL.
- **Stale FAQ entries removed** — migrating from ActiveRecord storeconfigs and HSQL, which referenced a nonexistent "OpenVoxDB 3.x" and the removed `/puppetdb/3.2/migrate.html` page, plus their dead reference definitions.

## Verification

Full `jekyll build` + htmlproofer scoped to `_site/openvoxdb/latest`: **0 broken internal links** (OpenBolt #202 sidebar pages excluded).

Closes #283 · Part of #262 (workstream I)
