### PR TITLE
docs: fix broken internal links in the openbolt collection

### DIFF
--- a/docs/_openbolt_5x/applying_manifest_blocks.md
+++ b/docs/_openbolt_5x/applying_manifest_blocks.md
@@ -331,7 +331,7 @@ gems with Bolt packages](bolt_installing.html#).
 [Hiera interpolations](https://puppet.com/docs/puppet/latest/hiera_merging.html#hiera_interpolation)
 are not supported in Bolt outside of apply blocks, because Hiera data is looked up per-target and
 plans do not run in a per-target context. If you want to use Hiera to look up data outside of an apply
-block, you can use a [plan hierarchy](writing_plans.html#using-hiera-data-in-plans).
+block, you can use a [plan hierarchy](#using-hiera-data-in-a-manifest-block).
 
 ## Puppet log functions in Bolt
 
@@ -360,7 +360,7 @@ In addition to the standard Puppet functions available to a catalog, such as
 `lookup()`, you can use the following Bolt functions in a manifest block:
 
 - [`puppetdb_query`](plan_functions.html#puppetdb_query)
-- [`puppetdb_facts`](plan_functions.html#puppetdb_facts)
+- [`puppetdb_facts`](plan_functions.html#puppetdb_fact)
 - [`facts`](plan_functions.html#facts)
 - [`vars`](plan_functions.html#vars)
 
@@ -455,7 +455,7 @@ Create a manifest that sets up a web server with nginx, and run it as a plan.
 📖 **Related information**  
 
 - [NGINX](https://www.nginx.com/resources/glossary/nginx/)
-- [Specify targets](running_bolt_commands.html#adding-options-to-bolt-commands)
+- [Specify targets](running_bolt_commands.html)
 - [Bolt Projects](projects.html)
 
 
@@ -544,9 +544,9 @@ Create a manifest that sets up a web server with IIS and run it as a plan.
 
 📖 **Related information**  
 - [IIS](https://www.iis.net)
-- [Specify targets](running_bolt_commands.html#adding-options-to-bolt-commands)
+- [Specify targets](running_bolt_commands.html)
 - [Bolt projects](projects.html)
 - [Puppet language Bolt plans](writing_plans.html)
 - For information on how Bolt loads the modulepath, see [Modules overview](modules.html#modulepath).
 - To learn more about using Puppet device modules, see [Running Bolt on network
-  devices](running_bolt_network.html#-using-puppet-device-modules-from-an-apply-block)
+  devices](running_bolt_network.html#-using-puppet-network-device-modules-from-an-apply-block)

--- a/docs/_openbolt_5x/automating_windows_targets.md
+++ b/docs/_openbolt_5x/automating_windows_targets.md
@@ -172,7 +172,7 @@ documentation.](https://puppet.com/docs/pdk/1.x/pdk_overview.html)
 
     **Note:** `--targets windows` refers to the name of the group of targets
     that you specified in your inventory file. For more information, see
-    [Specify targets](running_bolt_commands.html#adding-options-to-bolt-commands).
+    [Specify targets](running_bolt_commands.html).
 
 ## Deploy a package with Bolt and Chocolatey
 

--- a/docs/_openbolt_5x/bolt.md
+++ b/docs/_openbolt_5x/bolt.md
@@ -30,7 +30,6 @@ you are not required to install any agent software.
             <li><a class="xref" href="bolt_installing.html">Installing Bolt</a> - Follow the installation instructions for your operating system: *nix, macOS, or Windows.</li>
         </ul>
     </p>
-    <p><a class="xref" href="upgrading_to_bolt_3.html">Upgrade to Bolt 3.0</a></p>
     <p>Make one-time changes to your remote targets
         <ul>
             <li><a class="xref" href="running_bolt_commands.html">Run a command</a></li>

--- a/docs/_openbolt_5x/bolt_inventory_reference.md
+++ b/docs/_openbolt_5x/bolt_inventory_reference.md
@@ -202,7 +202,7 @@ groups:
 A map of [plugin hooks](writing_plugins.html#plugin-hooks) and which plugins a
 hook should use for targets in the group. The only configurable plugin hook is
 `puppet_library`, which configures the plugin used to install the Puppet agent
-on targets when plans call [apply_prep](plan_functions.html#apply-prep) or the
+on targets when plans call [apply_prep](plan_functions.html#apply_prep) or the
 `bolt apply` command or `Invoke-BoltApply` PowerShell cmdlet are used.
 
 The `puppet_library` plugin hook can use one of two plugins: `puppet_agent` or
@@ -348,7 +348,7 @@ targets:
 A map of [plugin hooks](writing_plugins.html#plugin-hooks) and which plugins a
 hook should use for the target. The only configurable plugin hook is
 `puppet_library`, which configures the plugin used to install the Puppet agent
-on a target when plans call [apply_prep](plan_functions.html#apply-prep) or the
+on a target when plans call [apply_prep](plan_functions.html#apply_prep) or the
 `bolt apply` command or `Invoke-BoltApply` PowerShell cmdlet are used.
 
 The `puppet_library` plugin hook can use one of two plugins: `puppet_agent` or

--- a/docs/_openbolt_5x/bolt_running_plans.md
+++ b/docs/_openbolt_5x/bolt_running_plans.md
@@ -8,7 +8,7 @@ title: Running plans
 Bolt plans allow you to tie together complex workflows that include multiple
 tasks, scripts, commands, and even other plans. Bolt is packaged with a
 collection of modules that contain useful plans to support common workflows. For
-details, see [Packaged modules](bolt_installing_modules.html#packaged-modules).
+details, see [Packaged modules](packaged_modules.html).
 
 To execute a plan, run `bolt plan run` and specify:
 -   The full name of the plan, formatted as `<MODULE>::<PLAN>`.
@@ -40,7 +40,7 @@ target that the plan runs its tasks or functions on. If your load balancer was
 You can pass a comma-separated list of target names, wildcard patterns, or group
 names to a plan parameter of type `TargetSpec`. For more information on the
 `TargetSpec` type, see [Writing plans in the Puppet
-language](./writing_plans.html#targetspec).
+language](bolt_types_reference.html#targetspec).
 
 ## Plan location
 

--- a/docs/_openbolt_5x/bolt_running_scripts.md
+++ b/docs/_openbolt_5x/bolt_running_scripts.md
@@ -29,7 +29,7 @@ Using a Puppet file reference is preferred for a few reasons:
 To execute a script you'll want to specify:
 - The script file reference (Puppet file reference, relative path, or absolute path)
 - Any arguments the script takes
-- [Bolt CLI options](bolt_command_reference.html#script-run) 
+- [Bolt CLI options](bolt_command_reference.html) 
 
 For example, the following script is named `update_images.sh` and is in a module named
 `manage_docker`. The script gets an updated image for every Docker container running in a

--- a/docs/_openbolt_5x/boltspec_reference.md
+++ b/docs/_openbolt_5x/boltspec_reference.md
@@ -59,7 +59,7 @@ and have the mocked function return `{ 'stdout' => 'Task was successful!' }`.
 ### `expect_command`
 
 The `expect_command` function mocks the [`run_command`
-function](plan_functions.html#run-command). It accepts a single parameter: a
+function](plan_functions.html#run_command). It accepts a single parameter: a
 command.
 
 ```ruby
@@ -95,7 +95,7 @@ The `expect_command` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-command) that must be passed to the
+  The [options](plan_functions.html#run_command) that must be passed to the
   `run_command` function. The test fails if the command is not run with the set
   of options.
 
@@ -153,7 +153,7 @@ The `expect_command` function accepts the following modifiers:
 ### `expect_download`
 
 The `expect_download` function mocks the [`download_file`
-function](plan_functions.html#download-file). It accepts a single parameter: the
+function](plan_functions.html#download_file). It accepts a single parameter: the
 path to a remote file to download.
 
 ```ruby
@@ -189,7 +189,7 @@ The `expect_download` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#download-file) that must be passed to the
+  The [options](plan_functions.html#download_file) that must be passed to the
   `download_file` function. The test fails if the file is not downloaded with
   the set of options.
 
@@ -303,7 +303,7 @@ The `expect_out_verbose` function accepts the following modifiers:
 
 ### `expect_plan`
 
-The `expect_plan` function mocks the [`run_plan` function](plan_functions.html#run-plan).
+The `expect_plan` function mocks the [`run_plan` function](plan_functions.html#run_plan).
 It accepts a single parameter: the name of a plan.
 
 ```ruby
@@ -330,7 +330,7 @@ The `expect_plan` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-plan) that must be passed
+  The parameters and [options](plan_functions.html#run_plan) that must be passed
   to the `run_plan` function. The test fails if the plan is not run with the set
   of parameters and options.
 
@@ -370,7 +370,7 @@ The `expect_plan` function accepts the following modifiers:
 ### `expect_script`
 
 The `expect_script` function mocks the [`run_script`
-function](plan_functions.html#run-script). It accepts a single parameter: the path
+function](plan_functions.html#run_script). It accepts a single parameter: the path
 to a script.
 
 ```ruby
@@ -406,7 +406,7 @@ The `expect_script` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-script) that must be passed to the
+  The [options](plan_functions.html#run_script) that must be passed to the
   `run_script` function. The test fails if the script is not run with the set of
   options.
 
@@ -463,7 +463,7 @@ The `expect_script` function accepts the following modifiers:
 ### `expect_task`
 
 The `expect_task` functions mocks the [`run_task`
-function](plan_functions.html#run-task). It accepts a single parameter: the name
+function](plan_functions.html#run_task). It accepts a single parameter: the name
 of a task.
 
 ```ruby
@@ -499,7 +499,7 @@ The `expect_task` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-script) that must be passed
+  The parameters and [options](plan_functions.html#run_script) that must be passed
   to the `run_task` function. The test fails if the task is not run with the set
   of parameters and options.
 
@@ -556,7 +556,7 @@ The `expect_task` function accepts the following modifiers:
 ### `expect_upload`
 
 The `expect_upload` function mocks the [`upload_file`
-function](plan_functions.html#upload-file). It accepts a single parameter: the
+function](plan_functions.html#upload_file). It accepts a single parameter: the
 path to a local file to upload.
 
 ```ruby
@@ -592,7 +592,7 @@ The `expect_upload` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#upload-file) that must be passed to the
+  The [options](plan_functions.html#upload_file) that must be passed to the
   `upload_file` function. The test fails if the file is not uploaded with the
   set of options.
 
@@ -650,14 +650,14 @@ function in a plan.
 ### `allow_apply_prep`
 
 The `allow_apply_prep` function stubs the [`apply_prep`
-function](plan_functions.html#apply-prep). It does not accept parameters or
+function](plan_functions.html#apply_prep). It does not accept parameters or
 modifiers. Using the `allow_apply_prep` stub only allows you to invoke the
 `apply_prep` function in a plan.
 
 ### `allow_command`
 
 The `allow_command` function stubs the [`run_command`
-function](plan_functions.html#run-command). It accepts a single parameter: a
+function](plan_functions.html#run_command). It accepts a single parameter: a
 command.
 
 ```ruby
@@ -693,7 +693,7 @@ The `allow_command` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-command) that can be passed to the
+  The [options](plan_functions.html#run_command) that can be passed to the
   `run_command` function. The test fails if the command is run with a different
   set of options.
 
@@ -751,7 +751,7 @@ The `allow_command` function accepts the following modifiers:
 ### `allow_download`
 
 The `allow_download` function stubs the [`download_file`
-function](plan_functions.html#download-file). It accepts a single parameter: the
+function](plan_functions.html#download_file). It accepts a single parameter: the
 path to a remote file to download.
 
 ```ruby
@@ -787,7 +787,7 @@ The `allow_download` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#download-file) that can be passed to the
+  The [options](plan_functions.html#download_file) that can be passed to the
   `download_file` function. The test fails if the file is downloaded with a
   different set of options.
 
@@ -903,7 +903,7 @@ The `allow_out_verbose` function accepts the following stub modifiers:
 ### `allow_plan`
 
 The `allow_plan` function stubs the [`run_plan`
-function](plan_functions.html#run-plan). It accepts a single parameter: the name
+function](plan_functions.html#run_plan). It accepts a single parameter: the name
 of a plan.
 
 ```ruby
@@ -930,7 +930,7 @@ The `allow_plan` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-plan) that can be passed to
+  The parameters and [options](plan_functions.html#run_plan) that can be passed to
   the `run_plan` function. The test fails if the plan is run with a different
   set of parameters and options.
 
@@ -970,7 +970,7 @@ The `allow_plan` function accepts the following modifiers:
 ### `allow_script`
 
 The `allow_script` function stubs the [`run_script`
-function](plan_functions.html#run-script). It accepts a single parameter: the path
+function](plan_functions.html#run_script). It accepts a single parameter: the path
 to a script.
 
 ```ruby
@@ -1006,7 +1006,7 @@ The `allow_script` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-script) that can be passed to the
+  The [options](plan_functions.html#run_script) that can be passed to the
   `run_script` function. The test fails if the script is run with a different
   set of options.
 
@@ -1063,7 +1063,7 @@ The `allow_script` function accepts the following modifiers:
 ### `allow_task`
 
 The `allow_task` function stubs the [`run_task`
-function](plan_functions.html#run-task). It accepts a single parameter: the name
+function](plan_functions.html#run_task). It accepts a single parameter: the name
 of a task.
 
 ```ruby
@@ -1099,7 +1099,7 @@ The `allow_task` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-script) that can be passed to the
+  The parameters and [options](plan_functions.html#run_script) that can be passed to the
   `run_task` function. The test fails if the task is run with a different
   set of parameters and options.
 
@@ -1156,7 +1156,7 @@ The `allow_task` function accepts the following modifiers:
 ### `allow_upload`
 
 The `allow_upload` function stubs the [`upload_file`
-function](plan_functions.html#upload-file). It accepts a single parameter: the
+function](plan_functions.html#upload_file). It accepts a single parameter: the
 path to a local file to upload.
 
 ```ruby
@@ -1192,7 +1192,7 @@ The `allow_upload` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#upload-file) that can be passed to the
+  The [options](plan_functions.html#upload_file) that can be passed to the
   `upload_file` function. The test fails if the file is uploaded with a
   different set of  options.
 
@@ -1243,7 +1243,7 @@ scheme.
 ### `allow_any_command`
 
 The `allow_any_command` function stubs all invocations of the [`run_command`
-function](plan_functions.html#run-command). It does not accept parameters.
+function](plan_functions.html#run_command). It does not accept parameters.
 
 ```ruby
 allow_any_command
@@ -1278,7 +1278,7 @@ The `allow_any_command` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-command) that can be passed to the
+  The [options](plan_functions.html#run_command) that can be passed to the
   `run_command` function. The test fails if any command is run with a different
   set of options.
 
@@ -1336,7 +1336,7 @@ The `allow_any_command` function accepts the following modifiers:
 ### `allow_any_download`
 
 The `allow_any_download` function stubs all invocations of the [`download_file`
-function](plan_functions.html#download-file). It does not accept parameters.
+function](plan_functions.html#download_file). It does not accept parameters.
 
 ```ruby
 allow_any_download
@@ -1371,7 +1371,7 @@ The `allow_any_download` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#download-file) that can be passed to the
+  The [options](plan_functions.html#download_file) that can be passed to the
   `download_file` function. The test fails if any file is downloaded with a
   different set of options.
 
@@ -1489,7 +1489,7 @@ The `allow_any_out_verbose` function accepts the following modifiers:
 ### `allow_any_plan`
 
 The `allow_any_plan` function stubs all invocations of the [`run_plan`
-function](plan_functions.html#run-plan). It does not accept parameters.
+function](plan_functions.html#run_plan). It does not accept parameters.
 
 ```ruby
 allow_any_plan
@@ -1515,7 +1515,7 @@ The `allow_any_plan` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-plan) that can be passed to
+  The parameters and [options](plan_functions.html#run_plan) that can be passed to
   the `run_plan` function. The test fails if any plan is run with a different
   set of parameters and options.
 
@@ -1555,7 +1555,7 @@ The `allow_any_plan` function accepts the following modifiers:
 ### `allow_any_script`
 
 The `allow_script` function stubs all invocations of the [`run_script`
-function](plan_functions.html#run-script). It does not accept parameters.
+function](plan_functions.html#run_script). It does not accept parameters.
 
 ```ruby
 allow_any_script
@@ -1590,7 +1590,7 @@ The `allow_any_script` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#run-script) that can be passed to the
+  The [options](plan_functions.html#run_script) that can be passed to the
   `run_script` function. The test fails if any script is run with a different
   set of options.
 
@@ -1647,7 +1647,7 @@ The `allow_any_script` function accepts the following modifiers:
 ### `allow_any_task`
 
 The `allow_any_task` function stubs the [`run_task`
-function](plan_functions.html#run-task). It does not accept parameters.
+function](plan_functions.html#run_task). It does not accept parameters.
 
 ```ruby
 allow_any_task
@@ -1682,7 +1682,7 @@ The `allow_any_task` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The parameters and [options](plan_functions.html#run-script) that can be passed to the
+  The parameters and [options](plan_functions.html#run_script) that can be passed to the
   `run_task` function. The test fails if any task is run with a different
   set of parameters and options.
 
@@ -1730,7 +1730,7 @@ The `allow_any_task` function accepts the following modifiers:
 ### `allow_any_upload`
 
 The `allow_any_upload` function stubs any invocation of the [`upload_file`
-function](plan_functions.html#upload-file). It does not accept parameters.
+function](plan_functions.html#upload_file). It does not accept parameters.
 
 ```ruby
 allow_any_upload
@@ -1765,7 +1765,7 @@ The `allow_any_upload` function accepts the following modifiers:
 
 - `with_params(parameters)`
 
-  The [options](plan_functions.html#upload-file) that can be passed to the
+  The [options](plan_functions.html#upload_file) that can be passed to the
   `upload_file` function. The test fails if any file is uploaded with a
   different set of  options.
 

--- a/docs/_openbolt_5x/choria-transport.md
+++ b/docs/_openbolt_5x/choria-transport.md
@@ -18,9 +18,9 @@ Key components:
 
 The transport uses the `choria-mcorpc-support` Ruby gem as its client library.
 
-For the project roadmap, see [choria-transport-plan.md](choria-transport-plan.html).
-For developer documentation, see [choria-transport-dev.md](choria-transport-dev.html).
-For test environment setup, see [choria-transport-testing.md](choria-transport-testing.html).
+For the project roadmap, see [choria-transport-plan.md](https://github.com/openvoxproject/openbolt/blob/main/developer-docs/choria/choria-transport-plan.md).
+For developer documentation, see [choria-transport-dev.md](https://github.com/openvoxproject/openbolt/blob/main/developer-docs/choria/choria-transport-dev.md).
+For test environment setup, see [choria-transport-testing.md](https://github.com/openvoxproject/openbolt/blob/main/developer-docs/choria/choria-transport-testing.md).
 
 ## Prerequisites
 
@@ -230,7 +230,7 @@ agent is not available on a target, that target gets a clear error result.
 
 Not yet supported. These will be implemented in Phase 4 with a new
 chunked file-transfer agent. See the
-[project plan](choria-transport-plan.html#phase-4-file-transfer-agent) for
+[project plan](https://github.com/openvoxproject/openbolt/blob/main/developer-docs/choria/choria-transport-plan.md#phase-4-file-transfer-agent) for
 details.
 
 ### connected?
@@ -295,7 +295,7 @@ mcollective::plugin_classes:
 Restart `choria-server` on target nodes after installing.
 
 For detailed installation instructions (including manual file copy), see
-[choria-transport-testing.md](choria-transport-testing.html#shell-agent).
+[choria-transport-testing.md](https://github.com/openvoxproject/openbolt/blob/main/developer-docs/choria/choria-transport-testing.md#shell-agent).
 
 ## Using bolt_tasks with an OpenVox/Puppet Server
 

--- a/docs/_openbolt_5x/creating_a_script_plan.md
+++ b/docs/_openbolt_5x/creating_a_script_plan.md
@@ -128,7 +128,7 @@ parameters:
 ```
 
 Next set that argument as an environment variable as part of the [script
-step](writing_yaml_plans.html#script_step)
+step](writing_yaml_plans.html#script-step)
 ```yaml
 steps:
   - name: run_script
@@ -204,7 +204,7 @@ parameters:
     ...
 ```
 
-Next, add the argument to the [script step](writing_yaml_plans.html#script_step)
+Next, add the argument to the [script step](writing_yaml_plans.html#script-step)
 ```yaml
 steps:
   - name: run_script
@@ -304,7 +304,7 @@ parameters:
     ...
 ```
 
-Next, add the argument to the [script step](writing_yaml_plans.html#script_step)
+Next, add the argument to the [script step](writing_yaml_plans.html#script-step)
 ```yaml
 steps:
   - name: run_script

--- a/docs/_openbolt_5x/experimental_features.md
+++ b/docs/_openbolt_5x/experimental_features.md
@@ -341,7 +341,7 @@ of plan steps to execute in the background while other parts of the plan execute
 * The `background` plan function begins executing a block of code in parellel with the main plan
   and other backgrounded code blocks. This is great for use cases where you want to start a process
   and don't care about the results, or don't need the results until much later in the plan. This
-  function returns a [Future](bolt_types_reference.html#Future) object so that the result can be
+  function returns a [Future](bolt_types_reference.html#future) object so that the result can be
   accessed later in the plan.
 * The `wait` function is a sister to `background`. It accepts a Future or array of Futures and
   blocks until they are finished, optionally with a timeout, then returns the results.

--- a/docs/_openbolt_5x/glossary.md
+++ b/docs/_openbolt_5x/glossary.md
@@ -17,7 +17,7 @@ Use the `apply` [Bolt plan function](writing_plans.html) to apply a block of Pup
 block) to a target.
 
 Before you can apply a manifest to a target, prepare the target using
-the `apply_prep` plan function. See [`apply_prep`](#apply-prep).
+the `apply_prep` plan function. See [`apply_prep`](#apply_prep).
 
 📖 **Related information**
 
@@ -32,7 +32,7 @@ path. The `puppet-agent` package and facts are required for an `apply`.
 📖 **Related information**
 
 - [Applying Puppet code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html)
-- [`apply_prep` example](plan_functions.html#apply-prep)
+- [`apply_prep` example](plan_functions.html#apply_prep)
 
 ## catalog
 
@@ -59,7 +59,7 @@ for a list of supported platforms.
 ## fact
 
 A fact is a piece of information about a target, such as its hostname, IP
-address, or operating system. Facts are typically gathered by Puppet's [Facter](#Facter) tool.
+address, or operating system. Facts are typically gathered by Puppet's [Facter](#facter) tool.
 
 ## Facter
 

--- a/docs/_openbolt_5x/inspecting_plans.md
+++ b/docs/_openbolt_5x/inspecting_plans.md
@@ -10,7 +10,7 @@ effect it has on your targets.
 
 > 🔩 **Tip:** Bolt is packaged with a collection of modules that contain useful
 > plans to support common workflows. For details, see [Packaged
-> modules](bolt_installing_modules.html#packaged-modules).
+> modules](packaged_modules.html).
 
 ## Discover plans
 
@@ -30,7 +30,7 @@ View a list of available plans:
 
 If you don't see a plan you were expecting to find, make sure the plan is
 located in the correct directory. For more information, see [How Bolt locates
-plans](./bolt_running_plans.html#how-bolt-locates-plans)
+plans](./bolt_running_plans.html#plan-location)
 
 ## Show documentation for a plan
 

--- a/docs/_openbolt_5x/logs.md
+++ b/docs/_openbolt_5x/logs.md
@@ -222,7 +222,7 @@ The next time you run Bolt, the warning message will not be logged.
 
 - [Debugging tasks](writing_tasks.html#debugging-tasks)
 - [Debugging YAML plans](writing_tasks.html#debugging-tasks)
-- [Debugging Puppet language plans](writing_plans.html#debugging-plans)
+- [Debugging Puppet language plans](debugging_plans.html#debugging-plans)
 - [Project level configuration](configuring_bolt.html#project-level-configuration)
 - [Applying Puppet code](applying_manifest_blocks.html) 
 - [Bolt command reference](bolt_command_reference.html)

--- a/docs/_openbolt_5x/projects.md
+++ b/docs/_openbolt_5x/projects.md
@@ -51,7 +51,7 @@ file:
 
 > 🔩 **Tip:** To create a project with a list of pre-installed modules, use the
 > `--modules` option. For more information, see
-> [](./bolt_installing_modules.html#create-a-Bolt-project-with-pre-installed-modules).
+> [](./bolt_installing_modules.html#create-a-bolt-project-with-pre-installed-modules).
 
 ## Configuring a project
 

--- a/docs/_openbolt_5x/supported_plugins.md
+++ b/docs/_openbolt_5x/supported_plugins.md
@@ -18,7 +18,7 @@ files, and plans.
 | --- | --- | --- |
 | `aws_inventory` | Generate targets from Amazon Web Services EC2 instances. | [aws_inventory](https://forge.puppet.com/puppetlabs/aws_inventory) |
 | `azure_inventory` | Generate targets from Azure VMs and VM scale sets. | [azure_inventory](https://forge.puppet.com/puppetlabs/azure_inventory) |
-| `env_var` | Read values stored in environment variables. | [env_var](#env-var) |
+| `env_var` | Read values stored in environment variables. | [env_var](#env_var) |
 | `gcloud_inventory` | Generate targets from Google Cloud compute engine instances. | [gcloud_inventory](https://forge.puppet.com/puppetlabs/gcloud_inventory) |
 | `pkcs7` | Decrypt ciphertext. | [pkcs7](https://forge.puppet.com/puppetlabs/pkcs7) |
 | `prompt` | Prompt the user for a sensitive value. | [prompt](#prompt) |

--- a/docs/_openbolt_5x/testing_plans.md
+++ b/docs/_openbolt_5x/testing_plans.md
@@ -267,16 +267,16 @@ documentation.
 
 | plan function | Stub function | Global stub function | Mock function
 | --- | --- | --- | --- |
-| [`apply`](plan_functions.html#apply) | [`allow_apply`](boltspec_reference.html#allow-apply) | - | - |
-| [`apply_prep`](plan_functions.html#apply-prep) | [`allow_apply_prep`](boltspec_reference.html#allow-apply-prep) | - | - |
-| [`download_file`](plan_functions.html#download-file) | [`allow_download`](boltspec_reference.html#allow-download) | [`allow_any_download`](boltspec_reference.html#allow-any-download) | [`expect_download`](boltspec_reference.html#expect_download) |
-| [`out::message`](plan_functions.html#outmessage) | [`allow_out_message`](boltspec_reference.html#allow-out-message) | [`allow_any_out_message`](boltspec_reference.html#allow-any-out-message) | [`expect_out_message`](boltspec_reference.html#expect-out-message) |
-| [`out::verbose`](plan_functions.html#outverbose) | [`allow_out_verbose`](boltspec_reference.html#allow-out-verbose) | [`allow_any_out_verbose`](boltspec_reference.html#allow-any-out-verbose) | [`expect_out_verbose`](boltspec_reference.html#expect-out-verbose) |
-| [`run_command`](plan_functions.html#run-command) | [`allow_command`](boltspec_reference.html#allow-command) | [`allow_any_command`](boltspec_reference.html#allow-any-command) | [`expect_command`](boltspec_reference.html#expect-command) |
-| [`run_plan`](plan_functions.html#run-plan) | [`allow_plan`](boltspec_reference.html#allow-plan) | [`allow_any_plan`](boltspec_reference.html#allow-any-plan) | [`expect_plan`](boltspec_reference.html#expect-plan) |
-| [`run_script`](plan_functions.html#run-script) | [`allow_script`](boltspec_reference.html#allow-script) | [`allow_any_script`](boltspec_reference.html#allow-any-script) |[`expect_script`](boltspec_reference.html#expect-script) |
-| [`run_task`](plan_functions.html#run-task) | [`allow_task`](boltspec_reference.html#allow-task) | [`allow_any_task`](boltspec_reference.html#allow-any-task) | [`expect_task`](boltspec_reference.html#expect-task) |
-| [`upload_file`](plan_functions.html#upload-file) | [`allow_upload`](boltspec_reference.html#allow-upload) | [`allow_any_upload`](boltspec_reference.html#allow-any-upload) | [`expect_upload`](boltspec_reference.html#expect-upload) |
+| [`apply`](plan_functions.html#apply) | [`allow_apply`](boltspec_reference.html#allow_apply) | - | - |
+| [`apply_prep`](plan_functions.html#apply_prep) | [`allow_apply_prep`](boltspec_reference.html#allow_apply_prep) | - | - |
+| [`download_file`](plan_functions.html#download_file) | [`allow_download`](boltspec_reference.html#allow_download) | [`allow_any_download`](boltspec_reference.html#allow_any_download) | [`expect_download`](boltspec_reference.html#expect_download) |
+| [`out::message`](plan_functions.html#outmessage) | [`allow_out_message`](boltspec_reference.html#allow_out_message) | [`allow_any_out_message`](boltspec_reference.html#allow_any_out_message) | [`expect_out_message`](boltspec_reference.html#expect_out_message) |
+| [`out::verbose`](plan_functions.html#outverbose) | [`allow_out_verbose`](boltspec_reference.html#allow_out_verbose) | [`allow_any_out_verbose`](boltspec_reference.html#allow_any_out_verbose) | [`expect_out_verbose`](boltspec_reference.html#expect_out_verbose) |
+| [`run_command`](plan_functions.html#run_command) | [`allow_command`](boltspec_reference.html#allow_command) | [`allow_any_command`](boltspec_reference.html#allow_any_command) | [`expect_command`](boltspec_reference.html#expect_command) |
+| [`run_plan`](plan_functions.html#run_plan) | [`allow_plan`](boltspec_reference.html#allow_plan) | [`allow_any_plan`](boltspec_reference.html#allow_any_plan) | [`expect_plan`](boltspec_reference.html#expect_plan) |
+| [`run_script`](plan_functions.html#run_script) | [`allow_script`](boltspec_reference.html#allow_script) | [`allow_any_script`](boltspec_reference.html#allow_any_script) |[`expect_script`](boltspec_reference.html#expect_script) |
+| [`run_task`](plan_functions.html#run_task) | [`allow_task`](boltspec_reference.html#allow_task) | [`allow_any_task`](boltspec_reference.html#allow_any_task) | [`expect_task`](boltspec_reference.html#expect_task) |
+| [`upload_file`](plan_functions.html#upload_file) | [`allow_upload`](boltspec_reference.html#allow_upload) | [`allow_any_upload`](boltspec_reference.html#allow_any_upload) | [`expect_upload`](boltspec_reference.html#expect_upload) |
 
 ### Modifiers
 
@@ -870,7 +870,7 @@ pdk bundle exec rake spec
 ### Testing a plan that uses `run_task_with`
 
 The following example demonstrates testing a plan that uses the [`run_task_with()`
-plan function](plan_functions.html#run-task-with).
+plan function](plan_functions.html#run_task_with).
 
 This plan accepts two parameters: `sql` and `targets`. The plan executes SQL on
 a Postgres database using the `postgresql::sql` task. Each target has a

--- a/docs/_openbolt_5x/troubleshooting.md
+++ b/docs/_openbolt_5x/troubleshooting.md
@@ -191,7 +191,7 @@ would be in Puppet. For example, Puppet `notice` level logs are equivalent to
 the `info` level in Bolt. As a result, if you use the `notice()` Puppet log
 function, Bolt does not print the contents of `notice` to the console by
 default. You can see which Bolt log level each Puppet log level maps to in
-[Puppet log functions in Bolt](writing_plans.html#puppet-log-functions-in-bolt).
+[Puppet log functions in Bolt](debugging_plans.html#puppet-log-functions-in-bolt).
 
 To print logs and messages in Bolt to the console you can do one or more of the
 following:
@@ -201,7 +201,7 @@ following:
   configuration file.
 
 - When you have messages you want to log directly from Bolt, use Bolt's [log
-  plan functions](writing_plans.html#log-functions).
+  plan functions](debugging_plans.html#log-functions).
 
 - When you have messages you want printed to the console regardless of log
   level, you should use the [`out::message` plan

--- a/docs/_openbolt_5x/using_plugins.md
+++ b/docs/_openbolt_5x/using_plugins.md
@@ -142,7 +142,7 @@ $resolved = resolve_references($references)
 
 📖 **Related information**
 
-- [Bolt functions: resolve_references](plan_functions.html#resolve-references)
+- [Bolt functions: resolve_references](plan_functions.html#resolve_references)
 
 ## Secret plugins
 

--- a/docs/_openbolt_5x/writing_plans.md
+++ b/docs/_openbolt_5x/writing_plans.md
@@ -562,7 +562,7 @@ in the inventory, otherwise it will create the target and return it. Similarly
 an array of target objects. Some transport options can be [configured in the URI
 string](https://puppet.com/docs/bolt/latest/configuring_bolt.html), but if this
 isn't sufficient you can use
-[set_config](https://puppet.com/docs/bolt/latest/plan_functions.html#set-config)
+[set_config](https://puppet.com/docs/bolt/latest/plan_functions.html#set_config)
 to set configuration options on the targets.
 
 Use `Target.new()` to create a target that clobbers an existing target with the
@@ -616,12 +616,12 @@ plan create_targets(
 There are a handful of functions available to modify existing target objects
 inside a plan:
 
-* [add_facts](https://puppet.com/docs/bolt/latest/plan_functions.html#add-facts)
-* [add_to_group](https://puppet.com/docs/bolt/latest/plan_functions.html#add-to-group)
-* [remove_from_group](https://puppet.com/docs/bolt/latest/plan_functions.html#remove-from-group)
-* [set_config](https://puppet.com/docs/bolt/latest/plan_functions.html#set-config)
-* [set_feature](https://puppet.com/docs/bolt/latest/plan_functions.html#set-feature)
-* [set_var](https://puppet.com/docs/bolt/latest/plan_functions.html#set-var)
+* [add_facts](https://puppet.com/docs/bolt/latest/plan_functions.html#add_facts)
+* [add_to_group](https://puppet.com/docs/bolt/latest/plan_functions.html#add_to_group)
+* [remove_from_group](https://puppet.com/docs/bolt/latest/plan_functions.html#remove_from_group)
+* [set_config](https://puppet.com/docs/bolt/latest/plan_functions.html#set_config)
+* [set_feature](https://puppet.com/docs/bolt/latest/plan_functions.html#set_feature)
+* [set_var](https://puppet.com/docs/bolt/latest/plan_functions.html#set_var)
 
 These can be used to add facts, transport specific configuration options,
 features, and variables to target objects, as well as add or remove objects from
@@ -634,7 +634,7 @@ runs.
 
 Target objects can be temporarily modified during a plan run. For example, you
 can store a target's configuration in a temporary variable, modify the target's
-configuration using the [`set_config`](plan_functions.html#set-config) function,
+configuration using the [`set_config`](plan_functions.html#set_config) function,
 and then restore the target's original configuration.
 
 Temporarily modify a target's configuration:

--- a/docs/_openbolt_5x/writing_plans.md
+++ b/docs/_openbolt_5x/writing_plans.md
@@ -111,9 +111,9 @@ plan](https://github.com/puppetlabs/puppetlabs-facts/blob/master/plans/init.pp).
 ## Defining plan parameters
 
 After the plan's name, in parentheses, define any parameters that you want to
-pass into your plan as arguments. To define a parameter, use the syntax `<TYPE>
-<PARAMETER_NAME>`. For example, the following plan defines two parameters, `src`
-and `dest`, which are both strings:
+pass into your plan as arguments. To define a parameter, use the syntax
+`<TYPE> <PARAMETER_NAME>`. For example, the following plan defines two
+parameters, `src` and `dest`, which are both strings:
 
 ```puppet
 plan mymodule::myplan(
@@ -144,7 +144,7 @@ plan test::parameter_passing (
 
 The implementation of the `demo_undef_bash.sh` task is:
 
-```shell script
+```shell
 #!/bin/bash
 example_env=$PT_example_nul
 echo "Environment: $PT_example_nul"
@@ -675,7 +675,7 @@ PuppetDB. Variables are computed externally or assigned directly.
 Using the `facts` plan function does not automatically collect facts for a
 target, and will only return facts that are currently set in the inventory. To
 collect facts from a target and set them in the inventory, run the
-[facts](#collect-facts-from-targets) plan or
+[facts](#collect-facts-from-the-targets) plan or
 [puppetdb_fact](#collect-facts-from-puppetdb) plan.
 
 Set variables in a plan using `$target.set_var`:

--- a/docs/_openbolt_5x/writing_tasks.md
+++ b/docs/_openbolt_5x/writing_tasks.md
@@ -184,7 +184,7 @@ environment in task code as `PT_message`. When a user runs the task, they can
 specify the value for the parameter on the command line as `message=hello`, and
 the task runner submits the value `hello` to the `PT_message` variable.
 
-```shell script
+```shell
 #!/usr/bin/env bash
 echo your message is $PT_message
 ```
@@ -700,7 +700,7 @@ targets:
 
 Finally, make `my_slack` a target that can run the `slack::message`:
 
-```shell script
+```shell
 bolt task run slack::message --targets my_slack message="hello" channel=<slack channel id>
 ```
 
@@ -721,7 +721,7 @@ them instead of arguments.
 
 Given a script that accepts positional arguments on the command line:
 
-```shell script
+```shell
 version=$1
 [ -z "$version" ] && echo "Must specify a version to deploy && exit 1
 
@@ -734,7 +734,7 @@ fi
 
 To convert the script into a task, replace this logic with task variables:
 
-```shell script
+```shell
 version=$PT_version #no need to validate if we use metadata
 if [ -z "$PT_filename" ]; then
   filename=$PT_filename
@@ -984,13 +984,13 @@ quoting to prevent substituted variables from being executed.
 
 Instead of
 
-```shell script
+```shell
 eval "echo $input"
 ```
 
 use
 
-```shell script
+```shell
 eval "echo '$input'"
 ```
 

--- a/docs/_openbolt_5x/writing_tasks.md
+++ b/docs/_openbolt_5x/writing_tasks.md
@@ -174,7 +174,7 @@ for simple JSON types such as strings and numbers. For arrays and hashes, use
 structured input instead, because parameters with undefined values (`nil`,
 `undef`) passed as environment variables have the `String` value `null`. For
 more information, see [Structured input and
-output](#structured-input-and-output).
+output](#using-structured-input-and-output).
 
 To add a parameter to your task as an environment variable, pass the argument
 prefixed with the Puppet task prefix `PT_`.

--- a/docs/_openbolt_5x/writing_yaml_plans.md
+++ b/docs/_openbolt_5x/writing_yaml_plans.md
@@ -769,7 +769,7 @@ converted and prints the converted Puppet language plan to stdout.
 syntactically correct, but behaves differently. Always manually verify a
 converted Puppet language plan's functionality. There are some constructs that
 do not translate from YAML plans to Puppet language plans. These are
-[listed](#yaml-plan-constructs-that-cannot-be-translated-to-puppet-plans) below.
+listed below.
 If you convert a YAML plan to Puppet and it changes behavior, [file an
 issue](https://github.com/puppetlabs/bolt/issues) in Bolt's Git repo.
 


### PR DESCRIPTION
## What

Fix the authored-page broken internal links in the **openbolt** collection. This is workstream **J** of #262 (the site-wide "true zero broken links" effort) — the sibling of the now-merged openvox collection sweep (#273).

Validated by regenerating the openbolt reference pages from `main` (per CONTRIBUTING: `rake references:openbolt VERSION=main`) so the #202 generated pages render, then running htmlproofer against `_site/openbolt/latest`. This brings the broken-link count from **117 instances to 9**. Fixes across 21 authored pages:

- **Anchor slug drift** — `plan_functions`/`boltspec_reference` cross-link anchors are now underscore-form (e.g. `#run-command` → `#run_command`, `#allow-any-out-message` → `#allow_any_out_message`). Plus individual drift like `#Future` → `#future`, `#env-var` → `#env_var`, `#Facter` → `#facter`, a missing "network" segment, capitalisation.
- **Relocated sections re-pointed** — log/debugging topics → the dedicated `debugging_plans.html`, targetspec → `bolt_types_reference.html`, hiera → in-page anchor.
- **Removed-section links** pointed at their bare page; one self-link unlinked ("listed below" is self-explanatory).
- **choria-transport** dev/plan/testing references → their openbolt developer-docs GitHub source (not published to the site).
- **Removed the stale "Upgrade to Bolt 3.0" nav entry** (page never existed for OpenBolt).
- **Page-render fixes (`writing_plans`, `writing_tasks`)** — these pages stopped emitting heading IDs partway down because kramdown switched into raw/literal mode, so several later sections' anchors were reported missing even though the sections exist. Two *render* bugs (not anchor drift): a `<TYPE> <PARAMETER_NAME>` inline code span split across a line break (kramdown parsed `<TYPE>` as an HTML tag), and ` ```shell script ` fences (space in the info string) not recognised as fence openers under GFM. This restored `#collect-facts-from-puppetdb`, `#converting-scripts-to-tasks`, and `#passing-sensitive-data-to-tasks`, and fixed a `writing_plans` self-link missing its "the" segment.

## Remaining 9 (not fixable here)

The remaining 9 broken links all live **inside generated openbolt reference pages** (`bolt_types_reference`, `plan_functions`, `bolt_defaults_reference`, `bolt_project_reference`) — openbolt documentation-template bugs (hyphenated cross-link anchors emitted by the generator). Fixed upstream in OpenVoxProject/openbolt#251 (resolves OpenVoxProject/openbolt#249); they clear here once a new openbolt release is built from `main`. They are, in full:

- `plan_functions.html#run-plan` → `#run_plan`
- `plan_functions.html#apply-prep` (self-link) → `#apply_prep`
- `bolt_inventory_reference.html#plugin-hooks-1` → `#plugin_hooks-1`
- `writing_plans.html#collect-facts-from-targets` → `#collect-facts-from-the-targets` (×2: bolt_types_reference, plan_functions)
- `writing_plugins.html#hooks` → `#plugin-hooks` (×2: bolt_defaults_reference, bolt_project_reference)
- `using_plugins.html#task` → `supported_plugins.html#task` (×2: bolt_defaults_reference, bolt_project_reference)

With the openbolt#251 fixes applied on top, htmlproofer reports **0 failures** for `_site/openbolt/latest`. The generated pages also only render in production once openbolt is built from `main` (`config.yaml` already pins `version: main`; see #202).

Closes #284 · Part of #262 (workstream J)

