### PR TITLE
Remove dead openbolt version config key

### DIFF
--- a/lib/puppet_references/config.yaml
+++ b/lib/puppet_references/config.yaml
@@ -4,6 +4,5 @@ puppet:
     # False defaults make true overrides easier to read/code
     skip_download: false
 openbolt:
-  version: main
   repo:
     skip_download: false


### PR DESCRIPTION
## What

Remove the dead `version: main` key from the `openbolt:` block in `lib/puppet_references/config.yaml`.

## Why

The key has never been read. `build_openbolt_references` ([`lib/puppet_references.rb`](https://github.com/OpenVoxProject/openvox-docs/blob/master/lib/puppet_references.rb)) only consumes `bolt_config.fetch('repo', {})` and resolves the ref to build as:

```ruby
@version_commit = commit || repo.newest_release   # commit = ENV['VERSION']
```

So the actual openbolt ref is `ENV['VERSION']` when passed, otherwise `repo.newest_release` (the newest semver tag). `config['openbolt']['version']` never enters the picture — it's been a no-op since it was introduced alongside the openbolt collection in #232.

Leaving it in is misleading: it implies openbolt reference docs build from `main`, when CI (no `VERSION`) actually — and correctly — builds the newest release tag (currently `5.5.0`). That release-tracking behavior is the intended one, so this just drops the key rather than wiring it up.

No code reads the key (confirmed across `lib/` and `spec/`), so removal is behavior-preserving.
