### PR TITLE
docs: credit OpenVox and Vox Pupuli in the copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The content in this documentation project is
 
 Copyright (c) Puppet, Inc.
+Copyright (c) Vox Pupuli
 
 Licensed under the Creative Commons 3.0
 with Attribution and Share Alike Clauses

--- a/README.markdown
+++ b/README.markdown
@@ -8,19 +8,19 @@ reporting problems with the published docs.
 To build the documentation in this repository, first install Ruby 3.2 or later.
 Then use Bundler to install the project dependencies:
 
-```
+```console
 bundle install
 ```
 
 Then build the documentation with:
 
-```
+```console
 bundle exec jekyll build
 ```
 
 Or serve it locally to preview in a browser:
 
-```
+```console
 bundle exec jekyll serve
 ```
 
@@ -71,4 +71,7 @@ customized or overridden, see the theme documentation for details.
 
 ## Copyright
 
-Copyright (c) 2009-2024 Puppet, Inc. See LICENSE for details.
+Copyright (c) 2009-2024 Puppet, Inc.
+Copyright (c) 2024-present Vox Pupuli.
+
+See LICENSE for details.


### PR DESCRIPTION
## What

The README and LICENSE attributed only Puppet, Inc. This adds Vox Pupuli as the copyright holder for the continuation work, so the notices reflect who maintains the project now.

The documentation content is CC-BY-SA 3.0, so the original `Puppet, Inc.` attribution stays (the license requires it) and the Vox Pupuli line is added alongside it rather than replacing it.

- **LICENSE:** yearless line, matching the existing yearless Puppet line.
- **README:** open-ended `2024-present` range, matching the existing `2009-2024` Puppet line, so it won't go stale.

Also specifies the `console` language on the three README code fences to satisfy markdownlint (MD040).

Closes #296
