### PR TITLE
docs: add OpenVox 8.27.0 to the openvox-agent release contents table

### DIFF
--- a/docs/_openvox_8x/about_agent.md
+++ b/docs/_openvox_8x/about_agent.md
@@ -49,6 +49,7 @@ latest [OpenVox Server documentation][openvox_server].
 
 | OpenVox release | OpenFact | Ruby | OpenSSL |
 | --- | --- | --- | --- |
+| 8.27.0 | 5.6.1 | 3.2.11 | 3.0.20 |
 | 8.26.2 | 5.6.0 | 3.2.11 | 3.0.20 |
 | 8.26.1 | 5.6.0 | 3.2.11 | 3.0.20 |
 | 8.26.0 | 5.6.0 | 3.2.11 | 3.0.20 |


### PR DESCRIPTION
## What

Adds the latest stable OpenVox 8.x release, **8.27.0**, to the "Release contents of `openvox-agent` 8.x" table on the About openvox-agent page. The table previously stopped at 8.26.2.

| OpenVox release | OpenFact | Ruby | OpenSSL |
| --- | --- | --- | --- |
| 8.27.0 | 5.6.1 | 3.2.11 | 3.0.20 |

## Sourcing

- **OpenFact 5.6.1** — from the [8.27.0 release notes](https://github.com/OpenVoxProject/openvox/releases/tag/8.27.0) ("Promote openfact 5.6.1 into 8.x").
- **Ruby 3.2.11 / OpenSSL 3.0.20** — from puppet-runtime `2026.05.11.1` (the runtime 8.27.0 ships), per its `ruby-3.2.json` and `openssl-3.0.json`. Unchanged from 8.26.2.

9.0.0-alpha1 is a prerelease, so it is intentionally not added to the 8.x table.
