### PR TITLE
docs: fix Hiera nav label and stale deprecation content

### DIFF
--- a/_data/nav/openvox_8x.yml
+++ b/_data/nav/openvox_8x.yml
@@ -255,7 +255,7 @@
     link: "designing_convenient_roles.html"
 - text: Hiera
   items:
-  - text: Hiera
+  - text: About Hiera
     link: "hiera_intro.html"
   - text: Interactive Hiera Demo
     link: "hiera_demo.html"

--- a/docs/_openvox_8x/hiera_config_yaml_3.md
+++ b/docs/_openvox_8x/hiera_config_yaml_3.md
@@ -29,7 +29,7 @@ This version of Puppet supports three formats for hiera.yaml --- you can use any
 
 ## Important: version 3 is deprecated
 
-Version 3 of hiera.yaml is deprecated, and we plan to remove support for it in Puppet 6.
+Version 3 of hiera.yaml is deprecated and not recommended. OpenVox 8.x still supports it for backward compatibility, but you should use [version 5][v5] instead.
 
 More importantly, it has some major problems:
 

--- a/docs/_openvox_8x/hiera_config_yaml_4.md
+++ b/docs/_openvox_8x/hiera_config_yaml_4.md
@@ -22,7 +22,7 @@ v4     | Environment and module layers | Deprecated. A transitional format, used
 
 ## Important: version 4 is deprecated.
 
-Version 4 of hiera.yaml is deprecated, and we plan to remove support for it in Puppet 6.
+Version 4 of hiera.yaml is deprecated and not recommended. OpenVox 8.x still supports it for backward compatibility, but you should use [version 5][v5] instead.
 
 More importantly, version 4 can't use some of Hiera 5's best new features, like custom backends.
 

--- a/docs/_openvox_8x/hiera_migrate.md
+++ b/docs/_openvox_8x/hiera_migrate.md
@@ -21,6 +21,8 @@ title: "Upgrading to Hiera 5"
 [custom_backend_system]: ./hiera_custom_backends.html
 [functions_puppet]: ./lang_write_functions_in_puppet.html
 
+> **Note:** Hiera 5 has been the default since Puppet 5 (2017), so most OpenVox 8.x users already use it and do not need this guide. It remains here for the rare case of migrating very old Hiera 3 data.
+
 Upgrading to Hiera 5 offers some major advantages. A real environment data layer means changes to your hierarchy are now routine and testable,
 using multiple backends in your hierarchy is easier and you can make a custom backend.
 


### PR DESCRIPTION
## What

Small Hiera documentation cleanups.

- **Nav:** rename the duplicate "Hiera" item (under the "Hiera" section header) to "About Hiera" in `_data/nav/openvox_8x.yml`.
- **Stale deprecation language:** `hiera_config_yaml_3.md` and `hiera_config_yaml_4.md` said v3/v4 would have "support removed in Puppet 6" (long EOL). Reworded to reflect reality — these formats are deprecated and not recommended, but OpenVox 8.x still supports them for backward compatibility (use v5 instead).
- **`hiera_migrate.md`:** added a short note that Hiera 5 has been the default since Puppet 5 (2017), so most OpenVox 8.x users don't need the migration guide. Kept the page (the site has no redirect mechanism, so deleting it would 404 the old URL).

## Notes

Verified the issue's other claims before working it (see #225): the "broken links" were already resolved (reference labels resolve to existing anchors), and a proposed `puppet lookup` nav entry was dropped as redundant with the existing "Looking up data with Hiera" page.

Passes `jekyll build` and the internal link check. markdownlint changes are confined to modified files (advisory) with no new errors introduced.

Closes #225
