### PR TITLE
docs: repoint puppet.com/docs links to OpenVox equivalents (openvox, openvox-server)

### DIFF
--- a/docs/_openvox-server_8x/ca-api/v1/http_certificate_status.md
+++ b/docs/_openvox-server_8x/ca-api/v1/http_certificate_status.md
@@ -40,7 +40,7 @@ Change the status of the specified certificate. The desired state
 is sent in the body of the PUT request as a one-item PSON hash; the two
 allowed complete hashes are:
 
-* `{"desired_state":"signed"}` (for signing a certificate signing request, similar to `puppetserver ca sign`). To set the validity period of the signed certificate, specify the `cert_ttl` key in the body of the request, with an integer value. By default, this key specifies the number of seconds, but you can specify another time unit. See [configuration](https://puppet.com/docs/puppet/latest/configuration.html#configuration-settings) for a list of Puppet's accepted time unit markers.
+* `{"desired_state":"signed"}` (for signing a certificate signing request, similar to `puppetserver ca sign`). To set the validity period of the signed certificate, specify the `cert_ttl` key in the body of the request, with an integer value. By default, this key specifies the number of seconds, but you can specify another time unit. See [configuration](/openvox/latest/configuration.html#configuration-settings) for a list of Puppet's accepted time unit markers.
 * `{"desired_state":"revoked"}` (for revoking a certificate, similar to
 `puppetserver ca revoke`).
 

--- a/docs/_openvox-server_8x/external_ssl_termination.markdown
+++ b/docs/_openvox-server_8x/external_ssl_termination.markdown
@@ -26,7 +26,7 @@ Note: This assumes the default behavior of Puppet 5 and greater of using Puppet 
 >
 > With `allow-header-cert-info` set to 'true', authorization code will use only the client HTTP header values---not an SSL-layer client certificate---to determine the client subject name, authentication status,
 > and trusted facts. This is true even if the web server is hosting an HTTPS connection. This applies to validation of the client via rules in the
-> [auth.conf](https://puppet.com/docs/puppet/latest/config_file_auth.html) file and any [trusted facts][trusted] extracted from certificate extensions.
+> [auth.conf](/openvox/latest/config_file_auth.html) file and any [trusted facts][trusted] extracted from certificate extensions.
 >
 > If the `client-auth` setting in the `webserver` config block is set to `need` or `want`, the Jetty web server will still validate the client certificate against a certificate authority store, but it will only
 > verify the SSL-layer client certificate---not a certificate in an `X-Client-Cert` header.
@@ -67,4 +67,4 @@ characters must be encoded as `%20` and not `+` characters.
 > [SERVER-217](https://tickets.puppetlabs.com/browse/SERVER-217).
 
 [pem format]: /docs/background/ssl/cert_anatomy.html#pem-file
-[trusted]: https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html#trusted-facts
+[trusted]: /openvox/latest/lang_facts_and_builtin_vars.html#trusted-facts

--- a/docs/_openvox-server_8x/puppet_server_metrics.markdown
+++ b/docs/_openvox-server_8x/puppet_server_metrics.markdown
@@ -7,7 +7,7 @@ title: "Monitoring OpenVox Server metrics"
 [Graphite]: https://graphiteapp.org
 [Grafana]: http://grafana.org
 [sample Grafana dashboard]: ./sample-puppetserver-metrics-dashboard.json
-[static catalogs]: https://puppet.com/docs/puppet/latest/static_catalogs.html
+[static catalogs]: /openvox/latest/static_catalogs.html
 [HTTP client metrics]: ./http_client_metrics.html
 [`grafanadash`]: https://forge.puppet.com/cprice404/grafanadash
 [`metrics.conf`]: ./config_file_metrics.html

--- a/docs/_openvox-server_8x/puppet_server_metrics_performance.markdown
+++ b/docs/_openvox-server_8x/puppet_server_metrics_performance.markdown
@@ -69,7 +69,7 @@ For real-world catalogs, you can generally add an absolute minimum of 15MB for e
 compilation to compiling a catalog for a basic role that installs Tomcat and Postgres servers.
 
 Your Puppet-managed infrastructure is probably larger and more complex than that test scenario, and every complication adds more to each additional JRuby's memory requirements. (For instance, we recommend
-assuming that OpenVox Server will use [at least 512MB per JRuby](https://puppet.com/docs/pe/latest/configuring/config_puppetserver.html) while under load.) You can calculate a similar value unique to your
+assuming that OpenVox Server will use [at least 512MB per JRuby](tuning_guide.html) while under load.) You can calculate a similar value unique to your
 infrastructure by measuring `puppetserver` memory usage during your infrastructure's catalog compilations and comparing it to compiling a minimal catalog for a similar number of nodes.
 
 The `jruby-metrics` section of the [status API][] endpoint also lists the `requested-instances`, which shows what requests have come in that are waiting to borrow a JRuby instance. This part of the status

--- a/docs/_openvox-server_8x/restarting.markdown
+++ b/docs/_openvox-server_8x/restarting.markdown
@@ -5,11 +5,11 @@ canonical: "/puppetserver/latest/restarting.html"
 ---
 
 [logback.xml]: ./config_file_logbackxml.html
-[Hiera]: https://puppet.com/docs/puppet/latest/hiera_intro.html
+[Hiera]: /openvox/latest/hiera_intro.html
 [gems]: ./gems.html
-[core dependencies]: https://puppet.com/docs/puppet/latest/about_agent.html#what-are-puppet-agent-and-puppet-server
-[environment]: https://puppet.com/docs/puppet/latest/environments_about.html
-[environment caching]: https://puppet.com/docs/puppet/latest/configuration.html#environmenttimeout
+[core dependencies]: /openvox/latest/about_agent.html#what-openvox-agent-provides
+[environment]: /openvox/latest/environments_about.html
+[environment caching]: /openvox/latest/configuration.html#environment_timeout
 
 Starting in version 2.3.0, you can restart Puppet Server by sending a hangup signal, also known as a [HUP signal or SIGHUP](https://en.wikipedia.org/wiki/SIGHUP), to the running Puppet Server process. The HUP
 signal stops Puppet Server and reloads it gracefully, without terminating the JVM process. This is generally _much_ faster than completely stopping and restarting the process. This allows you to quickly load
@@ -46,10 +46,6 @@ OS distributions which use systemd service configurations:
 
     systemctl reload puppetserver
 
-> **Note:** If you're using Puppet Enterprise (PE), you can reload the server from the command line by running `service pe-puppetserver reload`. However if you need to change a setting, do so in console or with
-> Heira, and then the agent will reload the server when it applies the change. For more information, see
-> [Configuring and tuning Puppet Server](https://puppet.com/docs/pe/2018.1/config_puppetserver.html#configuring_and_tuning_puppet_server).
-
 ## Restarting Puppet Server to pick up changes
 
 There are three ways to trigger your Puppet Server environment to refresh and pick up changes you've made. A request to the [HTTP Admin API to flush the JRuby pool](./admin-api/v1/jruby-pool.html) is the
@@ -81,4 +77,4 @@ For these types of changes, you must restart the process by using the operating 
 
 > Note: To ensure that the Puppet master and CA service is running in a platform agnostic way, use the `puppet resource service puppetserver ensure=running` command. This command is equivalent to
 > `systemctl start puppetserver` on systems that support it. For more information on the resource command and managing a server’s desired state, see
-> [Man Page: puppet resource](https://puppet.com/docs/puppet/6.4/man/resource.html) and [Resource Type: service](https://puppet.com/docs/puppet/6.4/types/service.html).
+> [Man Page: puppet resource](/openvox/latest/man/resource.html) and [Resource Type: service](/openvox/latest/types/service.html).

--- a/docs/_openvox-server_8x/ssl_server_certificate_change_and_virtual_ips.markdown
+++ b/docs/_openvox-server_8x/ssl_server_certificate_change_and_virtual_ips.markdown
@@ -4,8 +4,6 @@ title: "Puppet Server: Known Issues: SSL Server Certificate Change and Virtual I
 canonical: "/puppetserver/latest/ssl_server_certificate_change_and_virtual_ips.html"
 ---
 
-[pe_db_instructions]: https://puppet.com/docs/pe/2017.2/release_notes_known_issues_puppetdb.html#puppetdb-behind-a-load-balancer-causes-puppet-server-errors
-
 Puppet Server can often encounter `server certificate change is restricted` errors when it makes HTTPS requests to a group of load-balanced servers behind a virtual IP address. This page describes the issue, workarounds for the issue, and our future plans for handling the issue.
 
 The behavior described in this page was identified in [SERVER-207](https://tickets.puppet.com/browse/SERVER-207).
@@ -34,9 +32,6 @@ javax.net.ssl.SSLHandshakeException: server certificate change is restricted dur
 If you need Puppet Server to act as a client to a load-balanced HTTPS service (e.g., multiple PuppetDB servers), your best option right now is to have all of the servers behind the load balancer present the same certificate.
 
 There appear to be ways to fulfill the renegotiation check with certificates that only partially match ([see here for more info](http://hg.openjdk.java.net/bsd-port/bsd-port/jdk/rev/eabde5c42157#l1.186)), but these might not be foolproof, especially because future JDK implementations might disallow these partial matches. The most reliable way is to simply use the same certificates.
-
-The Puppet Enterprise documentation has [instructions for configuring multiple PuppetDB][pe_db_instructions] servers to use a single certificate, but note that this configuration isn't necessarily supported.
-
 
 ### Alternate Workaround
 

--- a/docs/_openvox_8x/READMEtemplate.txt
+++ b/docs/_openvox_8x/READMEtemplate.txt
@@ -45,7 +45,7 @@ Include usage examples for common use cases in the **Usage** section. Show your 
 
 ## Reference
 
-This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) and [style guide](https://puppet.com/docs/puppet/latest/puppet_strings_style.html)
+This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://docs.openvoxproject.org/openvox/latest/openvox_strings.html) and [style guide](https://docs.openvoxproject.org/openvox/latest/openvox_strings_style.html)
 
 If you aren't ready to use Strings yet, manually create a REFERENCE.md in the root of your module directory and list out each of your module's classes, defined types, facts, functions, Puppet tasks, task plans, and resource types and providers, along with the parameters for each.
 

--- a/docs/_openvox_8x/puppet_tasks.md
+++ b/docs/_openvox_8x/puppet_tasks.md
@@ -3,9 +3,8 @@ layout: default
 title: "Puppet tasks"
 ---
 
-[writing]: https://puppet.com/docs/bolt/0.x/writing_tasks_and_plans.html
-[bolt]: https://puppet.com/docs/bolt/0.x/bolt.html
-[pe_tasks]: https://puppet.com/docs/pe/2017.3/orchestrator/running_tasks.html
+[writing]: /openbolt/latest/writing_tasks.html
+[bolt]: /openbolt/latest/getting_started_with_bolt.html
 
 Puppet tasks are single, ad hoc actions that you can run on target machines in your infrastructure, allowing you to make as-needed changes to remote systems. You can run tasks with the Puppet Enterprise orchestrator or with Puppet's standalone task runner, Bolt.
 
@@ -19,4 +18,3 @@ Related topics:
 
 * [Writing tasks and plans][writing]
 * [Running tasks and plans with Bolt][bolt]
-* [Running tasks with the PE orchestrator][pe_tasks]

--- a/docs/_openvox_8x/schemas/catalog.json
+++ b/docs/_openvox_8x/schemas/catalog.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "tags": {
-            "description": "Tags: regex is from https://puppet.com/docs/puppet/latest/lang_reserved.html",
+            "description": "Tags: regex is from https://docs.openvoxproject.org/openvox/latest/lang_reserved.html",
             "type": "array",
             "items": {
                 "type": "string",
@@ -59,7 +59,7 @@
                         }
                     },
                     "tags": {
-                        "description": "Tags: regex is from https://puppet.com/docs/puppet/latest/lang_reserved.html",
+                        "description": "Tags: regex is from https://docs.openvoxproject.org/openvox/latest/lang_reserved.html",
                         "type": "array",
                         "items": {
                             "type": "string",
@@ -67,7 +67,7 @@
                         }
                     },
                     "parameters": {
-                        "description": "Parameters: regex is from https://puppet.com/docs/puppet/latest/lang_reserved.html",
+                        "description": "Parameters: regex is from https://docs.openvoxproject.org/openvox/latest/lang_reserved.html",
                         "type": "object",
                         "patternProperties": {
                             "^[a-z][a-z0-9_]*$": {}

--- a/docs/_openvox_8x/services_agent_windows.markdown
+++ b/docs/_openvox_8x/services_agent_windows.markdown
@@ -165,4 +165,4 @@ In addition to local logging, OpenVox agent submits a [report][] to the OpenVox 
 
 ### Setting Puppet Agent CPU priority
 
-When CPU usage is high, try lowering the priority of the Puppet Agent service. This can be achieved using the [process priority setting](https://puppet.com/docs/puppet/latest/configuration.html#priority), a cross platform configuration option. This can also be set in the OpenVox Server. 
+When CPU usage is high, try lowering the priority of the Puppet Agent service. This can be achieved using the [process priority setting](configuration.html#priority), a cross platform configuration option. This can also be set in the OpenVox Server.

--- a/docs/_openvox_8x/style_guide.markdown
+++ b/docs/_openvox_8x/style_guide.markdown
@@ -1299,7 +1299,7 @@ The example manifest should provide a clear example of how to declare the class 
 
 We recommend several community tools for testing your code and style.
 
-* [Puppet development kit](https://puppet.com/docs/pdk/latest/pdk.html) a package of development and testing tools to help you create great Puppet modules.
+* [Puppet development kit](/pdk.html) a package of development and testing tools to help you create great Puppet modules.
 * [puppet-lint](https://puppet-lint.com/) tests your code for adherence to the style guidelines.
 * [metadata-json-lint](https://github.com/voxpupuli/metadata-json-lint) tests your `metadata.json` for adherence to the style guidelines.
 * For testing your module, we recommend rspec. [rspec-puppet](https://github.com/puppetlabs/rspec-puppet) can help you write rspec tests for Puppet.


### PR DESCRIPTION
## Summary

Repoints `puppet.com/docs` links to OpenVox-hosted equivalents in the `openvox` and `openvox-server` collections, and removes dead Puppet Enterprise references that pointed at puppet.com PE docs OpenVox doesn't have. After this, both collections have **zero** puppet.com/docs links.

Link forms follow CONTRIBUTING: within-collection links are relative (`page.html`), cross-collection links are absolute (`/openvox/latest/page.html`), external links use full URIs.

## Changes

**Repointed to OpenVox equivalents**
- `openvox`: `services_agent_windows` (configuration#priority), `puppet_tasks` (bolt links → `/openbolt/latest/...`), `READMEtemplate.txt` and `schemas/catalog.json` (openvox_strings / lang_reserved, full `docs.openvoxproject.org` URLs since they're consumed off-site), and the style-guide **PDK** link → `/pdk.html` (the OpenVox-hosted PDK page)
- `openvox-server`: `restarting`, `external_ssl_termination`, `puppet_server_metrics`, `ca-api/http_certificate_status` → `/openvox/latest/*`. Two anchors corrected to the OpenVox page versions (`#environment_timeout`, `about_agent#what-openvox-agent-provides`). The "512MB per JRuby" sizing ref now points at the OpenVox Server `tuning_guide`.

**Removed dead Puppet Enterprise references** (no OpenVox equivalent)
- `puppet_tasks.md`: the "Running tasks with the PE orchestrator" related-topics entry
- `restarting.markdown`: the PE-only `service pe-puppetserver reload` note
- `ssl_server_certificate_change_and_virtual_ips.markdown`: the pointer to PE's PuppetDB-behind-a-load-balancer docs

## Remaining `#295` scope

The other collections (`openfact`, `openvoxdb`, `ecosystem`, `openvox-containers`) have **no** puppet.com/docs links. **openbolt** is handled in #319.

## Verification

- `jekyll build` passes
- Every repointed internal target resolves, including all anchored links (verified the link anchors against the target pages' `id`s, not just page existence)
- `catalog.json` still valid JSON (and confirmed it's a stable committed file — the `Http`/`copy_schemas` generator that would overwrite it is never invoked)
- `git diff --check` clean

Part of #295
