### PR TITLE
references: stamp a "generated, do not edit" notice on openbolt pages

### DIFF
--- a/lib/puppet_references/openbolt/docs.rb
+++ b/lib/puppet_references/openbolt/docs.rb
@@ -55,9 +55,23 @@ module PuppetReferences
             next
           end
 
-          content = rewrite_md_links(source.read)
+          content = insert_generated_note(rewrite_md_links(source.read))
           dest = OUTPUT_DIR + filename
           dest.open('w') { |f| f.write(content) }
+        end
+      end
+
+      # Stamp the shared "generated, don't edit" notice after the page's
+      # leading H1 (the placement make_header uses for the other collections).
+      # Falls back to after the YAML front matter, then to the top of the file.
+      def insert_generated_note(content)
+        note = PuppetReferences::Util.generated_note('OpenBolt', @commit)
+        if (m = content.match(/\A(---\n.*?\n---\n\n)?(# [^\n]*\n)/m))
+          "#{m[1]}#{m[2]}\n#{note}\n#{m.post_match}"
+        elsif (m = content.match(/\A(---\n.*?\n---\n)/m))
+          "#{m[1]}\n#{note}\n\n#{m.post_match}"
+        else
+          "#{note}\n\n#{content}"
         end
       end
 

--- a/lib/puppet_references/util.rb
+++ b/lib/puppet_references/util.rb
@@ -4,12 +4,20 @@ require 'puppet_references'
 require 'yaml'
 module PuppetReferences
   module Util
+    # The "this page is generated, don't edit it here" notice that every
+    # generated reference page carries. Kept in one place so all generators
+    # (and the openbolt copy step, which doesn't use make_header) stay in sync.
+    def self.generated_note(repo, commit)
+      '> **NOTE:** This page was generated from the ' \
+        "#{repo} source code based on version #{commit} on #{Time.now}. " \
+        'Do not edit it here; fix it upstream.'
+    end
+
     # Given a hash of data, return YAML frontmatter suitable for the docs site.
     def self.make_header(data, repo, commit)
       # clean out any symbols:
-      generated_at = "> **NOTE:** This page was generated from the #{repo} source code based on version #{commit} on #{Time.now}"
       clean_data = data.transform_keys(&:to_s)
-      YAML.dump(clean_data) + "---\n\n" + "# #{clean_data['title']}" + "\n\n" + generated_at + "\n\n"
+      YAML.dump(clean_data) + "---\n\n" + "# #{clean_data['title']}" + "\n\n" + generated_note(repo, commit) + "\n\n"
     end
 
     # Run a command that can't cope with a contaminated shell environment.


### PR DESCRIPTION
## Summary

Adds a "generated, do not edit" notice to the openbolt reference pages, closing the gap in #314.

The gitignore half of #314 already existed (per-collection `.gitignore` files keep generated pages out of the repo), and the puppet/facter generators already stamp a "generated from source" NOTE via `Util.make_header`. The **openbolt** generator was the one that didn't — it copies upstream pages verbatim with no notice, so they looked hand-editable (and got edited, then clobbered on regeneration — which is what surfaced this).

## Changes

- Extract the notice into `Util.generated_note(repo, commit)` so it lives in one place, and add an explicit **"Do not edit it here; fix it upstream."** line. `make_header` now routes through it, so the openvox/openfact pages gain the same clearer wording.
- The openbolt generator injects the notice after each page's leading H1 (matching `make_header`'s placement), robust to pages with **or** without front matter.

## Verification

Clobbered all generated artifacts (`git clean -Xd` of the three collections) and regenerated each set from scratch. **All 68 freshly-generated pages carry the notice:**
- **openvox** (`rake references:openvox`): `configuration`, `metaparameter`, `indirection`, `report`, `function`, `type`, `type_strings`, plus `man/` (22), `types/` (13), `types_strings/` (15) ✅
- **openfact** (`rake references:openfact`): `core_facts`, `cli` ✅
- **openbolt** (`rake references:openbolt`): all 9 generated pages ✅

`rubocop` clean on both changed files; `jekyll build` passes and the notice renders; regenerated files stay gitignored, so the commit is just the two generator files.

Closes #314
