### PR TITLE
docs: add "Using VoxBox in CI" devkit page

### DIFF
--- a/_data/nav/ecosystem_8x.yaml
+++ b/_data/nav/ecosystem_8x.yaml
@@ -33,6 +33,8 @@
     link: "devkit/jig.html"
   - text: Consistent Style
     link: "devkit/linting.html"
+  - text: Using VoxBox in CI
+    link: "devkit/voxbox.html"
   - text: Unit Testing
     link: "devkit/unit_testing.html"
   - text: Publishing Modules

--- a/docs/_ecosystem_8x/devkit/components.md
+++ b/docs/_ecosystem_8x/devkit/components.md
@@ -13,8 +13,9 @@ We'll focus on the tools that you may want to be aware of and install or use dir
 * [ModuleSync](https://github.com/voxpupuli/modulesync) helps maintain a portfolio of many modules at once.
   It does this by maintaining both common static files (like contributing guides, licenses, or testing boilerplate) as well as templated files like `metadata.json` across multiple module repositories.
   This allows you to keep them all in a consistent state with minimal fuss.
-* [Voxbox](https://github.com/voxpupuli/container-voxbox) is a container that lets you run many of the developer
+* [VoxBox](https://github.com/voxpupuli/container-voxbox) is a container that lets you run many of the developer
 tools without installing anything but a container runtime like Docker or Podman.
+  See [Using VoxBox in CI](voxbox.html) for how to run it locally and in GitLab pipelines.
 * [OnceOver](https://github.com/voxpupuli/onceover) is used for basic validation of your control repository.
   It can sometimes be insurmountable to get proper unit testing for every single module you use, especially when most of them are maintained by others.
   OnceOver will do basic `it_compiles` spec tests for each of your profile classes, giving you some confidence in them.

--- a/docs/_ecosystem_8x/devkit/setup.md
+++ b/docs/_ecosystem_8x/devkit/setup.md
@@ -21,7 +21,7 @@ sudo gem install bundler
 Once you have a working Ruby environment you're ready to start using the Vox Pupuli testing suite!
 
 {% include alert.html type="tip" content="If you'd prefer to run the testing tools via a container runtime like Docker or Podman,
-then check out the [VoxBox](https://github.com/voxpupuli/container-voxbox) project." %}
+then check out [Using VoxBox in CI](voxbox.html)." %}
 
 
 ## Installing a devkit component

--- a/docs/_ecosystem_8x/devkit/voxbox.md
+++ b/docs/_ecosystem_8x/devkit/voxbox.md
@@ -1,0 +1,156 @@
+---
+layout: default
+title: "Using VoxBox in CI"
+---
+
+[VoxBox](https://github.com/voxpupuli/container-voxbox) is a container image that bundles the Vox Pupuli developer toolkit.
+It lets you run the testing and linting tasks without installing Ruby, Bundler, or the gems yourself.
+All you need is a container runtime like Docker or Podman.
+
+This makes it especially handy in CI pipelines, where you want a clean, reproducible environment for every run.
+
+## When to use VoxBox
+
+Use VoxBox when you want the devkit tooling without managing a local Ruby toolchain, particularly in CI.
+
+If you're working locally and already have a Ruby environment, the [`voxpupuli-test` suite](setup.html#setting-up-the-vox-pupuli-test-suite) installed via your `Gemfile` is usually the more convenient choice.
+VoxBox shines when you want isolation from the host, identical behavior across machines, or a turnkey CI image.
+
+GitHub Actions users generally don't need VoxBox: Vox Pupuli modules run the shared reusable workflows ([`voxpupuli/gha-puppet`](https://github.com/voxpupuli/gha-puppet)) instead.
+VoxBox is most useful for GitLab CI and local runs.
+
+## Running tasks locally
+
+Mount your module directory into the container at `/repo` and pass a rake task name.
+The image entrypoint is `bundle exec rake -f /opt/voxbox/Rakefile`, so anything you pass after the image name is treated as a rake task.
+
+```console
+cd puppet-example
+podman run -it --rm -v "$PWD:/repo:Z" ghcr.io/voxpupuli/voxbox:latest spec
+```
+
+With Docker, drop the `:Z` SELinux relabel flag if your system doesn't use it:
+
+```console
+docker run -it --rm -v "$PWD:/repo" ghcr.io/voxpupuli/voxbox:latest lint
+```
+
+Run the container with no task to list everything available (the entrypoint runs `rake -T` for you):
+
+```console
+podman run -it --rm -v "$PWD:/repo:Z" ghcr.io/voxpupuli/voxbox:latest
+```
+
+Common tasks include `spec`, `lint`, `validate`, `rubocop`, and the same `voxpupuli-test` tasks described elsewhere in this guide.
+
+## GitLab CI
+
+Running VoxBox under GitLab CI requires one non-obvious change: you **must blank the image entrypoint** with `entrypoint: [""]`.
+
+GitLab runners start your job by launching a shell and feeding it your `script:`.
+If the image keeps its default entrypoint (`bundle exec rake -f /opt/voxbox/Rakefile`), GitLab hands that shell invocation to rake as a task name instead of running your script, and the job fails before it starts.
+Blanking the entrypoint lets the runner open a shell, after which you call rake yourself.
+
+```yaml
+stages:
+  - lint
+
+variables:
+  # Mirrors the container entrypoint so jobs read cleanly.
+  RAKE: bundle exec rake -f /opt/voxbox/Rakefile
+
+default:
+  image:
+    name: ghcr.io/voxpupuli/voxbox:latest
+    entrypoint: [""]
+
+lint:puppet:
+  stage: lint
+  script:
+    - $RAKE voxpupuli:custom:lint_all
+```
+
+Note the Rakefile path: on current images the bundled Rakefile lives at `/opt/voxbox/Rakefile`.
+On older images it lived at `/Rakefile`, so pin to a recent image and use the `/opt/voxbox/Rakefile` path.
+
+{% include alert.html type="warning" content="These examples use the `:latest` tag for brevity, but for reproducible CI you should pin
+to a specific released version rather than tracking `:latest`, which can change underneath you.
+Just confirm the tag you pin uses the `/opt/voxbox/Rakefile` layout: older images keep the Rakefile at `/Rakefile`.
+Run the container with no arguments (`rake -T`) to list its tasks and check." %}
+
+GitLab can also ingest VoxBox output as native reports.
+For a [code quality report](https://docs.gitlab.com/ci/testing/code_quality/):
+
+```yaml
+code-quality:
+  image:
+    name: ghcr.io/voxpupuli/voxbox:latest
+    entrypoint: [""]
+  stage: lint
+  script:
+    - bundle exec rake -f /opt/voxbox/Rakefile voxpupuli:custom:lint_all
+  variables:
+    CODECLIMATE_REPORT_FILE: "gl-code-quality-report.json"
+  artifacts:
+    when: always
+    reports:
+      codequality: gl-code-quality-report.json
+    expire_in: 1 week
+```
+
+For [unit test (JUnit) reports](https://docs.gitlab.com/ci/testing/unit_test_reports/), add the formatter to your `.rspec`:
+
+```text
+--format RspecJunitFormatter
+--out rspec.xml
+```
+
+Then add the job:
+
+```yaml
+rspec:
+  image:
+    name: ghcr.io/voxpupuli/voxbox:latest
+    entrypoint: [""]
+  stage: test
+  script:
+    - bundle exec rake -f /opt/voxbox/Rakefile spec
+  artifacts:
+    when: always
+    reports:
+      junit: rspec.xml
+    expire_in: 1 week
+```
+
+## Troubleshooting
+
+### `Don't know how to build task 'sh'`
+
+```text
+rake aborted!
+Don't know how to build task 'sh' (See the list of available tasks with rake --tasks)
+```
+
+This means the image entrypoint swallowed your job's `script:`.
+GitLab passed `sh` to the container entrypoint (`bundle exec rake -f /opt/voxbox/Rakefile`), which interpreted it as a rake task name.
+It is not caused by a shell script in your repository, so renaming files won't help.
+
+Fix it by blanking the entrypoint in your job's `image:` block:
+
+```yaml
+image:
+  name: ghcr.io/voxpupuli/voxbox:latest
+  entrypoint: [""]
+```
+
+If you still see a "no such file" error for the Rakefile, confirm you're pointing at `/opt/voxbox/Rakefile` rather than the legacy `/Rakefile` path.
+
+## Validating a pipeline locally
+
+You can reproduce and verify the GitLab setup on your own machine, without pushing to GitLab, using [`gitlab-ci-local`](https://github.com/firecow/gitlab-ci-local).
+A working sample harness (a minimal module plus a corrected `.gitlab-ci.yml`) lives in the [container-voxbox repository](https://github.com/voxpupuli/container-voxbox).
+
+```console
+brew install gitlab-ci-local
+gitlab-ci-local lint:puppet
+```

--- a/docs/_ecosystem_8x/devkit/voxbox.md
+++ b/docs/_ecosystem_8x/devkit/voxbox.md
@@ -16,7 +16,9 @@ Use VoxBox when you want the devkit tooling without managing a local Ruby toolch
 If you're working locally and already have a Ruby environment, the [`voxpupuli-test` suite](setup.html#setting-up-the-vox-pupuli-test-suite) installed via your `Gemfile` is usually the more convenient choice.
 VoxBox shines when you want isolation from the host, identical behavior across machines, or a turnkey CI image.
 
-GitHub Actions users generally don't need VoxBox: Vox Pupuli modules run the shared reusable workflows ([`voxpupuli/gha-puppet`](https://github.com/voxpupuli/gha-puppet)) instead.
+As of June 2026, GitHub Actions users generally don't need VoxBox: Vox Pupuli modules run the
+shared reusable workflows ([`voxpupuli/gha-puppet`](https://github.com/voxpupuli/gha-puppet)),
+which don't use VoxBox yet (see [gha-puppet#96](https://github.com/voxpupuli/gha-puppet/pull/96)).
 VoxBox is most useful for GitLab CI and local runs.
 
 ## Running tasks locally
@@ -43,9 +45,14 @@ podman run -it --rm -v "$PWD:/repo:Z" ghcr.io/voxpupuli/voxbox:latest
 
 Common tasks include `spec`, `lint`, `validate`, `rubocop`, and the same `voxpupuli-test` tasks described elsewhere in this guide.
 
+If you run VoxBox locally a lot, the bundled [EasyVoxBox (`evb`)](https://github.com/voxpupuli/container-voxbox#easyvoxbox-evb)
+helper script shortens these commands and lets you pass options in any order, which is handy for shell aliases.
+Use `evb --noop <task>` to print the full command it would run without executing it.
+
 ## GitLab CI
 
 Running VoxBox under GitLab CI requires one non-obvious change: you **must blank the image entrypoint** with `entrypoint: [""]`.
+The [container-voxbox GitLab docs](https://github.com/voxpupuli/container-voxbox#gitlab) cover the same setup upstream.
 
 GitLab runners start your job by launching a shell and feeding it your `script:`.
 If the image keeps its default entrypoint (`bundle exec rake -f /opt/voxbox/Rakefile`), GitLab hands that shell invocation to rake as a task name instead of running your script, and the job fails before it starts.


### PR DESCRIPTION
## Summary

Adds a dedicated DevKit page, **Using VoxBox in CI**, documenting how to run the
[VoxBox](https://github.com/voxpupuli/container-voxbox) container locally and in GitLab
pipelines. The detailed usage (entrypoint behavior, rake tasks, the GitLab CI gotcha)
previously lived only in the container-voxbox README, so new users kept hitting the same
`Don't know how to build task 'sh'` failure in GitLab and asking in Slack.

## What's in the page

- When to use VoxBox vs. a local `voxpupuli-test` setup, plus a note that GitHub Actions
  users generally want the shared `voxpupuli/gha-puppet` workflows instead.
- Running tasks locally via Docker/Podman (`/repo` mount, no-arg `rake -T`).
- A working **GitLab CI** example: entrypoint blanked (`entrypoint: [""]`), the
  `/opt/voxbox/Rakefile` path, the `$RAKE` variable pattern, plus code-quality and
  JUnit report jobs.
- A warning to pin a released image tag rather than `:latest` for reproducible CI, and to
  confirm the Rakefile layout of whatever tag you pin.
- A troubleshooting section for the `Don't know how to build task 'sh'` error.
- A pointer to `gitlab-ci-local` for local validation.

Also repoints the existing passing mentions in `devkit/setup.md` and
`devkit/components.md` at the new page, and adds it to the Developer Tooling nav.

## Validation

The GitLab CI examples were verified end-to-end on a real GitLab.com pipeline (not just
the local emulator). Reproducible reference project:
**https://gitlab.com/michael.harp/voxbox-ci-sanity**

All three jobs pass on GitLab.com shared runners, and the report widgets ingest correctly.

**Pipeline — all jobs green:**

![Pipeline passed](https://gitlab.com/michael.harp/voxbox-ci-sanity/-/raw/main/screenshots/voxbox-pipeline-passed.png)

**`lint:puppet` log — the `$RAKE` script runs (no `sh` task error), proving the entrypoint fix:**

![lint:puppet job log](https://gitlab.com/michael.harp/voxbox-ci-sanity/-/raw/main/screenshots/voxbox-lint-job-log.png)

**JUnit report ingested — GitLab Tests tab shows 3/3 passing:**

![Tests report](https://gitlab.com/michael.harp/voxbox-ci-sanity/-/raw/main/screenshots/voxbox-tests-report.png)

Markdownlint, `jekyll build`, and `rake test:links` (htmlproofer) all pass locally.

Closes #323
