### PR TITLE
Parameterize reference generation by target collection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,14 @@ bundle exec rake references:openfact INSTALLPATH=docs VERSION=main
 bundle exec rake references:openbolt INSTALLPATH=docs VERSION=main
 ```
 
+By default the references are built into each product's current stable collection
+(e.g. `_openvox_latest`). Use `COLLECTION` to target a specific version's directory,
+for example when regenerating a frozen older major from its matching upstream tag:
+
+```console
+bundle exec rake references:openvox INSTALLPATH=docs VERSION=8.27.0 COLLECTION=_openvox_8x
+```
+
 ## Writing guidelines
 
 ### Naming of OpenVox and Puppet

--- a/Rakefile
+++ b/Rakefile
@@ -33,27 +33,28 @@ end
 desc 'List the available groups of references. Run `rake references:<GROUP>` to build.'
 task :references do
   puts 'The following references are available:'
-  puts 'bundle exec rake references:openvox [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
-  puts 'bundle exec rake references:openfact [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
-  puts 'bundle exec rake references:openbolt [VERSION=<GIT TAG OR COMMIT> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
-  puts '  VERSION can be omitted, uses latest tag'
+  puts 'bundle exec rake references:openvox [VERSION=<GIT TAG OR COMMIT> COLLECTION=<DIR> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
+  puts 'bundle exec rake references:openfact [VERSION=<GIT TAG OR COMMIT> COLLECTION=<DIR> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
+  puts 'bundle exec rake references:openbolt [VERSION=<GIT TAG OR COMMIT> COLLECTION=<DIR> INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
+  puts '  VERSION can be omitted, uses latest non-prerelease tag; an explicit VERSION builds that exact ref (e.g. a 9.x prerelease)'
+  puts '  COLLECTION can be omitted, defaults to the current stable dir per product (e.g. _openvox_latest); set it to build a frozen version (e.g. _openvox_9x)'
   puts '  INSTALLPATH can be omitted, defaults to references_output/'
 end
 
 namespace :references do
   task openvox: 'references:check' do
     require 'puppet_references'
-    PuppetReferences.build_puppet_references(ENV.fetch('VERSION', nil))
+    PuppetReferences.build_puppet_references(ENV.fetch('VERSION', nil), collection: ENV.fetch('COLLECTION', '_openvox_latest'))
   end
 
   task openfact: 'references:check' do
     require 'puppet_references'
-    PuppetReferences.build_facter_references(ENV.fetch('VERSION', nil))
+    PuppetReferences.build_facter_references(ENV.fetch('VERSION', nil), collection: ENV.fetch('COLLECTION', '_openfact_latest'))
   end
 
   task openbolt: 'references:check' do
     require 'puppet_references'
-    PuppetReferences.build_openbolt_references(ENV.fetch('VERSION', nil))
+    PuppetReferences.build_openbolt_references(ENV.fetch('VERSION', nil), collection: ENV.fetch('COLLECTION', '_openbolt_latest'))
   end
 
   desc 'Generate _data/agent_release_contents.yml from upstream component pins'
@@ -68,6 +69,7 @@ namespace :references do
 
   task :check do
     puts 'No VERSION given to build references for - using latest tag' unless ENV['VERSION']
+    puts "Building into collection #{ENV.fetch('COLLECTION')}" if ENV['COLLECTION']
     puts "Using provided install path #{ENV.fetch('INSTALLPATH')} instead of default" if ENV['INSTALLPATH']
     puts "Using default install path 'references_output'" unless ENV['INSTALLPATH']
   end

--- a/lib/puppet_references.rb
+++ b/lib/puppet_references.rb
@@ -31,7 +31,19 @@ module PuppetReferences
   require 'puppet_references/facter/facter_cli'
   require 'puppet_references/openbolt/docs'
 
-  def self.build_puppet_references(commit)
+  # Map a target collection dir (e.g. "_openvox_8x", "_openfact_latest") to its
+  # published URL base (e.g. "/openvox/8.x", "/openfact/latest"). Used by the
+  # reference generators to emit canonical links that match the version they're
+  # being built into, rather than always pointing at "latest". Splitting on the
+  # last underscore keeps hyphenated product names intact (e.g. "openvox-server").
+  def self.url_base_for(collection)
+    name = collection.to_s.delete_prefix('_')
+    product, _, version = name.rpartition('_')
+    label = (version == 'latest') ? 'latest' : version.sub(/\A(\d+)x\z/, '\1.x')
+    "/#{product}/#{label}"
+  end
+
+  def self.build_puppet_references(commit, collection: '_openvox_latest')
     references = [
       PuppetReferences::Puppet::Man,
       PuppetReferences::Puppet::PuppetDoc,
@@ -42,21 +54,21 @@ module PuppetReferences
     config = PuppetReferences::Config.read
     repo = PuppetReferences::Repo.new('openvox', PUPPET_DIR, nil, config['puppet']['repo'])
     @version_commit = commit || repo.newest_release
-    puts "Using tag #{@version_commit}"
+    puts "Using tag #{@version_commit} -> #{collection}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle
-    build_from_list_of_classes(references, real_commit)
+    build_from_list_of_classes(references, real_commit, collection)
   end
 
-  def self.build_openbolt_references(commit)
+  def self.build_openbolt_references(commit, collection: '_openbolt_latest')
     config = PuppetReferences::Config.read
     bolt_config = config.fetch('openbolt', {})
     repo = PuppetReferences::Repo.new('openbolt', BOLT_DIR, nil, bolt_config.fetch('repo', {}))
     @version_commit = commit || repo.newest_release
-    puts "Using tag #{@version_commit}"
+    puts "Using tag #{@version_commit} -> #{collection}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle
-    ref = PuppetReferences::Openbolt::Docs.new(real_commit)
+    ref = PuppetReferences::Openbolt::Docs.new(real_commit, collection)
     ref.build_all
   end
 
@@ -64,7 +76,7 @@ module PuppetReferences
     Gem::Version.correct?(string)
   end
 
-  def self.build_facter_references(commit)
+  def self.build_facter_references(commit, collection: '_openfact_latest')
     references = [
       PuppetReferences::Facter::CoreFacts,
     ]
@@ -73,20 +85,20 @@ module PuppetReferences
     version4 = Gem::Version.create('4.0.0')
     repo = PuppetReferences::Repo.new('openfact', FACTER_DIR)
     @version_commit = commit || repo.newest_release
-    puts "Using tag #{@version_commit}"
+    puts "Using tag #{@version_commit} -> #{collection}"
     real_commit = repo.checkout(@version_commit)
     repo.update_bundle
     if !semantic?(@version_commit) || (semantic?(@version_commit) && Gem::Version.create(@version_commit) >= version4)
       references << PuppetReferences::Facter::FacterCli
     elsif semantic?(@version_commit) && Gem::Version.create(@version_commit) < version4
-      reference = PuppetReferences::Facter::FacterCli.new(real_commit)
+      reference = PuppetReferences::Facter::FacterCli.new(real_commit, collection)
       reference.build_v3_cli
     end
-    build_from_list_of_classes(references, real_commit)
+    build_from_list_of_classes(references, real_commit, collection)
   end
 
-  def self.build_from_list_of_classes(reference_classes, real_commit)
-    references = reference_classes.map { |r| r.new(real_commit) }
+  def self.build_from_list_of_classes(reference_classes, real_commit, collection)
+    references = reference_classes.map { |r| r.new(real_commit, collection) }
     references.each(&:build_all)
 
     locations = references.map do |ref|

--- a/lib/puppet_references/facter/core_facts.rb
+++ b/lib/puppet_references/facter/core_facts.rb
@@ -4,24 +4,18 @@ require 'puppet_references'
 module PuppetReferences
   module Facter
     class CoreFacts < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openfact_latest'
       PREAMBLE_FILE = Pathname.new(__FILE__).dirname + 'core_facts_preamble.md'
       PREAMBLE = PREAMBLE_FILE.read
 
-      def initialize(*)
-        @latest = '/openvox/latest'
-        super
-      end
-
       def build_all
         puts 'Core facts: building reference.'
-        OUTPUT_DIR.mkpath
+        collection_dir.mkpath
         raw_text = `ruby #{PuppetReferences::FACTER_DIR}/lib/docs/generate.rb`
         header_data = { title: 'Facter: Core Facts',
                         toc: 'columns',
                         canonical: "#{@latest}/core_facts.html", }
         content = make_header(header_data, 'OpenFact', PuppetReferences.version_commit) + PREAMBLE + raw_text
-        filename = OUTPUT_DIR + 'core_facts.md'
+        filename = collection_dir + 'core_facts.md'
         filename.open('w') { |f| f.write(content) }
         puts 'Core facts: done!'
       end

--- a/lib/puppet_references/facter/facter_cli.rb
+++ b/lib/puppet_references/facter/facter_cli.rb
@@ -4,13 +4,6 @@ require 'puppet_references'
 module PuppetReferences
   module Facter
     class FacterCli < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openfact_latest'
-
-      def initialize(*)
-        @latest = '/openvox/latest'
-        super
-      end
-
       def header_data
         { title: 'Facter: CLI',
           toc: 'columns',
@@ -20,7 +13,7 @@ module PuppetReferences
       def build_all
         require 'open3'
         puts 'Building CLI documentation page for facter.'
-        OUTPUT_DIR.mkpath
+        collection_dir.mkpath
         Bundler.with_unbundled_env do
           Open3.capture3("BUNDLE_GEMFILE=#{PuppetReferences::FACTER_DIR}/Gemfile bundle update")
         end
@@ -33,14 +26,14 @@ module PuppetReferences
         # Strip the "TITLE - Manual" header line and the dated footer line mandoc adds
         markdown_text = markdown_text.lines[1...-1].join
         content = make_header(header_data, 'OpenFact', PuppetReferences.version_commit) + markdown_text
-        filename = OUTPUT_DIR + 'cli.md'
+        filename = collection_dir + 'cli.md'
         filename.open('w') { |f| f.write(content) }
         puts 'CLI documentation is done!'
       end
 
       def build_v3_cli
-        OUTPUT_DIR.mkpath
-        filename = OUTPUT_DIR + 'cli.md'
+        collection_dir.mkpath
+        filename = collection_dir + 'cli.md'
         man_filepath = PuppetReferences::FACTER_DIR + 'man/man8/facter.8'
         raw_text = PuppetReferences::Util.convert_man(man_filepath)
         content = make_header(header_data, 'OpenFact', PuppetReferences.version_commit) + raw_text

--- a/lib/puppet_references/openbolt/docs.rb
+++ b/lib/puppet_references/openbolt/docs.rb
@@ -6,7 +6,6 @@ require 'fileutils'
 module PuppetReferences
   module Openbolt
     class Docs < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openbolt_5x'
       DOCS_SOURCE = PuppetReferences::BOLT_DIR + 'documentation'
 
       GENERATED_PAGES = %w[
@@ -21,13 +20,8 @@ module PuppetReferences
         privilege_escalation.md
       ].freeze
 
-      def initialize(*)
-        @latest = '/openbolt/latest'
-        super
-      end
-
       def build_all
-        OUTPUT_DIR.mkpath
+        collection_dir.mkpath
         puts 'OpenBolt Docs: Building all...'
         generate_reference_pages
         copy_reference_pages
@@ -56,7 +50,7 @@ module PuppetReferences
           end
 
           content = insert_generated_note(rewrite_md_links(source.read))
-          dest = OUTPUT_DIR + filename
+          dest = collection_dir + filename
           dest.open('w') { |f| f.write(content) }
         end
       end
@@ -77,7 +71,7 @@ module PuppetReferences
 
       def copy_images
         Pathname.glob(DOCS_SOURCE + '*.{png,jpg,gif,svg}').each do |img|
-          FileUtils.cp(img.to_path, (OUTPUT_DIR + img.basename).to_path)
+          FileUtils.cp(img.to_path, (collection_dir + img.basename).to_path)
         end
       end
 

--- a/lib/puppet_references/puppet/functions.rb
+++ b/lib/puppet_references/puppet/functions.rb
@@ -10,23 +10,17 @@ module PuppetReferences
   module Puppet
     class Functions < PuppetReferences::Reference
       TEMPLATE_FILE = Pathname.new(File.expand_path(__FILE__)).dirname + 'functions_template.erb'
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openvox_latest'
       PREAMBLE_FILE = Pathname.new(File.expand_path(__FILE__)).dirname + 'functions_preamble.md'
       PREAMBLE = PREAMBLE_FILE.read
-
-      def initialize(*)
-        @latest = '/openvox/latest'
-        super
-      end
 
       def build_all
         build_variant('function.md')
       end
 
       def build_variant(filename, preferred_version = 'ruby4x')
-        OUTPUT_DIR.mkpath
+        collection_dir.mkpath
         puts "Functions ref (#{filename}): Building"
-        strings_data = PuppetReferences::Puppet::Strings.new
+        strings_data = PuppetReferences::Puppet::Strings.new(@collection)
         functions = strings_data['puppet_functions']
         header_data = { title: 'Built-in function reference',
                         canonical: "#{@latest}/function.html",
@@ -46,10 +40,10 @@ module PuppetReferences
         # This substitution could potentially make things a bit brittle, but it has to be done because the jump
         # From H2s to H4s is causing issues with the DITA-OT, which sees this as a rule violation. If it
         # Does become an issue, we should return to this and figure out a better way to generate the functions doc.
-        content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + PREAMBLE + "\n\n" + body.gsub(/#####\s(.*?:)/, '**\1**').gsub(
+        content = localize_links(make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + PREAMBLE + "\n\n" + body.gsub(/#####\s(.*?:)/, '**\1**').gsub(
           /####\s/, '###\s'
-        )
-        output_path = OUTPUT_DIR + filename
+        ))
+        output_path = collection_dir + filename
         output_path.open('w') { |f| f.write(content) }
         puts "Functions ref (#{filename}): Done!"
       end

--- a/lib/puppet_references/puppet/http.rb
+++ b/lib/puppet_references/puppet/http.rb
@@ -5,17 +5,19 @@ require 'fileutils'
 module PuppetReferences
   module Puppet
     class Http < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openvox_latest'
-      DOCS_DIR = OUTPUT_DIR + 'http_api'
       API_SOURCE = PuppetReferences::PUPPET_DIR + 'api'
 
       def initialize(*)
-        @latest = '/openvox/latest/http_api'
         super
+        @latest = "#{@latest}/http_api"
+      end
+
+      def docs_dir
+        collection_dir + 'http_api'
       end
 
       def build_all
-        DOCS_DIR.mkpath
+        docs_dir.mkpath
         puts 'HTTP API: Building all...'
         copy_schemas
         copy_docs
@@ -24,7 +26,7 @@ module PuppetReferences
 
       def copy_schemas
         # This cp_r method is finicky and makes me long for rsync.
-        FileUtils.cp_r((API_SOURCE + 'schemas').to_path, OUTPUT_DIR.to_path)
+        FileUtils.cp_r((API_SOURCE + 'schemas').to_path, collection_dir.to_path)
       end
 
       def copy_docs
@@ -48,7 +50,7 @@ module PuppetReferences
         header_data = { title: "Puppet HTTP API: #{title}",
                         canonical: "#{@latest}/#{shortname}.html", }
         content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + file.read
-        dest = DOCS_DIR + file.basename
+        dest = docs_dir + file.basename
         dest.open('w') { |f| f.write(content) }
       end
     end

--- a/lib/puppet_references/puppet/man.rb
+++ b/lib/puppet_references/puppet/man.rb
@@ -5,15 +5,17 @@ require 'puppet_references'
 module PuppetReferences
   module Puppet
     class Man < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openvox_latest/man'
-
       def initialize(*)
-        @latest = '/openvox/latest/man'
         super
+        @latest = "#{@latest}/man"
+      end
+
+      def man_dir
+        collection_dir + 'man'
       end
 
       def build_all
-        OUTPUT_DIR.mkpath
+        man_dir.mkpath
         commands = get_subcommands
         puts 'Man pages: Building all...'
         build_index(commands)
@@ -105,7 +107,7 @@ module PuppetReferences
 
         MSG
         # write index
-        filename = OUTPUT_DIR + 'overview.md'
+        filename = man_dir + 'overview.md'
         filename.open('w') { |f| f.write(index_text) }
       end
 
@@ -125,7 +127,7 @@ module PuppetReferences
         # raw_text = PuppetReferences::ManCommand.new(subcommand).get
         man_filepath = PuppetReferences::PUPPET_DIR.to_s + "/man/man8/puppet-#{subcommand}.8"
         content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + PuppetReferences::Util.convert_man(man_filepath)
-        filename = OUTPUT_DIR + "#{subcommand}.md"
+        filename = man_dir + "#{subcommand}.md"
         filename.open('w') { |f| f.write(content) }
       end
     end

--- a/lib/puppet_references/puppet/puppet_doc.rb
+++ b/lib/puppet_references/puppet/puppet_doc.rb
@@ -5,15 +5,9 @@ module PuppetReferences
   module Puppet
     class PuppetDoc < PuppetReferences::Reference
       REFERENCES = %w[configuration metaparameter indirection report].freeze
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openvox_latest'
-
-      def initialize(*)
-        @latest = '/openvox/latest'
-        super
-      end
 
       def build_all
-        OUTPUT_DIR.mkpath
+        collection_dir.mkpath
         puts 'Oldskool refs: Building all...'
         REFERENCES.each do |ref|
           build_reference(ref)
@@ -31,7 +25,7 @@ module PuppetReferences
                         toc: 'columns',
                         canonical: "#{@latest}/#{reference}.html", }
         content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + raw_content
-        filename = OUTPUT_DIR + "#{reference}.md"
+        filename = collection_dir + "#{reference}.md"
         filename.open('w') { |f| f.write(content) }
       end
 

--- a/lib/puppet_references/puppet/strings.rb
+++ b/lib/puppet_references/puppet/strings.rb
@@ -3,29 +3,33 @@
 require 'puppet_references'
 require 'json'
 
-# @@string_data_cached class var usage is intentional here
+# @@generated_files class var usage is intentional here: it memoizes which
+# strings.json files this process has already generated, so the expensive
+# `puppet strings generate` runs once per output collection rather than once per
+# Strings instance. Keyed by path so building more than one collection in a
+# single process generates each rather than reusing the first.
 # rubocop:disable Style/ClassVars
 module PuppetReferences
   module Puppet
     class Strings < Hash
-      STRINGS_JSON_FILE = PuppetReferences::OUTPUT_DIR + '_openvox_latest/strings.json'
-      @@strings_data_cached = false
+      @@generated_files = []
 
-      def initialize(force_cached: false)
+      def initialize(collection = '_openvox_latest', force_cached: false)
         super()
-        @@strings_data_cached = true if force_cached
-        generate_strings_data unless @@strings_data_cached
-        merge!(JSON.parse(File.read(STRINGS_JSON_FILE)))
+        @json_file = PuppetReferences::OUTPUT_DIR + collection + 'strings.json'
+        generate_strings_data unless force_cached || @@generated_files.include?(@json_file.to_s)
+        merge!(JSON.parse(File.read(@json_file)))
         # We can't keep the actual data hash in an instance variable, because if you duplicate the main hash, all its
         # deeply nested members will be assigned by reference to the new hash, and you'll get leakage across objects.
       end
 
       def generate_strings_data
         puts 'Generating Puppet Strings JSON data...'
+        @json_file.dirname.mkpath
         rubyfiles = Dir.glob("#{PuppetReferences::PUPPET_DIR}/lib/puppet/**/*.rb")
-        system("bundle exec puppet strings generate --format json --out #{STRINGS_JSON_FILE} #{rubyfiles.join(' ')}")
-        puts "Strings data: Done! (#{STRINGS_JSON_FILE})"
-        @@strings_data_cached = true
+        system("bundle exec puppet strings generate --format json --out #{@json_file} #{rubyfiles.join(' ')}")
+        puts "Strings data: Done! (#{@json_file})"
+        @@generated_files << @json_file.to_s
       end
     end
   end

--- a/lib/puppet_references/puppet/type.rb
+++ b/lib/puppet_references/puppet/type.rb
@@ -15,11 +15,10 @@ module PuppetReferences
       PREAMBLE = PREAMBLE_FILE.read
 
       def initialize(*)
-        @latest = '/openvox/latest'
-        @output_dir_unified = PuppetReferences::OUTPUT_DIR + '_openvox_latest'
-        @output_dir_individual = PuppetReferences::OUTPUT_DIR + '_openvox_latest/types'
-        @base_filename = 'type'
         super
+        @output_dir_unified = collection_dir
+        @output_dir_individual = collection_dir + 'types'
+        @base_filename = 'type'
       end
 
       def build_all
@@ -46,7 +45,7 @@ module PuppetReferences
         links = names.map do |name|
           "* [#{name}](./#{name}.html)" unless skip_names.include?(name)
         end
-        content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "## List of resource types\n\n" + links.join("\n") + "\n\n" + PREAMBLE
+        content = localize_links(make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "## List of resource types\n\n" + links.join("\n") + "\n\n" + PREAMBLE)
         filename = @output_dir_individual + 'overview.md'
         filename.open('w') { |f| f.write(content) }
       end
@@ -68,7 +67,7 @@ module PuppetReferences
           text_for_type(name, typedocs[name])
         end.join("\n\n---------\n\n")
 
-        content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + PREAMBLE + all_type_docs + "\n\n"
+        content = localize_links(make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + PREAMBLE + all_type_docs + "\n\n")
         filename = @output_dir_unified + "#{@base_filename}.md"
         filename.open('w') { |f| f.write(content) }
       end
@@ -83,7 +82,7 @@ module PuppetReferences
         puts "Type ref: Building #{name}"
         header_data = { title: "Resource Type: #{name}",
                         canonical: "#{@latest}/types/#{name}.html", }
-        content = make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + text_for_type(name, data) + "\n\n"
+        content = localize_links(make_header(header_data, 'OpenVox', PuppetReferences.version_commit) + "\n\n" + text_for_type(name, data) + "\n\n")
         filename = @output_dir_individual + "#{name}.md"
         filename.open('w') { |f| f.write(content) }
       end

--- a/lib/puppet_references/puppet/type_strings.rb
+++ b/lib/puppet_references/puppet/type_strings.rb
@@ -7,8 +7,8 @@ module PuppetReferences
     class TypeStrings < PuppetReferences::Puppet::Type
       def initialize(*)
         super
-        @output_dir_individual = PuppetReferences::OUTPUT_DIR + '_openvox_latest/types_strings'
-        @output_dir = PuppetReferences::OUTPUT_DIR + '_openvox_latest'
+        @output_dir_individual = collection_dir + 'types_strings'
+        @output_dir = collection_dir
         @base_filename = 'type_strings'
       end
 
@@ -16,7 +16,7 @@ module PuppetReferences
         # 1. Get Strings JSON.
         # 2. Munge it to match the old format I threw together, which the template uses.
         # 3. Dump result to JSON.
-        strings_data = PuppetReferences::Puppet::Strings.new
+        strings_data = PuppetReferences::Puppet::Strings.new(@collection)
         File.write("#{@output_dir}/raw_strings_data_output.json", strings_data)
         type_hash = strings_data['resource_types'].each_with_object({}) do |type, memo|
           memo[ type['name'] ] = {

--- a/lib/puppet_references/puppet/yard.rb
+++ b/lib/puppet_references/puppet/yard.rb
@@ -4,16 +4,13 @@ require 'puppet_references'
 module PuppetReferences
   module Puppet
     class Yard < PuppetReferences::Reference
-      OUTPUT_DIR = PuppetReferences::OUTPUT_DIR + '_openvox_latest/yard'
-
-      def initialize(*)
-        @latest = '/openvox/latest/yard'
-        super
+      def yard_dir
+        collection_dir + 'yard'
       end
 
       def build_all
         puts 'Building YARD references, which always takes a while...'
-        PuppetReferences::PuppetCommand.new("yard -o #{OUTPUT_DIR}").get
+        PuppetReferences::PuppetCommand.new("yard -o #{yard_dir}").get
         puts 'Done with YARD!'
       end
     end

--- a/lib/puppet_references/reference.rb
+++ b/lib/puppet_references/reference.rb
@@ -5,9 +5,30 @@ require 'puppet_references'
 module PuppetReferences
   class Reference
     attr_accessor :commit, :latest
+    attr_reader :collection
 
-    def initialize(commit)
+    def initialize(commit, collection)
       @commit = commit
+      @collection = collection
+      @latest = PuppetReferences.url_base_for(collection)
+    end
+
+    # Absolute path to the target collection directory under the install path.
+    def collection_dir
+      PuppetReferences::OUTPUT_DIR + @collection
+    end
+
+    # Rewrite this product's own "/<product>/latest/" doc links to the target
+    # version's base, so generated pages for a frozen version stay within that
+    # version instead of leaking to latest. Links to a *different* product's
+    # "/latest/" are left alone — cross-product links follow latest by policy.
+    # No-op when building the current latest collection.
+    def localize_links(text)
+      latest_base = PuppetReferences.url_base_for(@collection.sub(/_[^_]+\z/, '_latest'))
+      version_base = PuppetReferences.url_base_for(@collection)
+      return text if latest_base == version_base
+
+      text.gsub("#{latest_base}/", "#{version_base}/")
     end
 
     def make_header(header_data, source, commit)


### PR DESCRIPTION
## What

Make the reference generators able to build into an arbitrary target collection,
rather than always writing into the current stable collection. This is the first
step toward versioned docs (frozen historical versions + a new major line).

## Why

Today each generator hardcodes its output dir (`_<product>_latest`, or
`_openbolt_5x` for OpenBolt) and emits canonical URLs at load time, so every build
lands in the current stable collection. To freeze `_openvox_8x` and build a new
`_openvox_9x` from a different upstream tag, builds need to target a specific
collection and emit URLs that match that version.

## Changes

- Add `PuppetReferences.url_base_for` to map a collection dir to its published URL
  base (e.g. `_openvox_9x` → `/openvox/9.x`), splitting on the last underscore so
  hyphenated product names (`openvox-server`) stay intact.
- Thread a `collection:` argument through `build_puppet_references` /
  `build_facter_references` / `build_openbolt_references` into every generator,
  replacing the load-time `OUTPUT_DIR` constants with instance-level paths derived
  from the target collection.
- **Fix an existing OpenFact bug:** `core_facts` and `facter_cli` stamped
  `/openvox/latest` canonicals while writing into `_openfact_*`; they now derive the
  correct `/openfact/...` base.
- **Localize intra-product body links.** Generated pages embedded `/<product>/latest/`
  links (e.g. via the static type preamble), which would leak a frozen version's
  pages back to latest. Add `Reference#localize_links`, which rewrites only the
  target product's own `/latest/` doc links to the version base, applied in the type
  and functions generators. Cross-product links (a different product's `/latest/`)
  are left to follow latest per the repo's linking policy, and it's a no-op when
  building the latest collection.
- **Key the strings cache per collection.** `strings.json` generation was memoized
  with a single global flag while its path is now per collection; building more than
  one collection in one process would skip generation and read a missing/stale file.
  Memoize by output path instead.
- `Rakefile` accepts `COLLECTION=<dir>` alongside `VERSION=`, defaulting per product
  to the prior hardcoded targets so **CI behavior is unchanged**.

An explicit `VERSION` already bypasses the prerelease filter (`newest_release` is
only consulted when no `VERSION` is given), so a frozen version can be built from a
prerelease tag — no change needed there.

## Validation

Ran real end-to-end builds (not just unit checks):

- `references:openfact VERSION=5.6.1 COLLECTION=_openfact_5x` → files land in
  `_openfact_5x`, canonical `/openfact/5.x/...`.
- `references:openfact VERSION=5.6.1` (no `COLLECTION`) → `_openfact_latest`,
  canonical `/openfact/latest/...` (back-compat preserved + bug fixed).
- `references:openvox VERSION=9.0.0-alpha1 COLLECTION=_openvox_9x` → all five
  generators ran; `man/`, `types/`, `types_strings/` subdirs and the intermediate
  JSON (`strings.json`, `type.json`, …) all routed into `_openvox_9x`; every
  canonical is `/openvox/9.x/...` (0 stale `/openvox/latest` canonicals);
  `built_from_commit` matches the `9.0.0-alpha1` tag, confirming the prerelease build.
- `references:openvox VERSION=8.28.0 COLLECTION=_openvox_8x` → the three type-preamble
  links resolve to `/openvox/8.x` in both `type.md` (root) and `types/overview.md`
  (subdir), and **zero** intra-product `/openvox/latest/` links remain in the build.
- `localize_links` unit-checked: rewrites the own product's `/latest/`, preserves a
  different product's `/latest/` (cross-product) and external `puppet.com/.../latest`
  links, and is a no-op for the latest collection.
- `rubocop` clean; library loads; all generator classes instantiate with the
  expected output dir and URL base.

## Scope

This is the generator capability only. The `references:all` task that reads a
`_data/versions.yml` pin table, the cutover runbook, and the version selector are
follow-ups.

Part of #325.

