### PR TITLE
Add references:all version pin table and wire it into CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,9 +79,9 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          bundle exec rake references:openfact INSTALLPATH=docs
-          bundle exec rake references:openvox INSTALLPATH=docs
-          bundle exec rake references:openbolt INSTALLPATH=docs
+          # Build each product/version's reference docs from the pin table in
+          # _data/products.yml into its collection (see `rake references:all`).
+          bundle exec rake references:all INSTALLPATH=docs
           # Refresh the openvox-agent release-contents table from upstream pins.
           # Falls back to the committed _data file if the GitHub API is unreachable.
           bundle exec rake references:agent_versions || echo 'agent_versions refresh failed; using committed _data'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,7 @@ jobs:
       # into docs/ first, the same way the publish workflow does.
       - name: Generate reference docs
         run: |
-          bundle exec rake references:openfact INSTALLPATH=docs
-          bundle exec rake references:openvox INSTALLPATH=docs
-          bundle exec rake references:openbolt INSTALLPATH=docs
+          bundle exec rake references:all INSTALLPATH=docs
       - name: Build site
         run: bundle exec jekyll build
       - name: Check internal links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,13 @@ bundle exec rake references:openfact INSTALLPATH=docs
 bundle exec rake references:openbolt INSTALLPATH=docs
 ```
 
+Or build every pinned product/version at once — this is what CI does, reading the
+pins from `_data/products.yml`:
+
+```console
+bundle exec rake references:all INSTALLPATH=docs
+```
+
 Note: It is possible to specify a version (tag or branch) to be used.
 If no version is provided, the latest stable release tag will be used.
 This is useful when checking for changes made in upstream reference source like OpenFact or OpenBolt repo itself.
@@ -67,6 +74,14 @@ for example when regenerating a frozen older major from its matching upstream ta
 
 ```console
 bundle exec rake references:openvox INSTALLPATH=docs VERSION=8.27.0 COLLECTION=_openvox_8x
+```
+
+To build every pinned product/version in one go — the same way CI does — use
+`references:all`, which reads the version/tag pins from `_data/products.yml`
+(it does not take `VERSION` or `COLLECTION`):
+
+```console
+bundle exec rake references:all INSTALLPATH=docs
 ```
 
 ## Writing guidelines

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,8 @@ task :references do
   puts '  VERSION can be omitted, uses latest non-prerelease tag; an explicit VERSION builds that exact ref (e.g. a 9.x prerelease)'
   puts '  COLLECTION can be omitted, defaults to the current stable dir per product (e.g. _openvox_latest); set it to build a frozen version (e.g. _openvox_9x)'
   puts '  INSTALLPATH can be omitted, defaults to references_output/'
+  puts 'bundle exec rake references:all [INSTALLPATH=<RELATIVE OR ABSOLUTE PATH>]'
+  puts '  Builds every pinned product/version from _data/products.yml into its collection'
 end
 
 namespace :references do
@@ -55,6 +57,36 @@ namespace :references do
   task openbolt: 'references:check' do
     require 'puppet_references'
     PuppetReferences.build_openbolt_references(ENV.fetch('VERSION', nil), collection: ENV.fetch('COLLECTION', '_openbolt_latest'))
+  end
+
+  desc 'Build every pinned product/version from _data/products.yml into its collection'
+  task :all do
+    versions = YAML.load_file('_data/products.yml')
+    installpath = ENV.fetch('INSTALLPATH', nil)
+
+    # Each (product, version) builds in its own subprocess. A fresh process avoids
+    # cross-version contamination from load-time output constants and process-level
+    # caches (e.g. the Strings JSON cache), and re-resolves bundler cleanly for the
+    # vendored repo it checks out. Only products with a `references` task generate
+    # reference pages; authored-only products are skipped.
+    versions.each do |product_id, product|
+      task_name = product['references']
+      next unless task_name
+
+      product.fetch('versions', []).each do |version|
+        ref = version['ref']
+        collection = version['collection']
+        unless ref && collection
+          warn "references:all: skipping #{product_id} #{version['id']} (missing ref or collection)"
+          next
+        end
+
+        cmd = ['bundle', 'exec', 'rake', task_name, "VERSION=#{ref}", "COLLECTION=#{collection}"]
+        cmd << "INSTALLPATH=#{installpath}" if installpath
+        puts "references:all: #{cmd.join(' ')}"
+        Bundler.with_unbundled_env { sh(*cmd) }
+      end
+    end
   end
 
   desc 'Generate _data/agent_release_contents.yml from upstream component pins'

--- a/_data/products.yml
+++ b/_data/products.yml
@@ -1,0 +1,102 @@
+# Single source of truth for products and their documentation versions.
+#
+# Read by:
+#   - the `references:all` build loop: `references`, plus per-version `ref` and
+#     `collection` (which upstream tag builds into which collection dir).
+#   - the version selector UI (forthcoming): `label`, `latest`, `single_version`,
+#     and per-version `id`, `label`, `base`.
+#
+# Keyed by product id; insertion order is the display order. Each product has:
+#   - label:          display name for the UI (e.g. "OpenVox").
+#   - latest:         the version `id` that the `/<product>/latest/` alias points
+#                     at. `latest` is an ALIAS, never its own build row — reference
+#                     builds always target a real version dir (e.g. `_openvox_8x`),
+#                     and the `_<product>_latest` symlink serves it under `/latest/`.
+#   - references:     the rake task that (re)generates this product's reference
+#                     pages. Omit for authored-only products — their versions never
+#                     build generated references.
+#   - single_version: (optional) true when the product has no numbered collection,
+#                     only a real `_<product>_latest` dir (e.g. OpenVox Containers);
+#                     the selector can hide the picker for these.
+#   - versions:       list of version entries, newest first, each with:
+#       - id:         short version id (e.g. "8x"); the `latest` key references one.
+#       - label:      display label for the UI (e.g. "8.x").
+#       - collection: the Jekyll collection directory (e.g. `_openvox_8x`).
+#       - base:       the published URL base (e.g. `/openvox/8.x/`).
+#       - ref:        (products with a `references:` task only) the exact upstream
+#                     git tag to build the reference pages from. Pinning to a tag —
+#                     rather than a branch or "newest" — keeps a docs commit
+#                     reproducible and avoids a moving target ("newest stable" is
+#                     global, so it jumps majors once a new major ships, and `main`
+#                     rolls into the next major over time). Bump it to reflect a
+#                     newer release; a frozen older major keeps its final tag.
+
+openvox:
+  label: OpenVox
+  latest: 8x
+  references: references:openvox
+  versions:
+    - id: 8x
+      label: "8.x"
+      collection: _openvox_8x
+      base: /openvox/8.x/
+      ref: "8.28.0"
+
+openfact:
+  label: OpenFact
+  latest: 5x
+  references: references:openfact
+  versions:
+    - id: 5x
+      label: "5.x"
+      collection: _openfact_5x
+      base: /openfact/5.x/
+      ref: "5.6.1"
+
+openbolt:
+  label: OpenBolt
+  latest: 5x
+  references: references:openbolt
+  versions:
+    - id: 5x
+      label: "5.x"
+      collection: _openbolt_5x
+      base: /openbolt/5.x/
+      ref: "5.6.0"
+
+openvox-server:
+  label: OpenVox Server
+  latest: 8x
+  versions:
+    - id: 8x
+      label: "8.x"
+      collection: _openvox-server_8x
+      base: /openvox-server/8.x/
+
+openvoxdb:
+  label: OpenVoxDB
+  latest: 8x
+  versions:
+    - id: 8x
+      label: "8.x"
+      collection: _openvoxdb_8x
+      base: /openvoxdb/8.x/
+
+ecosystem:
+  label: Ecosystem
+  latest: 8x
+  versions:
+    - id: 8x
+      label: "8.x"
+      collection: _ecosystem_8x
+      base: /ecosystem/8.x/
+
+openvox-containers:
+  label: OpenVox Containers
+  latest: latest
+  single_version: true  # real `_latest` dir, no numbered collection (see header)
+  versions:
+    - id: latest
+      label: latest
+      collection: _openvox-containers_latest
+      base: /openvox-containers/latest/


### PR DESCRIPTION
## What

Builds on #326 (collection-parameterized generators) to make reference generation
data-driven and version-pinned:

- **`_data/products.yml`** — the source of truth for products and their doc
  versions. (Named `products`, not `versions`, to avoid colliding with the
  theme's reserved `site.data.versions` — its built-in selector expects a
  different `{ current, items }` shape; ours is keyed by product.)
  versions. Each product lists its versions (collection dir, base URL), which
  version `latest` aliases, and — for products with a reference generator — the
  rake task plus the exact upstream tag each version builds from. `latest` is an
  alias, never its own build row; authored-only products (OpenVox Server,
  OpenVoxDB, Ecosystem, OpenVox Containers) carry no generator and no pin.
- **`rake references:all`** — reads that table and builds each pinned
  `(tag -> collection)` pair in its own subprocess, so load-time output constants
  and process-level caches don't bleed across versions and bundler re-resolves
  cleanly per vendored repo.
- **`build.yaml`** (publish) and **`test.yml`** (PR internal-links check) — both
  replace the three hardcoded `rake references:*` lines with `rake references:all`,
  so PR CI exercises the same pin table the publish path uses. A broken
  `products.yml` entry now fails the PR rather than only at publish after merge.

## :warning: Behavior change: generated reference page body links

This is the one deploy-visible change, and it's intentional.

CI previously built references into `_<product>_latest`; now they build into the
real version dirs (`_openvox_8x`, etc.), which the `_<product>_latest` symlinks
alias. In a versioned dir, the generators localize the *generated reference pages'
own inline links* to that version's base. Concretely, the type reference pages'
preamble links change:

| Page | Before | After |
|------|--------|-------|
| `/openvox/8.x/type.html` body link | `/openvox/latest/custom_types.html` | `/openvox/8.x/custom_types.html` self-consistent |
| `/openvox/latest/type.html` body link | `/openvox/latest/custom_types.html` | `/openvox/8.x/custom_types.html` (alias serves the concrete version) |

**Why this is correct:** it's what keeps a frozen version coherent once a new major
ships — a `/openvox/8.x/` page must link to `/openvox/8.x/`, not to whatever
`latest` later becomes. Today `latest == 8.x`, so the targets are identical content.

**Scope is narrow:** only the *inline body links in generated reference pages* (the
three type-preamble links in `type.html` / `types/overview.html`). Navigation chrome
is unaffected — the sidebar stays collection-appropriate (`/latest/` pages keep
`/latest/` sidebar links), and the top-nav product link still points at `/latest/`.
Canonicals are unchanged (the theme derives them from `page.url`). **No broken
links.**

## Note on `products.yml` fields

The file is the shared registry for two consumers. This PR only ships the first, so
some fields are not yet read by code here (the header comment documents every key):

- **Used now by `references:all`:** `references` (per product), and `ref` /
  `collection` (per version).
- **Reserved for the version selector (next PR, #325):** `label` (product +
  version), `base`, `latest`, and `single_version` (the OpenVox Containers
  single-version case). Kept here so the registry is complete and self-describing
  rather than re-expanded later.

## Validation

- **Local full build** (`references:all` -> `jekyll build` -> htmlproofer):
  htmlproofer checked **1776 internal links across 447 files — 0 broken**. Confirmed
  `/openvox/8.x/type.html` and `/openvox/latest/type.html` both render the localized
  `/openvox/8.x/` body links, with per-URL canonicals (`/8.x/` and `/latest/`).
- **`references:all` end to end:** openvox 8.28.0, openfact 5.6.1, openbolt 5.5.0
  each built into its collection with version-pinned output.
- A manual `build.yaml` run on the merged #326 generator code completed green.

## Note

`build.yaml` lives outside autopublish's path filter, but `_data/products.yml` is
inside it — so merging this triggers a full publish that exercises the new wiring.

Part of #325.


