### PR TITLE
discourage unbounded resource collectors

### DIFF
--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -150,13 +150,17 @@ service { 'sshd':
 }
 ```
 
-And since collectors can be chained, you can create many-to-many relationships:
+And since collectors can be chained, you can create many-to-many relationships, although this practice is generally discouraged:
 
 ``` puppet
-Yumrepo <| |> -> Package <| |>
+Yumrepo <| tag == 'internal' |> -> Package <| tag == 'internal' |>
 ```
 
-This example applies all yum repository resources before applying any package resources, which protects any packages that rely on custom repositories.
+This example applies all internal yum repository resources before applying any internal package resources, which protects any packages that rely on custom repositories.
+
+{% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
+They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
+Using unbounded collectors may result in many unexpected resources being managed and may have catastrophic consequences." %}
 
 ### Capturing resource references for generated resources
 

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -19,7 +19,8 @@ title: "Language: Relationships and ordering"
 [containment]: ./lang_containment.html
 
 
-By default, Puppet applies resources in the order they're declared in their manifest. However, if a group of resources must _always_ be managed in a specific order, you should explicitly declare such relationships with relationship metaparameters, chaining arrows, and the `require` function.
+By default, Puppet applies resources in the order they're declared in their manifest.
+However, if a group of resources must _always_ be managed in a specific order, you should explicitly declare such relationships with relationship metaparameters, chaining arrows, and the `require` function.
 
 ## Syntax: Relationship metaparameters
 
@@ -31,14 +32,16 @@ package { 'openssh-server':
 }
 ```
 
-Puppet uses four [metaparameters][] to establish relationships, and you can set each of them as an attribute in any resource. The value of any relationship metaparameter should be a [resource reference][reference] (or [array][] of references) pointing to one or more **target resources**.
+Puppet uses four [metaparameters][] to establish relationships, and you can set each of them as an attribute in any resource.
+The value of any relationship metaparameter should be a [resource reference][reference] (or [array][] of references) pointing to one or more **target resources**.
 
 * `before` --- Applies a resource **before** the target resource.
 * `require` --- Applies a resource **after** the target resource.
 * `notify` --- Applies a resource **before** the target resource. The target resource [refreshes][refresh] if the notifying resource changes.
 * `subscribe` --- Applies a resource **after** the target resource. The subscribing resource [refreshes][refresh] if the target resource changes.
 
-If two resources need to happen in order, you can either put a `before` attribute in the prior one or a `require` attribute in the subsequent one; either approach creates the same relationship. The same is true of `notify` and `subscribe`.
+If two resources need to happen in order, you can either put a `before` attribute in the prior one or a `require` attribute in the subsequent one; either approach creates the same relationship.
+The same is true of `notify` and `subscribe`.
 
 The two examples below create the same ordering relationship:
 
@@ -166,11 +169,13 @@ Using unbounded collectors may result in many unexpected resources being managed
 
 In this version of the Puppet language, the _value_ of a resource declaration is a _reference_ to the resource it creates.
 
-You can take advantage of this if you're automatically creating resources whose titles you can't predict, by using the [iteration functions][lambdas] to declare several resources at once or using an array of strings as a resource title. If you assign the resulting resource references to a variable, you can then use them in chaining statements without ever knowing the final title of the affected resources.
+You can take advantage of this if you're automatically creating resources whose titles you can't predict, by using the [iteration functions][lambdas] to declare several resources at once or using an array of strings as a resource title.
+If you assign the resulting resource references to a variable, you can then use them in chaining statements without ever knowing the final title of the affected resources.
 
 For example:
 
-* The `map` function iterates over its arguments and returns an array of values, with each value produced by the last expression in the block. If that last expression is a resource declaration, `map` produces an array of resource references, which could then be used as an operand for a chaining arrow.
+* The `map` function iterates over its arguments and returns an array of values, with each value produced by the last expression in the block.
+  If that last expression is a resource declaration, `map` produces an array of resource references, which could then be used as an operand for a chaining arrow.
 * The value of a resource declaration whose title is an array, is itself an array of resource references that you can assign to a variable and use in a chaining statement.
 
 ### Caveats when chaining resource collectors
@@ -181,11 +186,14 @@ Chained collectors can cause huge [dependency cycles](#dependency-cycles); be ca
 
 #### Potential for breaking chains
 
-Although you can usually chain many resources or collectors together (`File['one'] -> File['two'] -> File['three']`), the chain can be broken if it includes a collector whose search expression doesn't match any resources. This is [Puppet bug PUP-1410](https://tickets.puppetlabs.com/browse/PUP-1410).
+Although you can usually chain many resources or collectors together (`File['one'] -> File['two'] -> File['three']`), the chain can be broken if it includes a collector whose search expression doesn't match any resources.
+This is [Puppet bug PUP-1410](https://tickets.puppetlabs.com/browse/PUP-1410).
 
 #### Implicit properties aren't searchable
 
-Collectors can search only on attributes present in the manifests; they cannot see properties that are automatically set or are read from the target system. For example, if the example above had been written as `Yumrepo <| |> -> Package <| provider == yum |>`, it would only create relationships with packages whose `provider` attribute had been _explicitly_ set to `yum` in the manifests. It would not affect any packages that didn't specify a provider but would end up using Yum because it's the default provider for the node's operating system.
+Collectors can search only on attributes present in the manifests; they cannot see properties that are automatically set or are read from the target system.
+For example, if the example above had been written as `Yumrepo <| |> -> Package <| provider == yum |>`, it would only create relationships with packages whose `provider` attribute had been _explicitly_ set to `yum` in the manifests.
+It would not affect any packages that didn't specify a provider but would end up using Yum because it's the default provider for the node's operating system.
 
 ### Reversed forms
 
@@ -209,7 +217,8 @@ class wordpress {
 
 The above example causes every resource in the `apache` and `mysql` classes to be applied before any of the resources in the `wordpress` class.
 
-Unlike the relationship metaparameters and chaining arrows, the `require` function does not have a reciprocal form or a notifying form. However, more complex behavior can be obtained by combining `include` and chaining arrows inside a class definition:
+Unlike the relationship metaparameters and chaining arrows, the `require` function does not have a reciprocal form or a notifying form.
+However, more complex behavior can be obtained by combining `include` and chaining arrows inside a class definition:
 
 ``` puppet
 class apache::ssl {
@@ -237,7 +246,8 @@ Some resource types can do a special "refresh" action when a dependency changes.
 
 (The built-in resource types that can refresh are [service][], [exec][], and sometimes [package][]. See each type's docs for info about their refresh behavior.)
 
-Puppet uses notifying relationships (`subscribe`, `notify`, and `~>`) to tell resources when they should refresh. A resource will perform its refresh action if Puppet changes any of the resources it subscribes to.
+Puppet uses notifying relationships (`subscribe`, `notify`, and `~>`) to tell resources when they should refresh.
+A resource will perform its refresh action if Puppet changes any of the resources it subscribes to.
 
 Notifying relationships also interact with [containment][]. The complete rules for notification and refreshing are:
 
@@ -256,8 +266,10 @@ Notifying relationships also interact with [containment][]. The complete rules f
 
 #### No-op
 
-* If a resource is in no-op mode (due to the global `noop` setting or the per-resource `noop` metaparameter), it _will not refresh_ when it receives a refresh event. However, Puppet will log a message stating what would have happened.
-* If a resource is in no-op mode but Puppet would otherwise have changed or refreshed it, it _will not send refresh events_ to subscribed resources. However, Puppet will log messages stating what would have happened to any resources further down the subscription chain.
+* If a resource is in no-op mode (due to the global `noop` setting or the per-resource `noop` metaparameter), it _will not refresh_ when it receives a refresh event.
+  However, Puppet will log a message stating what would have happened.
+* If a resource is in no-op mode but Puppet would otherwise have changed or refreshed it, it _will not send refresh events_ to subscribed resources.
+  However, Puppet will log messages stating what would have happened to any resources further down the subscription chain.
 
 ### Auto\* relationships
 

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -169,7 +169,8 @@ Using unbounded collectors may result in many unexpected resources being managed
 
 In this version of the Puppet language, the _value_ of a resource declaration is a _reference_ to the resource it creates.
 
-You can take advantage of this if you're automatically creating resources whose titles you can't predict, by using the [iteration functions][lambdas] to declare several resources at once or using an array of strings as a resource title.
+You can take advantage of this if you're automatically creating resources whose titles you can't predict,
+by using the [iteration functions][lambdas] to declare several resources at once or using an array of strings as a resource title.
 If you assign the resulting resource references to a variable, you can then use them in chaining statements without ever knowing the final title of the affected resources.
 
 For example:
@@ -186,13 +187,15 @@ Chained collectors can cause huge [dependency cycles](#dependency-cycles); be ca
 
 #### Potential for breaking chains
 
-Although you can usually chain many resources or collectors together (`File['one'] -> File['two'] -> File['three']`), the chain can be broken if it includes a collector whose search expression doesn't match any resources.
+Although you can usually chain many resources or collectors together (`File['one'] -> File['two'] -> File['three']`),
+the chain can be broken if it includes a collector whose search expression doesn't match any resources.
 This is [Puppet bug PUP-1410](https://tickets.puppetlabs.com/browse/PUP-1410).
 
 #### Implicit properties aren't searchable
 
 Collectors can search only on attributes present in the manifests; they cannot see properties that are automatically set or are read from the target system.
-For example, if the example above had been written as `Yumrepo <| |> -> Package <| provider == yum |>`, it would only create relationships with packages whose `provider` attribute had been _explicitly_ set to `yum` in the manifests.
+For example, if the example above had been written as `Yumrepo <| |> -> Package <| provider == yum |>`,
+it would only create relationships with packages whose `provider` attribute had been _explicitly_ set to `yum` in the manifests.
 It would not affect any packages that didn't specify a provider but would end up using Yum because it's the default provider for the node's operating system.
 
 ### Reversed forms
@@ -273,9 +276,14 @@ Notifying relationships also interact with [containment][]. The complete rules f
 
 ### Auto\* relationships
 
-Certain resource types can have automatic relationships with other resources, using  _autorequire_, _autonotify_, _autobefore_, or _autosubscribe_. This creates an ordering relationship without the user explicitly stating one. The [resource type reference][type] notes which resource types can have these types of relationships with other resources. Auto relationships between types and resources are established when applying a catalog.
+Certain resource types can have automatic relationships with other resources, using  _autorequire_, _autonotify_, _autobefore_, or _autosubscribe_.
+This creates an ordering relationship without the user explicitly stating one.
+The [resource type reference][type] notes which resource types can have these types of relationships with other resources.
+Auto relationships between types and resources are established when applying a catalog.
 
-When Puppet prepares to sync a resource whose type supports an auto relationship, it searches the catalog for any resources that match certain rules. If it finds any, it processes them in the correct order, sending refresh events if necessary. If Puppet _doesn't_ find any resources that could use an auto relationship, that's fine; they aren't considered a failed dependency.
+When Puppet prepares to sync a resource whose type supports an auto relationship, it searches the catalog for any resources that match certain rules.
+If it finds any, it processes them in the correct order, sending refresh events if necessary.
+If Puppet _doesn't_ find any resources that could use an auto relationship, that's fine; they aren't considered a failed dependency.
 
 ### Evaluation-order independence
 
@@ -292,7 +300,7 @@ If one of the resources in a relationship is never declared, **compilation fails
 
 If Puppet fails to apply the prior resource in a relationship, it skips the subsequent resource and log the following messages:
 
-```
+```text
 notice: <RESOURCE>: Dependency <OTHER RESOURCE> has failures: true
 warning: <RESOURCE>: Skipping because of failed dependencies
 ```
@@ -301,13 +309,11 @@ It then continues to apply any unrelated resources. Any resources that depend on
 
 This helps prevent inconsistent system state by causing a "clean" failure instead of attempting to apply a resource whose prerequisites might be broken.
 
-> **Note**: Although a resource won't be applied if a dependency fails, it can still receive and respond to refresh events from other, successful, dependencies. This is because refreshes are handled semi-independently of the normal resource sync process. It is an outstanding design issue, and can be tracked at [issue #7486](http://projects.puppetlabs.com/issues/7486).
-
 ### Dependency cycles
 
 If two or more resources require each other in a loop, Puppet compiles the catalog but won't be able to apply it. Puppet logs an error like the following, and attempts to help  identify the cycle:
 
-```
+```text
 err: Could not apply complete catalog: Found 1 dependency cycle:
 (<RESOURCE> => <OTHER RESOURCE> => <RESOURCE>)
 Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz


### PR DESCRIPTION
### Short description

- Discourage unbounded resource collectors.
- Remove longer relevant warning.

The error case described in https://web.archive.org/web/20151218043615/http://projects.puppetlabs.com/issues/7486 is no longer an error.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
