### PR TITLE
Raise publish build timeout to 10 minutes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,10 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    # references:all clones and generates docs for three products and the
+    # component-version tasks make live GitHub API calls, so the build is network-
+    # variable and runs ~5 min; give headroom above the previous tight 5-min cap.
+    timeout-minutes: 10
     needs:
       - setup
     env:


### PR DESCRIPTION
## What

Raise the publish `build` job's `timeout-minutes` from **5 to 10**.

## Why

The merge of #339 left `master` **unpublished**: its publish run was cancelled at the *Archive website* step and `deploy` was skipped. Root cause is the 5-minute `build` timeout, not a build error:

| Run | `build` job duration | Result |
|---|---|---|
| #335 (last green) | 4m41s | ✅ (only ~19s under the 5m cap) |
| #339 (cancelled) | 5m06s | ⏱️ timed out mid-Archive |

`references:all` clones and generates docs for three products (network-variable), and the component-version refresh tasks added in #339 make additional live GitHub API calls. The build was already at the edge of the 5-minute cap; the extra calls tipped it over. "Build website" itself succeeds — it's purely cumulative time, so more headroom is the fix.
