### PR TITLE
Raise deploy ship timeout to 5 minutes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,10 @@ jobs:
 
   ship:
     runs-on: ubuntu-24.04
-    timeout-minutes: 1
+    # Pulling and extracting the full-site archive, uploading the Pages artifact,
+    # and the GH Pages deployment together exceed 1 minute as the site grows, so
+    # give the job headroom above the previous tight 1-minute cap.
+    timeout-minutes: 5
     needs:
       - setup
     permissions:


### PR DESCRIPTION
## What

Raise the deploy `ship` job's `timeout-minutes` from **1 to 5**.

## Why

Follow-up to #340. A manual deploy of `master` was cancelled at the **Deploy to GH Pages** step: the `ship` job ran 1m02s and hit its 1-minute cap.

The job pulls + extracts the full-site archive, uploads the Pages artifact, and runs the GH Pages deployment. As the site has grown these now total just over a minute (older deploys ran ~30s), leaving no budget for the final deploy step. The successful build had already pushed the archive to GHCR, so this purely a wall-clock cap, not a content/build problem.
