### PR TITLE
Use version tag, not SHA, in OpenBolt generated note

### DIFF
--- a/lib/puppet_references/openbolt/docs.rb
+++ b/lib/puppet_references/openbolt/docs.rb
@@ -59,7 +59,7 @@ module PuppetReferences
       # leading H1 (the placement make_header uses for the other collections).
       # Falls back to after the YAML front matter, then to the top of the file.
       def insert_generated_note(content)
-        note = PuppetReferences::Util.generated_note('OpenBolt', @commit)
+        note = PuppetReferences::Util.generated_note('OpenBolt', PuppetReferences.version_commit)
         if (m = content.match(/\A(---\n.*?\n---\n\n)?(# [^\n]*\n)/m))
           "#{m[1]}#{m[2]}\n#{note}\n#{m.post_match}"
         elsif (m = content.match(/\A(---\n.*?\n---\n)/m))


### PR DESCRIPTION
## Problem

The "generated from" note on the OpenBolt generated reference pages showed the
upstream **commit SHA** instead of the clean version tag, unlike OpenVox and
OpenFact which show the tag:

```
OpenBolt:  generated from the OpenBolt source code based on version 41282c5265c0e4763d7c5f962636edefd675e6e8 on ...
OpenFact:  generated from the OpenFact source code based on version 5.6.1 on ...
```

## Fix

`lib/puppet_references/openbolt/docs.rb` passed `@commit` (the resolved SHA from
`Repo#checkout`) into the note. OpenVox/OpenFact instead use the pinned version
tag held in `PuppetReferences.version_commit`. This change makes OpenBolt match
them.

`PuppetReferences.version_commit` is set in `build_openbolt_references` before
`Docs.new` runs, so it holds the pinned tag.

## Verification

Built the references locally with the pinned version:

```console
bundle exec rake references:openbolt INSTALLPATH=docs
```

The generated note now reads the version tag instead of the SHA:

```
> **NOTE:** This page was generated from the OpenBolt source code based on version 5.6.0 on 2026-06-18 11:19:08 -0400. Do not edit it here; fix it upstream.
```

`ruby -c` and `rubocop` both pass on the changed file.

Closes #336
