### PR TITLE
Update Jig references for repo move to voxpupuli/jig

### DIFF
--- a/PDK.markdown
+++ b/PDK.markdown
@@ -26,4 +26,4 @@ OpenVox is compatible with PDK **3.4.0** and earlier for module development work
 The OpenVox community maintains tooling that replaces PDK workflows without requiring a commercial Puppet account:
 
 - **[VoxBox](https://github.com/voxpupuli/container-voxbox)** — A container image maintained by Vox Pupuli that includes rspec-puppet, Litmus, RuboCop, and other testing gems. It is the recommended way to run unit and acceptance tests for OpenVox modules in CI and local development.
-- **[jig](https://github.com/avitacco/jig)** — A Go-based reimplementation of PDK. Ships as a single static binary with no Ruby runtime dependency and supports module scaffolding, building, and releasing.
+- **[jig](https://github.com/voxpupuli/jig)** — A Go-based reimplementation of PDK. Ships as a single static binary with no Ruby runtime dependency and supports module scaffolding, building, and releasing.

--- a/docs/_ecosystem_8x/devkit/components.md
+++ b/docs/_ecosystem_8x/devkit/components.md
@@ -7,7 +7,7 @@ The Vox Pupuli developer toolkit is spread amongst many Ruby gems and other tool
 Most will be automatically pulled in via Bundler and the `Gemfile`, and some of the main ones will be listed at the bottom of this page for convenience.
 We'll focus on the tools that you may want to be aware of and install or use directly.
 
-* [Jig](https://github.com/avitacco/jig) is useful for scaffolding content for new and existing modules.
+* [Jig](https://github.com/voxpupuli/jig) is useful for scaffolding content for new and existing modules.
   All content it generates includes the appropriate barebones unit tests ready for you to fill out.
   It can also publish modules to the Puppet Forge.
 * [ModuleSync](https://github.com/voxpupuli/modulesync) helps maintain a portfolio of many modules at once.

--- a/docs/_ecosystem_8x/devkit/jig.md
+++ b/docs/_ecosystem_8x/devkit/jig.md
@@ -13,11 +13,11 @@ While OpenVox can technically load content this way in some cases, it's best to 
 
 It's possible to create files and maintain the proper directory structure by hand and nothing prevents you from doing so.
 However, many people today prefer to use a scaffolding tool to maintain proper structure and consistency.
-The tool we recommend for this today is [Jig](https://github.com/avitacco/jig).
+The tool we recommend for this today is [Jig](https://github.com/voxpupuli/jig).
 
 ## Installing Jig
 
-Download the latest release for your platform from the [releases page](https://github.com/avitacco/jig/releases).
+Download the latest release for your platform from the [releases page](https://github.com/voxpupuli/jig/releases).
 Uncompress it and move the `jig` binary to a path like `/usr/local/bin`.
 
 {% include alert.html type="tip" title="macOS Security Alert" content="The packages are unsigned, so macOS won't open them by default. Run it once and cancel the warning dialog that tells you to trash it.
@@ -29,7 +29,7 @@ This will place the compiled binary into `$GOPATH/bin`, which is likely to be `~
 Ensure that location is in your `$PATH`.
 
 ```console
-go install github.com/avitacco/jig@latest
+go install github.com/voxpupuli/jig@latest
 ```
 
 ## Creating a new module
@@ -46,6 +46,9 @@ Summary of the module []: This is not a real module; it just demonstrates the Ji
 Source URL for the module []: https://http.cat/status/404
 Created new module demo in /Users/ben.ford/Projects/demo
 ```
+
+To skip the interview and take the values from your config file, flags, or defaults instead, pass `--skip-interview` (or `-i`).
+You can supply individual values with flags such as `--forge-user`, `--author`, `--license`, `--summary`, and `--source`.
 
 Jig will create the full directory structure with starter files for the main class, Hiera data, rspec initialization helpers, etc.
 
@@ -123,7 +126,7 @@ Jig can create other types of content for your module:
 * `transport` _(uncommon)_
   * Creates a new [Resource API](https://github.com/puppetlabs/puppet-resource_api) transport and its associated files.
 
-See [Jig's GitHub page](https://github.com/avitacco/jig) for full documentation.
+See [Jig's GitHub page](https://github.com/voxpupuli/jig) for full documentation.
 
 ## Configuring Jig
 
@@ -148,7 +151,12 @@ To customize them, you'd dump them to disk and then edit as you like.
 jig templates dump ~/.config/jig/templates
 ```
 
-To use your new templates, add this directory to your Jig config file.
+Any template found in your directory takes precedence over the embedded default, and any template you don't override falls back to the embedded version, so you only need to include the files you want to change.
+
+To tell Jig where your templates live, use either of the following:
+
+* the `--template-dir` (`-t`) flag on `jig new`, which takes precedence, or
+* the `template_dir` key in your Jig config file.
 
 -----
 

--- a/docs/_openvox_8x/modules_publishing.markdown
+++ b/docs/_openvox_8x/modules_publishing.markdown
@@ -103,11 +103,11 @@ junit/
 tmp/
 ```
 
-The `.pdkignore` file excludes files during `jig module build` only.
+The `.pdkignore` file excludes files during `jig build` only.
 For example, you might want spec tests in your source control but not in your module package, so you would list them in `.pdkignore`.
 To prevent files, such as those in temporary directories, from ever being checked into Git, use `.gitignore`.
 
-If you have both a `.pdkignore` and a `.gitignore` file, the `jig module` command uses the `.pdkignore` file.
+If you have both a `.pdkignore` and a `.gitignore` file, the `jig build` command uses the `.pdkignore` file.
 
 ### Removing symlinks from your module
 
@@ -143,7 +143,7 @@ Related topics:
 
 To upload your module to the Forge, you first must build the module package.
 
-1. From the command line in your module's root directory, run `jig build build`. This command generates a `.tar.gz` package and saves it in the module's `pkg/` subdirectory.
+1. From the command line in your module's root directory, run `jig build`. This command generates a `.tar.gz` package and saves it in the module's `pkg/` subdirectory.
 
    For example:
 


### PR DESCRIPTION
## What

The Jig scaffolding tool moved from `github.com/avitacco/jig` to **`github.com/voxpupuli/jig`**. This updates every reference in the docs and refreshes the prose to match Jig's current CLI.

All command syntax was validated against the actual Jig source.

## Changes

**Repository URL move (`avitacco/jig` → `voxpupuli/jig`):**

- `PDK.markdown` — jig link
- `docs/_ecosystem_8x/devkit/components.md` — jig link
- `docs/_ecosystem_8x/devkit/jig.md` — recommendation link, releases page, `go install` path, and "full documentation" link

**Incorrect command syntax fixed in `docs/_openvox_8x/modules_publishing.markdown`:**

- `jig module build` → `jig build`
- the `jig module` command → `jig build`
- `jig build build` → `jig build`

Jig has no `module` subcommand; the build command is simply `jig build`.

**Prose refreshed to current features in `docs/_ecosystem_8x/devkit/jig.md`:**

- Documented the `--skip-interview` (`-i`) flag and its companion value flags (`--forge-user`, `--author`, `--license`, `--summary`, `--source`) on `jig new module`.
- Documented the template-override precedence: the `--template-dir` (`-t`) flag, then the `template_dir` config key.

## Validation notes

- Verified the full command/flag set against the Jig source (`new`/`build`/`release`/`templates dump`/`validate`/`test unit`/`update`).
- Jig's README advertises a `JIG_TEMPLATE_DIR` environment variable, but the source uses viper's `AutomaticEnv()` + `Unmarshal` with no `BindEnv`/default for `template_dir`, so the env var does not reliably bind. It is intentionally **not** documented here; only the verified flag and config key are.
- The `bundle exec` equivalents in `migrating.md` and the `jig build` / `jig release --version` usage in `publishing.md` were checked and remain correct, so they are unchanged.

## Conflicts

No conflicts with the other open PRs. #321 also touches `jig.md` but only appends a bullet at the end of the file; these hunks don't overlap and merge cleanly in either order.

Closes #346
