### PR TITLE
Add llms.txt and llms-full.txt for LLM-friendly docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,19 @@ See the [home layout reference][home-layout] for details.
 
 [home-layout]: https://jekyll-vitepress.dev/frontmatter-reference/#home-layout-keys
 
+### LLM-friendly documentation files
+
+The build produces two machine-readable files at the site root for use with
+large language models, generated from Liquid templates (`llms.txt` and
+`llms-full.txt`) the same way `search.json` is — no manual step is required:
+
+- `llms.txt` — a curated, link-based index of the docs, grouped by project,
+  following the [llms.txt convention](https://llmstxt.org/).
+- `llms-full.txt` — the full text of the docs concatenated as plain text.
+
+Both iterate the site's `_latest` collections at build time, so new pages and
+projects are included automatically.
+
 ### Modifying theme settings
 
 This project uses the [Jekyll VitePress theme][jekyll-vitepress], by

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,33 @@
+---
+layout: null
+permalink: /llms-full.txt
+---
+{%- assign site_url = "https://docs.openvoxproject.org" -%}
+# {{ site.title }}
+
+> {{ site.description }}
+
+This file contains the full text of the OpenVox documentation (current stable
+version of each project) concatenated as plain text for use with large language
+models. Each document is preceded by its title and canonical URL.
+{% assign latest_collections = site.collections | where_exp: "c", "c.label contains '_latest'" | sort: "label" %}
+{%- for collection in latest_collections -%}
+{%- assign project = collection.label | remove: "_latest" -%}
+{%- assign docs = collection.docs | where_exp: "d", "d.title" | sort: "url" -%}
+{%- if docs.size > 0 %}
+
+{% raw %}# ====================================================================={% endraw %}
+# Project: {{ project }}
+{% raw %}# ====================================================================={% endraw %}
+{% for doc in docs %}
+
+---
+
+## {{ doc.title | strip_html | strip }}
+
+Source: {{ site_url }}{{ doc.url }}
+
+{{ doc.content | strip_html | replace: '&lt;', '<' | replace: '&gt;', '>' | replace: '&quot;', '"' | replace: '&#39;', "'" | replace: '&amp;', '&' | strip }}
+{% endfor %}
+{%- endif -%}
+{%- endfor %}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+---
+layout: null
+permalink: /llms.txt
+---
+{%- assign site_url = "https://docs.openvoxproject.org" -%}
+# {{ site.title }}
+
+> {{ site.description }}
+
+This is an LLM-friendly index of the OpenVox documentation. Each link points to
+an HTML page on the documentation site; append nothing to fetch the rendered
+page. For the full documentation concatenated as plain text in a single file,
+see [{{ site_url }}/llms-full.txt]({{ site_url }}/llms-full.txt).
+
+Only the current stable ("latest") version of each project is listed below.
+{% assign latest_collections = site.collections | where_exp: "c", "c.label contains '_latest'" | sort: "label" %}
+{%- for collection in latest_collections -%}
+{%- assign project = collection.label | remove: "_latest" -%}
+{%- assign docs = collection.docs | where_exp: "d", "d.title" | sort: "url" %}
+{% if docs.size > 0 %}
+## {{ project }}
+{% for doc in docs %}
+- [{{ doc.title | strip_html | strip }}]({{ site_url }}{{ doc.url }})
+{%- endfor %}
+{% endif %}
+{%- endfor %}


### PR DESCRIPTION
## What

Publishes two machine-readable files at the site root following the
[`llms.txt` convention](https://llmstxt.org/):

- `https://docs.openvoxproject.org/llms.txt` — a curated, link-based index of the
  docs, grouped by project.
- `https://docs.openvoxproject.org/llms-full.txt` — the full text of the docs
  concatenated as plain text in a single file.

## How

Both files are root-level Liquid templates with `layout: null` and a fixed
`permalink`, exactly like the existing `search.json`. They render during the
normal `jekyll build`, so:

- No new plugins or gems, and they are produced automatically in CI.
- They iterate `site.collections`, so they always reflect the current docs,
  including the generated reference pages (`configuration.md`, `function.md`,
  `type.md`, man pages) that CI writes into `docs/` before the build.
- Only the `_latest` collections are emitted. The `_8x`/`_5x` directories are
  symlinked into `_latest`, so emitting both would list every page under two
  URLs; using `_latest` yields exactly one canonical `/latest/` URL per page.
- The `doc.title` filter (the same one `search.json` uses) skips the underscore-
  prefixed include partials that have no front matter.

The README gains a short section documenting the files.

## How this helps the developer workflow

- **Faster onboarding and Q&A.** Contributors can point an LLM-powered editor or
  chat assistant at `llms-full.txt` (or a few pages from `llms.txt`) and ask
  "how do I configure X?" or "where is Y documented?" instead of grepping the
  repo or crawling the rendered HTML site.
- **No manual bundling.** Today, feeding the docs to a model means cloning the
  repo and stitching collections together by hand while dodging the `_latest`
  symlinks to avoid duplicates. This produces a clean, deduplicated bundle on
  every build for free.
- **Better tooling integration.** Many assistants and IDE integrations already
  look for `/llms.txt` at a domain root, so this makes the docs first-class for
  those tools without any per-developer setup.
- **Authoring feedback loop.** Because the files regenerate on every build,
  writers can preview exactly what an LLM will see for their new or edited pages
  via `bundle exec jekyll serve`.
- **Clean content, no scraping.** Consumers get the documentation text with the
  theme HTML, navigation, and scripts stripped out.

## Testing

- `bundle exec jekyll build` succeeds; `_site/llms.txt` (~48 KB) and
  `_site/llms-full.txt` (~3.6 MB) are produced (local build, excluding the
  generated reference pages CI writes into `docs/`).
- Verified the index contains one `##` section per project and that every URL is
  unique (no `_8x`/`_5x` duplication; all links are `/latest/`).
- Verified `llms-full.txt` contains no residual HTML tags or undecoded entities
  (`&lt;`/`&gt;`/`&amp;`), so code blocks read cleanly.

## Notes

- `llms-full.txt` is large (dominated by the single-page resource type and
  function references). That is expected for a full-text bundle; tools that want
  a smaller payload can use `llms.txt` and fetch individual pages.
- The domain (`https://docs.openvoxproject.org`) is hardcoded in the templates
  rather than relying on `site.url` (which is unset), to keep the change isolated
  to the two new files.

Part of #358.

