### PR TITLE
Derive mermaid CDN version from package.json (single source of truth)

### DIFF
--- a/_data/package.json
+++ b/_data/package.json
@@ -1,0 +1,1 @@
+../package.json

--- a/_includes/jekyll_vitepress/head_end.html
+++ b/_includes/jekyll_vitepress/head_end.html
@@ -12,7 +12,7 @@
 </script>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs';
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{{ site.data.package.dependencies.mermaid }}/dist/mermaid.esm.min.mjs';
   mermaid.initialize({ startOnLoad: false });
 
   function renderMermaid() {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "openvox-docs",
   "private": true,
   "dependencies": {
-    "mermaid": "11.15.0"
+    "mermaid": "11.16.0"
   }
 }


### PR DESCRIPTION
Closes #370. Supersedes #367.

## Problem

The mermaid version was pinned in two places that had to be kept in sync by hand:

- `package.json` — `"mermaid": "11.x.y"`, a Dependabot tracking shim (there is no Node build)
- `_includes/jekyll_vitepress/head_end.html` — a hardcoded CDN import, which is the version the site actually loads

Dependabot only understands `package.json`, so its bump PRs changed the tracking file but not the CDN URL — the deployed version never moved and the two pins drifted. #367 had to be patched by hand to bump the CDN URL too, and that manual commit then tripped the "verified signatures" branch-protection rule.

## Change

Make `package.json` the single source of truth and derive the CDN version at build time:

- Symlink `_data/package.json -> ../package.json` so Jekyll loads it as `site.data.package` (the repo already uses symlinks for the `_latest` collections).
- Reference it via Liquid in `head_end.html`:
  ```liquid
  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{{ site.data.package.dependencies.mermaid }}/dist/mermaid.esm.min.mjs';
  ```
- Bump mermaid `11.15.0 -> 11.16.0`, which also exercises the new mechanism.

Future Dependabot bumps are now clean one-line `package.json` PRs that propagate to the live version automatically — no manual follow-up, no drift.

## Verification

- `bundle exec jekyll build` succeeds; rendered pages import `mermaid@11.16.0` (confirmed in `_site/`), with no leftover unrendered Liquid.
- Rendered the project's sequence diagram (`docs/_openvox_8x/subsystem_agent_server_comm.markdown`) against mermaid 11.16.0 from the live CDN in a headless browser — SVG renders cleanly, all actors and message lines present, no errors.

## Follow-up

Once this merges, #367 can be closed (master will already be at 11.16.0, so Dependabot won't reopen it).
