### PR TITLE
Add a generated supported-platforms page

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,6 +92,9 @@ jobs:
           bundle exec rake references:server_versions || echo 'server_versions refresh failed; using committed _data'
           bundle exec rake references:openvoxdb_versions || echo 'openvoxdb_versions refresh failed; using committed _data'
           bundle exec rake references:openbolt_versions || echo 'openbolt_versions refresh failed; using committed _data'
+          # Refresh the supported-platforms table from the shared-actions
+          # platforms.json, falling back to the committed _data file if unreachable.
+          bundle exec rake references:supported_platforms || echo 'supported_platforms refresh failed; using committed _data'
           bundle exec jekyll build
       - name: Archive website
         run: |

--- a/Rakefile
+++ b/Rakefile
@@ -147,6 +147,14 @@ namespace :references do
   desc 'Generate all component-version data files (agent, server, openvoxdb, openbolt)'
   task component_versions: %i[agent_versions server_versions openvoxdb_versions openbolt_versions]
 
+  desc 'Generate _data/supported_platforms.yml from the shared-actions platforms.json'
+  task :supported_platforms do
+    require 'puppet_references/supported_platforms'
+    path = ENV.fetch('SUPPORTED_PLATFORMS_DATA', '_data/supported_platforms.yml')
+    data = PuppetReferences::SupportedPlatforms.write_data_file(path:)
+    puts "Wrote #{data.values.sum(&:size)} platform rows across #{data.size} series to #{path}"
+  end
+
   task :check do
     puts 'No VERSION given to build references for - using latest tag' unless ENV['VERSION']
     puts "Building into collection #{ENV.fetch('COLLECTION')}" if ENV['COLLECTION']

--- a/_data/nav/openvox_8x.yml
+++ b/_data/nav/openvox_8x.yml
@@ -11,6 +11,8 @@
     link: "about_agent.html"
   - text: Component versions in recent releases
     link: "component_versions.html"
+  - text: Supported platforms
+    link: "supported_platforms.html"
 - text: Getting started
   items:
   - text: Getting started with OpenVox

--- a/_data/supported_platforms.yml
+++ b/_data/supported_platforms.yml
@@ -1,0 +1,250 @@
+---
+main:
+- os: Enterprise Linux 8
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: true
+- os: Enterprise Linux 9
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: true
+- os: Enterprise Linux 10
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Amazon Linux 2023
+  family: amazon
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Fedora 43
+  family: fedora
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Fedora 44
+  family: fedora
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: SLES 15
+  family: sles
+  agent_bolt:
+  - x86-64
+  server_db: true
+  fips: false
+- os: SLES 16
+  family: sles
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Debian 12
+  family: debian
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: false
+  fips: false
+- os: Debian 13
+  family: debian
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: Ubuntu 22.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Ubuntu 24.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: Ubuntu 26.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: macOS
+  family: macos
+  agent_bolt:
+  - Intel
+  - Apple Silicon
+  server_db: false
+  fips: false
+- os: Windows
+  family: windows
+  agent_bolt:
+  - x86-64
+  server_db: false
+  fips: false
+8.x:
+- os: Enterprise Linux 7
+  family: el
+  agent_bolt:
+  - x86-64
+  server_db: false
+  fips: false
+- os: Enterprise Linux 8
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: true
+- os: Enterprise Linux 9
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: true
+- os: Enterprise Linux 10
+  family: el
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Amazon Linux 2
+  family: amazon
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Amazon Linux 2023
+  family: amazon
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Fedora 42
+  family: fedora
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Fedora 43
+  family: fedora
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Fedora 44
+  family: fedora
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: SLES 15
+  family: sles
+  agent_bolt:
+  - x86-64
+  server_db: true
+  fips: false
+- os: SLES 16
+  family: sles
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Debian 11
+  family: debian
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Debian 12
+  family: debian
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Debian 13
+  family: debian
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: Ubuntu 22.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  server_db: true
+  fips: false
+- os: Ubuntu 24.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: Ubuntu 25.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: Ubuntu 26.04
+  family: ubuntu
+  agent_bolt:
+  - x86-64
+  - Arm64
+  - armhf
+  server_db: true
+  fips: false
+- os: macOS
+  family: macos
+  agent_bolt:
+  - Intel
+  - Apple Silicon
+  server_db: false
+  fips: false
+- os: Windows
+  family: windows
+  agent_bolt:
+  - x86-64
+  server_db: false
+  fips: false

--- a/docs/_openvox_8x/supported_platforms.md
+++ b/docs/_openvox_8x/supported_platforms.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: "Supported platforms"
+---
+
+[platforms_json]: https://github.com/OpenVoxProject/shared-actions/blob/main/platforms.json
+[component_versions]: ./component_versions.html
+
+This page lists the operating systems OpenVox builds packages for. It is generated
+from [`platforms.json`][platforms_json] in `OpenVoxProject/shared-actions`, the same
+list the build system uses to decide where packages are produced, so it always
+matches what actually ships.
+
+For the component versions inside a given release (Ruby, OpenSSL, JRuby, and so on),
+see [Component versions in recent releases][component_versions].
+
+## How to read these tables
+
+OpenVox ships on two build systems, which is why each row has two columns:
+
+- **openvox-agent / OpenBolt** — the Ruby components, built per CPU architecture.
+  The cell lists the architectures available for that OS.
+- **openvox-server / OpenVoxDB** — the JVM components, which are
+  architecture-independent. A check mark means packages are built for that OS; a
+  dash means they are not (the agent still runs there, but you would run the server
+  or database on a different platform).
+
+A dagger (†) marks operating systems with FIPS-validated builds. FIPS builds are
+x86-64 only.
+
+## OpenVox 8.x
+
+{% assign rows = site.data.supported_platforms["8.x"] %}
+
+<!-- markdownlint-disable MD055 MD056 -->
+
+| Operating system | openvox-agent / OpenBolt | openvox-server / OpenVoxDB |
+| --- | --- | --- |
+{% for r in rows %}| {{ r.os }}{% if r.fips %} †{% endif %} | {% if r.agent_bolt %}{{ r.agent_bolt | join: ", " }}{% else %}—{% endif %} | {% if r.server_db %}✓{% else %}—{% endif %} |
+{% endfor %}
+
+## Next major version (in development)
+
+> **In development.** These are the platforms targeted by the next major OpenVox
+> release while it is being developed. The list can change before that release is
+> final.
+
+{% assign rows = site.data.supported_platforms["main"] %}
+
+| Operating system | openvox-agent / OpenBolt | openvox-server / OpenVoxDB |
+| --- | --- | --- |
+{% for r in rows %}| {{ r.os }}{% if r.fips %} †{% endif %} | {% if r.agent_bolt %}{{ r.agent_bolt | join: ", " }}{% else %}—{% endif %} | {% if r.server_db %}✓{% else %}—{% endif %} |
+{% endfor %}
+<!-- markdownlint-enable MD055 MD056 -->
+
+> **Enterprise Linux** covers RHEL and its rebuilds (AlmaLinux, Rocky Linux, Oracle
+> Linux). A platform being listed means OpenVox publishes packages for it; see
+> [Installing OpenVox](./install_pre.html) for how to configure the repository on
+> your OS.

--- a/lib/puppet_references/supported_platforms.rb
+++ b/lib/puppet_references/supported_platforms.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'yaml'
+require 'fileutils'
+require 'net/http'
+require 'uri'
+
+module PuppetReferences
+  # Generates the data file rendered on the OpenVox "supported platforms" page
+  # from the authoritative platforms.json in OpenVoxProject/shared-actions. That
+  # file is the single list the OpenVox build system uses to decide where it
+  # builds packages, so deriving the docs table from it keeps the two from
+  # drifting.
+  #
+  # platforms.json is keyed by series ("main" = the in-development next major;
+  # "8.x" = the 8.x line). Under each series, the `vanagon` group lists the
+  # platforms the Ruby projects (openvox-agent, OpenBolt) build for, carrying CPU
+  # arch; the `ezbake-*` groups list the platforms the JVM projects
+  # (openvox-server, OpenVoxDB) build for, which are architecture-independent. We
+  # collapse those into one row per operating system, tracking the agent/bolt
+  # arches, whether server/db are built, and whether a FIPS build exists.
+  class SupportedPlatforms
+    SOURCE_URL = 'https://raw.githubusercontent.com/OpenVoxProject/shared-actions/main/platforms.json'
+    USER_AGENT = 'openvox-docs-supported-platforms'
+
+    VANAGON_GROUP = 'vanagon'
+    # ezbake-fips-rpm only contributes the FIPS flag; the OS itself is already
+    # covered by the el/redhatfips rows, so it does not add new server/db rows.
+    EZBAKE_GROUPS = %w[ezbake-deb ezbake-rpm ezbake-fips-rpm].freeze
+
+    # Display label per OS family. `el` and `redhatfips` share the Enterprise
+    # Linux label; the FIPS variant only sets the per-row fips flag.
+    FAMILY_LABEL = {
+      'el' => 'Enterprise Linux',
+      'redhatfips' => 'Enterprise Linux',
+      'amazon' => 'Amazon Linux',
+      'fedora' => 'Fedora',
+      'sles' => 'SLES',
+      'debian' => 'Debian',
+      'ubuntu' => 'Ubuntu',
+      'macos' => 'macOS',
+      'windows' => 'Windows',
+    }.freeze
+
+    # Row order on the rendered page, grouped by family then version ascending.
+    FAMILY_ORDER = %w[el amazon fedora sles debian ubuntu macos windows].freeze
+
+    # Families whose platform string carries no real version (the middle token is
+    # a variant like "all" or "msys2", not a release), rendered as a single row.
+    VERSIONLESS = %w[macos windows].freeze
+
+    # Build-arch tokens normalized to the labels shown on the page.
+    ARCH_LABEL = {
+      'x86_64' => 'x86-64', 'amd64' => 'x86-64', 'x64' => 'x86-64',
+      'aarch64' => 'Arm64', 'arm64' => 'Arm64',
+      'armhf' => 'armhf',
+    }.freeze
+
+    # macOS reads more naturally with marketing arch names than raw CPU arches.
+    MACOS_ARCH_LABEL = { 'x86_64' => 'Intel', 'arm64' => 'Apple Silicon' }.freeze
+
+    ARCH_ORDER = ['x86-64', 'Arm64', 'armhf', 'Intel', 'Apple Silicon'].freeze
+
+    # Resolve and write the data file consumed by the docs page. Returns the data.
+    def self.write_data_file(path:, source: nil)
+      data = new(source: source).series_rows
+      raise 'resolved no platforms; refusing to overwrite data file' if data.empty?
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, data.to_yaml)
+      data
+    end
+
+    def initialize(source: nil)
+      @source = source
+    end
+
+    # { series => [row, ...] } for every series in platforms.json.
+    def series_rows
+      platforms.transform_values { |groups| rows_for_series(groups) }
+    end
+
+    private
+
+    def rows_for_series(groups)
+      rows = {} # group-key => row hash
+
+      Array(groups[VANAGON_GROUP]).each do |platform|
+        family, version, arch = parse(platform, arch: true)
+        next unless family
+
+        row = (rows[[family, version]] ||= new_row(family, version))
+        row['fips'] = true if family_fips?(platform)
+        next if arch.nil?
+
+        (row['agent_bolt'] ||= []) << display_arch(family, arch)
+      end
+
+      EZBAKE_GROUPS.each do |group|
+        fips = group.include?('fips')
+        Array(groups[group]).each do |platform|
+          family, version, = parse(platform, arch: false)
+          next unless family
+
+          row = (rows[[family, version]] ||= new_row(family, version))
+          row['fips'] = true if fips
+          row['server_db'] = true
+        end
+      end
+
+      finalize(rows.values)
+    end
+
+    # A platform string is "<os>-<version>-<arch>" (vanagon) or "<os>-<version>"
+    # (ezbake). macOS/Windows carry a variant token ("all"/"msys2") in place of a
+    # version. Returns [grouping-family, version-or-nil, arch-or-nil]; family is
+    # nil (with a warning) for an unmapped OS so a new platform never silently
+    # vanishes nor breaks the build.
+    def parse(platform, arch:)
+      tokens = platform.split('-')
+      os = tokens.shift
+      a = arch ? tokens.pop : nil
+
+      unless FAMILY_LABEL.key?(os)
+        warn "supported_platforms: unknown OS family in #{platform.inspect}; skipping"
+        return [nil, nil, nil]
+      end
+
+      version = VERSIONLESS.include?(os) ? nil : tokens.join('-')
+      [grouping_family(os), version, a]
+    end
+
+    # redhatfips rows fold into the matching Enterprise Linux row.
+    def grouping_family(os)
+      (os == 'redhatfips') ? 'el' : os
+    end
+
+    def family_fips?(platform)
+      platform.start_with?('redhatfips-')
+    end
+
+    def new_row(family, version)
+      label = FAMILY_LABEL.fetch(family)
+      { 'os' => version.nil? ? label : "#{label} #{version}", 'family' => family,
+        'version' => version, 'agent_bolt' => nil, 'server_db' => false, 'fips' => false, }
+    end
+
+    def display_arch(family, arch)
+      return MACOS_ARCH_LABEL.fetch(arch, arch) if family == 'macos'
+
+      ARCH_LABEL.fetch(arch) do
+        warn "supported_platforms: unknown arch #{arch.inspect}; passing through"
+        arch
+      end
+    end
+
+    # Sort rows for display and tidy each one: order/uniq the arch list, and drop
+    # the grouping-only `version` field from the emitted data.
+    def finalize(rows)
+      rows.each do |row|
+        row['agent_bolt'] = row['agent_bolt'].uniq.sort_by { |a| ARCH_ORDER.index(a) || ARCH_ORDER.size } if row['agent_bolt']
+      end
+      rows.sort_by! { |row| [FAMILY_ORDER.index(row['family']) || FAMILY_ORDER.size, version_key(row['version'])] }
+      rows.each { |row| row.delete('version') }
+      rows
+    end
+
+    # Numeric-aware version sort key so "el 9" precedes "el 10".
+    def version_key(version)
+      return [] if version.nil?
+
+      version.split('.').map(&:to_i)
+    end
+
+    def platforms
+      @platforms ||= JSON.parse(@source || fetch)
+    end
+
+    def fetch
+      uri = URI(SOURCE_URL)
+      req = Net::HTTP::Get.new(uri)
+      req['User-Agent'] = USER_AGENT
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+      return res.body if res.is_a?(Net::HTTPSuccess)
+
+      raise "fetching #{SOURCE_URL} failed: #{res.code} #{res.body.to_s[0, 200]}"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a **Supported platforms** page to the OpenVox docs, generated from the
authoritative [`platforms.json`](https://github.com/OpenVoxProject/shared-actions/blob/main/platforms.json)
in `OpenVoxProject/shared-actions` — the same list the build system uses to decide
where it builds packages, so the docs never drift from what actually ships.

Closes #303.

## How it works

A new `PuppetReferences::SupportedPlatforms` generator fetches `platforms.json` and
collapses the per-build-system platform lists into **one row per operating system**:

- The `vanagon` group (Ruby projects) becomes the **openvox-agent / OpenBolt**
  column, listing the CPU architectures available for that OS.
- The `ezbake-*` groups (JVM projects, architecture-independent) become the
  **openvox-server / OpenVoxDB** column, shown as ✓ / —.
- `redhatfips-*` / `ezbake-fips-rpm` set a FIPS flag, rendered as a dagger (†) with
  a note that FIPS builds are x86-64 only.

OS and architecture tokens are normalized for readability (`el-9` → "Enterprise
Linux 9", `macos-all-arm64` → "Apple Silicon", and so on). Unknown tokens **warn and
pass through** rather than failing, so a new upstream platform never breaks the build
or silently disappears.

The page renders **both series** present in the source: the current **8.x** line and
the **in-development next major**.

## Plumbing

Follows the existing component-versions table pattern:

- `rake references:supported_platforms` writes `_data/supported_platforms.yml`,
  committed as a fallback.
- `build.yaml` refreshes it at deploy time with the same
  fall-back-to-committed guard as the other `references:*_versions` tasks.
- Added to the OpenVox 8 nav under "Component versions in recent releases".

## Validation

- `rake rubocop` clean; `jekyll build` succeeds; `markdownlint` clean on the new page.
- Output spot-checked against `platforms.json` (e.g. `main` Debian 12 correctly has
  no server/db; SLES 15 is x86-64 only).
- Rendered locally and confirmed both tables render as real tables (screenshot below).

## Screenshots

<!-- drag the screenshot here -->
<img width="1440" height="2898" alt="openvox_supported_platforms" src="https://github.com/user-attachments/assets/5c1de717-7099-4ca4-858b-c4bfdbe88d8f" />

