### PR TITLE
Add CVE fix lists for 8.13.0 releases of OpenVox Server and OpenVoxDB

### DIFF
--- a/docs/_openvox-server_8x/release_notes.markdown
+++ b/docs/_openvox-server_8x/release_notes.markdown
@@ -38,6 +38,12 @@ This is an enhancement and bug-fix release of OpenVox Server.
 
 All bug fixes, new features and other changes are provided on the [project's GitHub release page](https://github.com/OpenVoxProject/openvox-server/releases/tag/8.13.0).
 
+### Security Issues Resolved in 8.13.0
+
+| Identifier                                                               | CVSS 3.1 Score | Resolved By                                                |
+| :----------------------------------------------------------------------- | :------------: | :--------------------------------------------------------- |
+| [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) |       N/A      | `pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.3` |
+
 ### Known Issues
 
 #### `jruby-openssl` 0.15.4 Fails to Parse EC Keys

--- a/docs/_openvoxdb_8x/release_notes.markdown
+++ b/docs/_openvoxdb_8x/release_notes.markdown
@@ -72,6 +72,14 @@ This is an enhancement release of OpenVoxDB.
 All bug fixes, new features and other changes are provided on the
 [project's GitHub release page](https://github.com/OpenVoxProject/openvoxdb/releases/tag/8.13.0).
 
+### Security Issues Resolved in 8.14.0
+
+| Identifier                                                               | CVSS 3.1 Score | Resolved By                                                |
+| :----------------------------------------------------------------------- | :------------: | :--------------------------------------------------------- |
+| [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) |       N/A      | `pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.3` |
+| [CVE-2025-67721](https://nvd.nist.gov/vuln/detail/CVE-2025-67721)        |       7.5      | `pkg:maven/io.airlift/aircompressor@2.0.3`                 |
+| [CVE-2026-42198](https://nvd.nist.gov/vuln/detail/CVE-2026-42198)        |       7.5      | `pkg:maven/org.postgresql/postgresql@42.7.11`              |
+
 ## OpenVoxDB 8.12.1
 
 Released January 23, 2026.


### PR DESCRIPTION
### Short description

This changeset adds CVEs resolved in the 8.13.0 releases of OpenVox Server and OpenVoxDB. This completes the data currently available as `pom.xml` files were not published to Clojars prior to the 8.12.0 release.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
