### PR TITLE
Fix section header in OpenVoxDB 8.13.0 notes

### DIFF
--- a/docs/_openvoxdb_8x/release_notes.markdown
+++ b/docs/_openvoxdb_8x/release_notes.markdown
@@ -72,7 +72,7 @@ This is an enhancement release of OpenVoxDB.
 All bug fixes, new features and other changes are provided on the
 [project's GitHub release page](https://github.com/OpenVoxProject/openvoxdb/releases/tag/8.13.0).
 
-### Security Issues Resolved in 8.14.0
+### Security Issues Resolved in 8.13.0
 
 | Identifier                                                               | CVSS 3.1 Score | Resolved By                                                |
 | :----------------------------------------------------------------------- | :------------: | :--------------------------------------------------------- |


### PR DESCRIPTION
### Short description

I was a little fast on the copy + paste and accidentally duplicated the `Security Issues Resolved in 8.14.0` header. This commit corrects the version to the intended 8.13.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
