### PR TITLE
Remove obsolete 'Rack application' / Passenger / WEBrick deployment references

### DIFF
--- a/docs/_openvox_8x/config_important_settings.markdown
+++ b/docs/_openvox_8x/config_important_settings.markdown
@@ -125,7 +125,7 @@ These settings should usually go in `[server]`. However, if you're using Puppet 
 ### Basics
 
 * [`dns_alt_names`][dns_alt_names] --- A list of hostnames the server is allowed to use when acting as an OpenVox Server. The hostname your agents use in their `server` setting **must** be included in either this setting or the master's `certname` setting. Note that this setting is only used when initially generating the OpenVox Server's certificate --- if you need to change the DNS names, you must:
-    1. Turn off the Puppet server service (or your Rack server).
+    1. Turn off the Puppet server service.
     2. Run `sudo puppetserver ca clean --certname <SERVER'S CERTNAME>`.
     3. Run `sudo puppetserver ca generate --certname <SERVER'S CERTNAME> --subject-alt-names <ALT NAME 1>,<ALT NAME 2>,...`.
     4. Re-start the Puppet server service.

--- a/docs/_openvox_8x/config_print.markdown
+++ b/docs/_openvox_8x/config_print.markdown
@@ -78,7 +78,7 @@ To see the settings the OpenVox Server service would use:
 * Specify `--section server`.
 * Use the `--environment` option to specify the environment you want settings for, or let it default to `production`.
 * Remember to use `sudo`.
-* If your OpenVox Server is managed as a rack application (e.g. with Passenger), check the `config.ru` file to make sure it's using the [confdir][] and [vardir][] that you expect. If it's using non-standard ones, you will need to specify them on the command line with the `--confdir` and `--vardir` options; otherwise you might not see the correct values for settings.
+* If your OpenVox Server uses a non-standard [confdir][] or [vardir][], specify them on the command line with the `--confdir` and `--vardir` options; otherwise you might not see the correct values for settings.
 
 ### Examples
 

--- a/docs/_openvox_8x/dirs_codedir.markdown
+++ b/docs/_openvox_8x/dirs_codedir.markdown
@@ -20,8 +20,6 @@ When Puppet is running as either root, a Windows user with administrator privile
 
 The system codedir is what you usually want to use, since you will usually run Puppet's commands and services as root or `puppet`. (Note that admin commands like `puppet module` must be run with `sudo` to use the same codedir as OpenVox agent or OpenVox Server.)
 
-> **Note:** When OpenVox Server is running as a Rack application, the `config.ru` file must explicitly set `--codedir` to the system codedir. The example `config.ru` file provided with the Puppet source does this.
-
 ### Configuration
 
 The location of the codedir can be configured in puppet.conf with [the `codedir` setting][codedir], but note that Puppet Server doesn't use that setting; it has its own `jruby-puppet.master-code-dir` setting [in puppetserver.conf][puppetserver_conf]. If you're using a non-default codedir, _you must change both settings._

--- a/docs/_openvox_8x/dirs_confdir.markdown
+++ b/docs/_openvox_8x/dirs_confdir.markdown
@@ -21,8 +21,6 @@ The system confdir is what you usually want to use, since you will usually run P
 services as root or `puppet`. (Note that admin commands like `puppetserver ca` must be run with `sudo`
 to use the same confdir as OpenVox agent or OpenVox Server.)
 
-> **Note:** When OpenVox Server is running as a Rack application, the `config.ru` file must explicitly set `--confdir` to the system confdir. The example `config.ru` file provided with the Puppet source does this.
-
 ### Configuration
 
 Puppet's confdir can be specified on the command line with the `--confdir` option, but it can't be set

--- a/docs/_openvox_8x/dirs_vardir.markdown
+++ b/docs/_openvox_8x/dirs_vardir.markdown
@@ -24,8 +24,6 @@ The system cache directory is what you usually want to use, since you will usual
 and services as root or `puppet`. (Note that admin commands like `puppetserver ca` must be run with
 `sudo` to use the same directories as OpenVox agent or OpenVox Server.)
 
-> **Note:** When OpenVox Server is running as a Rack application, the `config.ru` file must explicitly set `--vardir` to the system cache directory. The example `config.ru` file provided with the Puppet source does this.
-
 ### Configuring the location of the cache directory
 
 You can specify Puppet's cache directory on the command line by using the `--vardir` option, but you can't set it in `puppet.conf`. If `--vardir` isn't specified when a Puppet application is started, it will always use the default cache directory location.

--- a/docs/_openvox_8x/static_catalogs.md
+++ b/docs/_openvox_8x/static_catalogs.md
@@ -117,7 +117,7 @@ The script's standard output becomes the file's `code_content`, provided the scr
 Starting in Puppet 4.4 and OpenVox Server 2.3.0, the global `static_catalogs` setting is enabled by default, whether you upgrade Puppet or perform a clean installation.
 However, the default configuration doesn't include the `code-id-command` and `code-content-command` scripts or settings needed to produce static catalogs, and even when configured to produce static catalogs OpenVox Server doesn't inline metadata for all types of file resources.
 
-Static catalogs are produced only by OpenVox Server. The Ruby OpenVox server never produces static catalogs, even when served by WEBrick or Passenger.
+Static catalogs are produced only by OpenVox Server.
 
 OpenVox Server also won't produce static catalogs for an agent under the following circumstances:
 


### PR DESCRIPTION
## Summary

Removes stale references to running OpenVox Server as a **Rack application** (`config.ru` with Passenger/Apache or WEBrick). That deployment model no longer exists in OpenVox 8 — OpenVox Server runs on JRuby (puppetserver) only.

## Changes

- Drop the three `config.ru`/Rack `> **Note:**` blocks in `dirs_vardir.markdown`, `dirs_confdir.markdown`, and `dirs_codedir.markdown` — they describe a deployment that no longer exists.
- Reword the `config_print.markdown` bullet to drop the Rack/Passenger/`config.ru` framing while keeping the useful guidance about specifying a non-standard `confdir`/`vardir` on the command line.
- Simplify the `static_catalogs.md` sentence to drop the obsolete Ruby/WEBrick/Passenger master reference; it now just states that static catalogs are produced only by OpenVox Server.
- Drop the "(or your Rack server)" aside in `config_important_settings.markdown` — an occurrence not listed in the issue but surfaced by a broader sweep.

The "Rack related settings" section in `config_important_settings.markdown` was already removed in #273; this covers the remaining inline mentions.

The two other `passenger` hits in the collection (`modules_installing.markdown`, `lang_namespaces.markdown`) are module-name/namespace examples, not deployment references, and are intentionally left untouched.

Closes #275
