### PR TITLE
Alternative fix: make OpenBolt topic-group pages reachable from the navbar

### DIFF
--- a/_data/nav/openbolt_5x.yml
+++ b/_data/nav/openbolt_5x.yml
@@ -45,8 +45,9 @@
   - text: Wrapping a script in a plan
     link: creating_a_script_plan.html
 - text: Plans
-  link: plans.html
   items:
+  - text: Overview
+    link: plans.html
   - text: Inspecting plans
     link: inspecting_plans.html
   - text: Running plans
@@ -60,8 +61,9 @@
   - text: Testing plans
     link: testing_plans.html
 - text: Tasks
-  link: tasks.html
   items:
+  - text: Overview
+    link: tasks.html
   - text: Inspecting tasks
     link: inspecting_tasks.html
   - text: Running tasks
@@ -97,8 +99,9 @@
   - text: Connecting Bolt to PuppetDB
     link: bolt_connect_puppetdb.html
 - text: Bolt Examples
-  link: bolt_examples.html
   items:
+  - text: Overview
+    link: bolt_examples.html
   - text: Automating Windows targets
     link: automating_windows_targets.html
   - text: Deploy a TIG stack with Bolt

--- a/docs/_openbolt_5x/bolt_examples.md
+++ b/docs/_openbolt_5x/bolt_examples.md
@@ -19,3 +19,6 @@ blog](https://puppet.com/search/?query=bolt&page=1&configure%5BhitsPerPage%5D=20
 
 > **Note:** Do you have a real-world use case for Bolt that you'd like to share? Reach out to us in the #bolt
   channel on [Slack](https://slack.puppet.com).
+
+- [Automating Windows targets](automating_windows_targets.html) — Use Bolt to manage a fleet of Windows machines.
+- [Deploy a TIG stack with Bolt](tig_stack.html) — Provision and configure a Telegraf, InfluxDB, and Grafana stack.

--- a/docs/_openbolt_5x/plans.md
+++ b/docs/_openbolt_5x/plans.md
@@ -10,3 +10,10 @@ to do complex task operations, such as running multiple tasks with one command,
 computing values for the input for a task, or running certain tasks based on
 results of another task. You write plans in the Puppet language. And like tasks,
 plans are packaged in modules and can be shared on the Forge.
+
+- [Inspecting plans](inspecting_plans.html) — Determine what effect a plan has on your targets before you run it.
+- [Running plans](bolt_running_plans.html) — Run a plan from the command line or from another plan.
+- [Writing plans in YAML](writing_yaml_plans.html) — Define simple workflows as a list of steps.
+- [Writing plans in the Puppet language](writing_plans.html) — Write plans with the full expressiveness of the Puppet language.
+- [Debugging plans](debugging_plans.html) — Print the result of each plan step to standard output.
+- [Testing plans](testing_plans.html) — Write unit tests for plans with BoltSpec.

--- a/docs/_openbolt_5x/tasks.md
+++ b/docs/_openbolt_5x/tasks.md
@@ -12,3 +12,8 @@ You can write tasks in any programming language that can run on the targets,
 such as Bash, Python, or Ruby. Tasks are packaged within modules, so you can
 reuse, download, and share tasks on the Forge. Task metadata describes the task,
 validates input, and controls how the task runner executes the task.
+
+- [Inspecting tasks](inspecting_tasks.html) — Look up a task's parameters and metadata before you run it.
+- [Running tasks](bolt_running_tasks.html) — Run a task from the command line or from a plan.
+- [Writing tasks](writing_tasks.html) — Package a task with metadata describing its parameters.
+- [Task helpers](task_helpers.html) — Use language-specific libraries to simplify writing tasks.


### PR DESCRIPTION
## Short description

Alternative, smaller fix for #386, posted alongside #387 for comparison.

#387 fixes this by teaching `_includes/nav-item.html` (the shared sidebar template used by every collection) to render a nav entry as both a clickable link and a collapsible group. This PR instead makes no template changes: it adds an "Overview" link as the first child item inside each of the three affected groups (Plans, Tasks, Bolt Examples), matching the pattern the nav data already uses for "Modules". The group header still only expands/collapses; the overview page becomes reachable via the new child link.

Trade-off versus #387: this doesn't make the group header itself clickable (so it doesn't match the original Puppet Bolt docs' click-to-navigate behavior exactly), but it carries zero risk to the shared nav template that every other collection's sidebar depends on.

Also adds a short hand-written list of sub-topics to `plans.md`, `tasks.md`, and `bolt_examples.md` (matching the original Puppet Bolt docs), rather than #387's approach of a generic Liquid include that reverse-looks-up the nav tree and parses rendered HTML to extract each child's intro paragraph. With only three affected pages that change rarely, a static list is simpler and avoids that include's build-order dependent HTML parsing.

Out of scope here (left to #387 or a follow-up): the Bolt-to-OpenBolt branding pass and folding `bolt.md` into `index.md`.
