### PR TITLE
Add unbounded-collector warning to the resource collectors page

### DIFF
--- a/docs/_openvox_8x/lang_collectors.markdown
+++ b/docs/_openvox_8x/lang_collectors.markdown
@@ -55,7 +55,7 @@ A collector with an empty search expression will match **every** resource of the
 
 {% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
 They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
-Using unbounded collectors may result in many unexpected resources being managed and may have catastrophic consequences." %}
+Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes." %}
 
 Parentheses can be used to improve readability and to modify the priority/grouping of `and`/`or`. You can
 create arbitrarily complex expressions using the following four operators:

--- a/docs/_openvox_8x/lang_collectors.markdown
+++ b/docs/_openvox_8x/lang_collectors.markdown
@@ -53,6 +53,10 @@ resembles the normal syntax for [Puppet expressions][expressions], but is not th
 
 A collector with an empty search expression will match **every** resource of the specified resource type.
 
+{% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
+They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
+Using unbounded collectors may result in many unexpected resources being managed and may have catastrophic consequences." %}
+
 Parentheses can be used to improve readability and to modify the priority/grouping of `and`/`or`. You can
 create arbitrarily complex expressions using the following four operators:
 

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -163,7 +163,7 @@ This example applies all internal yum repository resources before applying any i
 
 {% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
 They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
-Using unbounded collectors may result in many unexpected resources being managed and may have catastrophic consequences." %}
+Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes." %}
 
 ### Capturing resource references for generated resources
 


### PR DESCRIPTION
Adds the unbounded-resource-collector warning from `lang_relationships.markdown` (added in #334) to the dedicated collectors page, `lang_collectors.markdown`.

The collectors page already states that "A collector with an empty search expression will match **every** resource of the specified resource type," but only as a neutral fact. Since that page is the natural landing spot for someone looking up collector syntax, it should carry the same caution: unbounded collectors realize every matching virtual resource, including ones declared in third-party modules, which can have unforeseeable consequences like undesired configuration changes.

The warning text is identical to the one on the relationships page, placed directly after the empty-search-expression statement in the Search expressions section. Per review feedback, the closing phrase was reworded from "catastrophic consequences" to "unforeseeable consequences like undesired configuration changes" — applied to the original warning in `lang_relationships.markdown` as well, so the two copies stay identical.

Verified with a local `jekyll build`: the alert renders as a standard warning block on `openvox/latest/lang_collectors.html`.

Closes #389
