### PR TITLE
Add OpenVox training resources page

### DIFF
--- a/_data/nav/ecosystem_8x.yaml
+++ b/_data/nav/ecosystem_8x.yaml
@@ -7,6 +7,8 @@
     link: history.html
   - text: OpenVox Community
     link: community.html
+  - text: Training resources
+    link: training.html
 - text: Getting Started
   items:
   - text: Whirlwind guide

--- a/docs/_ecosystem_8x/training.md
+++ b/docs/_ecosystem_8x/training.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "OpenVox Training Resources"
+---
+
+# OpenVox Training Resources
+
+This page collects community-maintained OpenVox training material.
+These resources are useful for workshops, self-paced learning, and examples, but they are maintained outside the OpenVox documentation site.
+
+## Self-paced courses
+
+* **[Using OpenVox](https://sicuraus.github.io/using-openvox/)** — A self-paced introduction to configuration management with OpenVox.
+  The course covers OpenVox basics, installation, CLI usage, module structure, resources, the Puppet language, Hiera, and hands-on exercises.
+  It is adapted from earlier instructor-led training material and published under the [CC BY-SA 4.0 license](https://creativecommons.org/licenses/by-sa/4.0/).
+
+* **[Advanced OpenVox](https://sicuraus.github.io/advanced-openvox/)** — Advanced module development and testing with OpenVox.
+  The course covers module development tooling, encrypted Hiera data, templates, functions, custom facts, custom types and providers, tasks, plans, and testing.
+  It is adapted from earlier instructor-led training material and published under the [CC BY-SA 4.0 license](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Training repositories
+
+* **[betadots/openvox-training](https://github.com/betadots/openvox-training)** — A GitHub repository for OpenVox training material.
+
+## Contributing Training Material
+
+If you have OpenVox training material to share, open an issue or pull request for this page with a short description, the intended audience, and the license for the material.
+For larger donations or material that should be incorporated into the official documentation, start a discussion in the [OpenVox community channels](./community.html).


### PR DESCRIPTION
## Summary

- add an ecosystem page collecting community OpenVox training resources
- link the new page from the ecosystem navigation
- include guidance for future training material contributions

Closes #391

## Validation

- npx --yes markdownlint-cli2 docs/_ecosystem_8x/training.md
- /Users/michaelharp/.rbenv/versions/3.2.11/bin/bundle exec jekyll build