### PR TITLE
Switch to simpler callout syntax

### DIFF
--- a/docs/_ecosystem_8x/devkit/acceptance_testing.md
+++ b/docs/_ecosystem_8x/devkit/acceptance_testing.md
@@ -107,7 +107,9 @@ A manifest is idempotent when applying it more than once is safe: the first run 
 Idempotency is a core property of well-written Puppet code, and a manifest that keeps making changes on every run is a bug.
 Catching that here is one of the most valuable things an acceptance test does.
 
-{% include alert.html type="note" content="A few modules genuinely need two runs to converge, usually because the first run installs a tool that produces a new fact the second run then acts on. That's the rare exception, not a license to ignore a manifest that never settles; when you hit a real case, relax the second-run check for that one test." %}
+A few modules genuinely need two runs to converge, usually because the first run installs a tool that produces a new fact the second run then acts on.
+That's the rare exception, not a license to ignore a manifest that never settles; when you hit a real case, relax the second-run check for that one test.
+{: .note }
 
 Once the manifest is applied, you assert against the real node using the [`serverspec`](https://serverspec.org/) matchers such as `package`, `service`, and `port`.
 A typical test for a `chrony` class looks like this:
@@ -259,4 +261,6 @@ end
 By default the framework installs your module and its dependencies by resolving `metadata.json`.
 If you'd rather supply them yourself, `configure_beaker(modules: :fixtures)` uses the [fixtures](unit_testing.html) already checked out under `spec/fixtures/modules`, and `configure_beaker(modules: nil)` hands you full control.
 
-{% include alert.html type="tip" content="Acceptance tests are slow and resource-hungry compared to unit tests, so keep them for behavior you genuinely can't verify in a unit test. Reach for them when an OS difference, a real service, or an end-to-end interaction is the thing under test." %}
+Acceptance tests are slow and resource-hungry compared to unit tests, so keep them for behavior you genuinely can't verify in a unit test.
+Reach for them when an OS difference, a real service, or an end-to-end interaction is the thing under test.
+{: .tip }

--- a/docs/_ecosystem_8x/devkit/impact_analysis.md
+++ b/docs/_ecosystem_8x/devkit/impact_analysis.md
@@ -124,7 +124,8 @@ For this we use the [Catalog Diff Viewer](https://github.com/voxpupuli/puppet-ca
 
 ![Catalog Diff Viewer screenshot](diff_viewer.png)
 
-{% include alert.html type="tip" content="You can experiment with the [online demo](http://voxpupuli.org/puppet-catalog-diff-viewer) by selecting the `Demo 1` report from the dropdown menu." %}
+You can experiment with the [online demo](http://voxpupuli.org/puppet-catalog-diff-viewer) by selecting the `Demo 1` report from the dropdown menu.
+{: .tip }
 
 It's shipped as a container, which means that when you have some report files saved into `data/`, then you can simply run the container and then browse the viewer at [http://localhost:8080/](http://localhost:8080/).
 

--- a/docs/_ecosystem_8x/devkit/index.md
+++ b/docs/_ecosystem_8x/devkit/index.md
@@ -13,8 +13,9 @@ This style of operation allows your local testing to run exactly the same as it 
 
 This does expose you more directly to the Ruby ecosystem than you might be used to, but we've done our best to make that as painless as possible.
 
-{% include alert.html type="tip" content="If you're already familiar with maintaining Puppet content and testing and you just want to know how to migrate away from the PDK, you can
-[skip directly to that guide](migrating.html)." %}
+If you're already familiar with maintaining Puppet content and testing and you just want to know how to migrate away from the PDK, you can
+[skip directly to that guide](migrating.html).
+{: .tip }
 
 ## Who Is This For?
 

--- a/docs/_ecosystem_8x/devkit/linting.md
+++ b/docs/_ecosystem_8x/devkit/linting.md
@@ -8,8 +8,9 @@ In the Puppet world, this generally means ensuring that manifests are written to
 but other more specific checks have been added over the years.
 For example, recently [a check was added](https://github.com/voxpupuli/puppet-lint-exec_idempotency-check) to warn if an `exec` resource was written in a way that would never be idempotent.
 
-{% include alert.html type="info" content="It's worth knowing that while linters often indicate problems in the code, they're not always guaranteed to catch all syntax errors.
-Make sure to read about the `puppet_syntax` task." %}
+It's worth knowing that while linters often indicate problems in the code, they're not always guaranteed to catch all syntax errors.
+Make sure to read about the `puppet_syntax` task.
+{: .tip }
 
 The linters included in the Vox Pupuli test suite will validate Puppet manifests, `.erb` and `.epp` template files, module metadata, and Ruby code.
 Some checks can automatically fix the offending bit of code.

--- a/docs/_ecosystem_8x/devkit/migrating.md
+++ b/docs/_ecosystem_8x/devkit/migrating.md
@@ -14,7 +14,8 @@ This means that you'll maintain your own Ruby and Bundler installs, but most oth
 Before running commands in a new module repository, you'll need to run `bundle install`.
 If you get an error about a command not being available, you probably just need to run `bundle install`.
 
-{% include alert.html type="tip" content="There are a few exceptions to this pattern. For example, Jig is an installed package and VoxBox is a Docker container." %}
+There are a few exceptions to this pattern. For example, Jig is an installed package and VoxBox is a Docker container.
+{: .tip }
 
 Jig also contains thin wrappers around the `bundle exec` commands, so in many cases you can use the CLI patterns you're used to typing.
 Because Jig does not attempt to hide the Bundler environment from you, it will still need the module's gems installed (`bundle install`) and ModuleSync configured properly.

--- a/docs/_ecosystem_8x/devkit/publishing.md
+++ b/docs/_ecosystem_8x/devkit/publishing.md
@@ -68,8 +68,8 @@ require 'voxpupuli-release'
 Then you should set up your Forge API token.
 You can use the same token you generated for Jig, or you can create one specifically for these tasks.
 
-{% include alert.html type="tip" title="Pro tip" content="If you're going to use the token in a pipeline,
-you should generate one specifically for it so that you can revoke it if needed without disrupting other work." %}
+If you're going to use the token in a pipeline, you should generate one specifically for it so that you can revoke it if needed without disrupting other work.
+{: .tip }
 
 Add your token to `~/.puppetforge.yml`:
 

--- a/docs/_ecosystem_8x/devkit/setup.md
+++ b/docs/_ecosystem_8x/devkit/setup.md
@@ -20,8 +20,9 @@ sudo gem install bundler
 
 Once you have a working Ruby environment you're ready to start using the Vox Pupuli testing suite!
 
-{% include alert.html type="tip" content="If you'd prefer to run the testing tools via a container runtime like Docker or Podman,
-then check out [Using VoxBox in CI](voxbox.html)." %}
+If you'd prefer to run the testing tools via a container runtime like Docker or Podman,
+then check out [Using VoxBox in CI](voxbox.html).
+{: .tip }
 
 
 ## Installing a devkit component
@@ -184,7 +185,8 @@ If you'd like to explore the possibility, here is a non-exhaustive list of some 
 
 ## 🧩 [advanced] Overriding dependencies
 
-{% include alert.html type="warning" content="This section describes an ecosystem mitigation that is sometimes required, but never recommended if you can avoid it." %}
+This section describes an ecosystem mitigation that is sometimes required, but never recommended if you can avoid it.
+{: .warning }
 
 The Rubygems environment will manage dependencies for you and recursively install all the gems needed by the gems you specify.
 This is very convenient, but it does rely on _all module and gem authors_ to have properly maintained their dependencies.

--- a/docs/_ecosystem_8x/devkit/unit_testing.md
+++ b/docs/_ecosystem_8x/devkit/unit_testing.md
@@ -75,4 +75,5 @@ Writing the actual tests is out of scope of this guide, but you'll find it very 
 You'll find guides to follow on the [RSpec homepage](https://rspec.info), just remember that you don't have to set up the framework with the `rspec --init` command -- it's already done for you!
 
 
-{% include alert.html type="tip" content="The test suite includes a task that will run the linter, syntax checker, and unit tests all at once: `bundle exec rake test`." %}
+The test suite includes a task that will run the linter, syntax checker, and unit tests all at once: `bundle exec rake test`.
+{: .tip }

--- a/docs/_ecosystem_8x/devkit/voxbox.md
+++ b/docs/_ecosystem_8x/devkit/voxbox.md
@@ -80,10 +80,11 @@ lint:puppet:
 Note the Rakefile path: on current images the bundled Rakefile lives at `/opt/voxbox/Rakefile`.
 On older images it lived at `/Rakefile`, so pin to a recent image and use the `/opt/voxbox/Rakefile` path.
 
-{% include alert.html type="warning" content="These examples use the `:latest` tag for brevity, but for reproducible CI you should pin
+These examples use the `:latest` tag for brevity, but for reproducible CI you should pin
 to a specific released version rather than tracking `:latest`, which can change underneath you.
 Just confirm the tag you pin uses the `/opt/voxbox/Rakefile` layout: older images keep the Rakefile at `/Rakefile`.
-Run the container with no arguments (`rake -T`) to list its tasks and check." %}
+Run the container with no arguments (`rake -T`) to list its tasks and check.
+{: .warning }
 
 GitLab can also ingest VoxBox output as native reports.
 For a [code quality report](https://docs.gitlab.com/ci/testing/code_quality/):

--- a/docs/_ecosystem_8x/getting_started/agent-server.md
+++ b/docs/_ecosystem_8x/getting_started/agent-server.md
@@ -23,7 +23,8 @@ Before we dive in, you'll need:
 * Internet connectivity (to reach the package repos)
 * A healthy sense of adventure
 
-{% include alert.html type="tip" title="Pro tip" content="The OpenVox server currently supports only Linux platforms rather than everything that the agent runs on." %}
+The OpenVox server currently supports only Linux platforms rather than everything that the agent runs on.
+{: .tip }
 
 ## Server Installation
 
@@ -116,10 +117,11 @@ Info: Applying configuration version 'openvox-production-719ab13e0a1'
 Notice: Applied catalog in 2.55 seconds
 ```
 
-{% include alert.html type="tip" title="Pro tip" content="The `-t` flag (short for `--test`) runs the agent in test mode with verbose output and detailed reporting.
+The `-t` flag (short for `--test`) runs the agent in test mode with verbose output and detailed reporting.
 For production runs, the agent daemon (managed by systemd) runs automatically every 30 minutes.
 Use `puppet agent -t --noop` for a dry-run that shows what *would* change without actually changing anything.
-This is invaluable for CI/CD pipelines and change reviews." %}
+This is invaluable for CI/CD pipelines and change reviews.
+{: .tip }
 
 This time it should successfully connect, download its (empty) catalog, and apply it.
 You're in business!
@@ -183,9 +185,11 @@ Info: /Stage[main]/Main/Service[puppet]: Unscheduling refresh on Service[puppet]
 Notice: Applied catalog in 2.27 seconds
 ```
 
-{% include alert.html type="tip" title="Pro tip" content="The `-t` or `--test` flag is named this way because in regular use you won't *push* configuration to your agent nodes.
+The `-t` or `--test` flag is named this way because in regular use you won't *push* configuration to your agent nodes.
 You'll just let them retrieve and enforce configuration on their regular schedule.
-The `test` mode lets you interactively observe the results of new configuration you've written." %}
+The `test` mode lets you interactively observe the results of new configuration you've written.
+{: .tip
+}
 
 ## Next Steps
 

--- a/docs/_ecosystem_8x/getting_started/index.md
+++ b/docs/_ecosystem_8x/getting_started/index.md
@@ -27,8 +27,9 @@ Before we dive in, you'll need:
 * Internet connectivity (to reach the package repos)
 * A healthy sense of adventure
 
-{% include alert.html type="tip" title="Pro tip" content="OpenVox supports macOS, Windows, SLES, Amazon Linux, and other platforms.
-This guide focuses on the RHEL/Debian families because that's where most of the action is." %}
+OpenVox supports macOS, Windows, SLES, Amazon Linux, and other platforms.
+This guide focuses on the RHEL/Debian families because that's where most of the action is.
+{: .tip }
 
 
 ## Installation
@@ -41,11 +42,12 @@ The official [Installing OpenVox](https://voxpupuli.org/openvox/install/) guide 
 For this part of the guide, you'll only need to install the OpenVox Agent, but for other use cases you might want other packages.
 See the [platform docs](/openvox/latest/openvox_platform.html) for more information.
 
-{% include alert.html type="tip" title="Pro tip" content="The OpenVox agent installs into `/opt/puppetlabs/`.
+The OpenVox agent installs into `/opt/puppetlabs/`.
 The binary lives at `/opt/puppetlabs/bin/puppet`.
 The installer adds `/opt/puppetlabs/bin` to your `PATH`.
 If you're in a weird shell, source your profile or use the full path.
-For convenience, you can also add `/opt/puppetlabs/puppet/bin` to `PATH` in `/etc/profile.d/puppet.sh` so internal tools like `gem`, `bundle`, and `r10k` are available." %}
+For convenience, you can also add `/opt/puppetlabs/puppet/bin` to `PATH` in `/etc/profile.d/puppet.sh` so internal tools like `gem`, `bundle`, and `r10k` are available."
+{: .tip }
 
 
 ## Your First Manifest
@@ -88,9 +90,10 @@ Notice: OpenVox is now managing this system. Resistance is futile (but also unne
 Notice: Applied catalog in 2.55 seconds
 ```
 
-{% include alert.html type="tip" title="Pro tip" content="Always use `sudo puppet apply` when running manifests that affect system state.
+Always use `sudo puppet apply` when running manifests that affect system state.
 Running as `root` (or via sudo) ensures Puppet can manage all resources, including system packages, services, and protected files.
-For development and testing, you can run as a non-privileged user, but many resource types will fail or behave unexpectedly." %}
+For development and testing, you can run as a non-privileged user, but many resource types will fail or behave unexpectedly.
+{: .tip }
 
 
 ### Verify It Worked

--- a/docs/_ecosystem_8x/history.md
+++ b/docs/_ecosystem_8x/history.md
@@ -11,6 +11,7 @@ A **Puppet Standards Steering Committee** now guides language and feature evolut
 The result: a fully open, community-governed continuation of the platform, with the same DSL, the same Forge, and the same operational patterns you already know.
 Think of OpenVox as Puppet's cooler, community-owned sibling who actually shows up to the family reunion.
 
-{% include alert.html type="tip" title="Key takeaway" content="If you're running open-source Puppet today, OpenVox is a seamless replacement.
+If you're running open-source Puppet today, OpenVox is a seamless replacement.
 Your manifests, modules, Hiera data, and `puppet.conf` don't need to change.
-Swap the packages and you're running OpenVox." %}
+Swap the packages and you're running OpenVox.
+{: .info }

--- a/docs/_ecosystem_8x/index.md
+++ b/docs/_ecosystem_8x/index.md
@@ -16,7 +16,8 @@ Use the same desired state description to manage all your systems, whether they'
 It's complemented with OpenBolt, which lets you orchestrate complex operations across multiple nodes, perform ad-hoc tasks, and trigger immediate actions.
 Many people use both systems together in their infrastructures.
 
-{% include alert.html type="tip" content="Let the computer do the tedious part while you focus on the interesting bits and multiply your own expertise." %}
+Let the computer do the tedious part while you focus on the interesting bits and multiply your own expertise.
+{: .tip }
 
 
 ## Who Is This For?

--- a/docs/_openvox-server_8x/deprecated_features.markdown
+++ b/docs/_openvox-server_8x/deprecated_features.markdown
@@ -249,8 +249,9 @@ The `master.allow-header-cert-info` setting will be ignored completely. Whether 
 Look for `allow-header-cert-info` in the `master` section of your `puppetserver.conf` file. Set `allow-header-cert-info` in the `authorization` section of your `trapperkeeper-authorization` "auth.conf" file to
 the same value, then remove the setting from the `master` section.
 
-{% include alert.html type="warning" content="Only enable `allow-header-cert-info` when OpenVox Server is behind a trusted TLS-terminating proxy that sets these headers.
-If it is enabled when requests can reach OpenVox Server directly, clients can spoof their identity through the headers." %}
+Only enable `allow-header-cert-info` when OpenVox Server is behind a trusted TLS-terminating proxy that sets these headers.
+If it is enabled when requests can reach OpenVox Server directly, clients can spoof their identity through the headers.
+{: .warning }
 
 ### Context
 

--- a/docs/_openvox_8x/hiera_demo.md
+++ b/docs/_openvox_8x/hiera_demo.md
@@ -110,9 +110,10 @@ Notice the resolved path of each layer for the different platforms.
 
 {% endtabs %}
 
-{% include alert.html type="tip" content="Notice that the only layer changing and affecting the resolved values is `os/%{facts.os.family}.yaml`.
+Notice that the only layer changing and affecting the resolved values is `os/%{facts.os.family}.yaml`.
 This is because the only *fact* we are changing is `os.family`.
-Also note that Ubuntu and Debian resolve exactly the same; because they're both `debian` family, they both resolve to the exact same file." %}
+Also note that Ubuntu and Debian resolve exactly the same; because they're both `debian` family, they both resolve to the exact same file.
+{: .tip }
 
 
 ### [Demo] Understand how simultaneous changes in multiple facts change the resolution
@@ -152,5 +153,6 @@ This means that multiple layers are being resolved to a different path as you sw
 
 {% endtabs %}
 
-{% include alert.html type="tip" content="Notice that only the most specific value for each key is resolved.
-Hiera has other more complex ways of defining layers and hierarchies, but they all follow this pattern." %}
+Notice that only the most specific value for each key is resolved.
+Hiera has other more complex ways of defining layers and hierarchies, but they all follow this pattern.
+{: .tip }

--- a/docs/_openvox_8x/lang_collectors.markdown
+++ b/docs/_openvox_8x/lang_collectors.markdown
@@ -53,9 +53,10 @@ resembles the normal syntax for [Puppet expressions][expressions], but is not th
 
 A collector with an empty search expression will match **every** resource of the specified resource type.
 
-{% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
+Do not use unbounded resource collectors without search expressions to limit which resources match.
 They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
-Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes." %}
+Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes.
+{: .warning }
 
 Parentheses can be used to improve readability and to modify the priority/grouping of `and`/`or`. You can
 create arbitrarily complex expressions using the following four operators:

--- a/docs/_openvox_8x/lang_relationships.markdown
+++ b/docs/_openvox_8x/lang_relationships.markdown
@@ -161,9 +161,10 @@ Yumrepo <| tag == 'internal' |> -> Package <| tag == 'internal' |>
 
 This example applies all internal yum repository resources before applying any internal package resources, which protects any packages that rely on custom repositories.
 
-{% include alert.html type="warning" content="Do not use unbounded resource collectors without search expressions to limit which resources match.
+Do not use unbounded resource collectors without search expressions to limit which resources match.
 They have a side effect of _realizing_ any matching virtual resources whether declared in your own code or in third party modules.
-Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes." %}
+Using unbounded collectors may result in many unexpected resources being managed and may have unforeseeable consequences like undesired configuration changes.
+{: .warning }
 
 ### Capturing resource references for generated resources
 

--- a/docs/_openvox_8x/manage_a_service_with_a_module.md
+++ b/docs/_openvox_8x/manage_a_service_with_a_module.md
@@ -32,7 +32,8 @@ puppet module install puppet-chrony
 
 OpenVox downloads the module into your environment's module path, `/etc/puppetlabs/code/environments/production/modules`.
 
-{% include alert.html type="tip" title="Pro tip" content="`puppet module install` resolves and installs a module's dependencies automatically. Run `puppet module list` to see everything that's installed." %}
+`puppet module install` resolves and installs a module's dependencies automatically. Run `puppet module list` to see everything that's installed.
+{: .tip }
 
 ## Step 2: Declare the class
 

--- a/docs/_openvox_8x/modules_publishing.markdown
+++ b/docs/_openvox_8x/modules_publishing.markdown
@@ -49,8 +49,9 @@ However, your module directory on disk must use the short name, without the user
 Module directory names cannot contain dashes or periods; only letters, numbers, and underscores.
 As long as you have the correct long name in your `metadata.json` file, the `puppet module build` command uses the correct names in the correct places.
 
-{% include alert.html type="note" content="Although the  Forge expects to receive modules named `username-module`, its web interface presents them as `username/module`.
-Always use the `username-module` style in your metadata files and when issuing commands." %}
+Although the  Forge expects to receive modules named `username-module`, its web interface presents them as `username/module`.
+Always use the `username-module` style in your metadata files and when issuing commands.
+{: .note }
 
 
 Related topics:
@@ -73,8 +74,9 @@ Before you build your module package for publishing, you'll need to make sure it
 
 To do this, you'll exclude unnecessary files from your package or repository, remove or ignore any symlinks your module contains, and make sure your `metadata.json` contains the correct information.
 
-{% include alert.html type="note" content="In order to successfully publish your module to the Puppet Forge and ensure that everything is rendered correctly, your `README`, license file, changelog, and `metadata.json` must be UTF-8 encoded.
-If you used modern tooling to create your module, these files are already UTF-8 encoded." %}
+In order to successfully publish your module to the Puppet Forge and ensure that everything is rendered correctly, your `README`, license file, changelog, and `metadata.json` must be UTF-8 encoded.
+If you used modern tooling to create your module, these files are already UTF-8 encoded.
+{: .note }
 
 
 ### Excluding files from the package
@@ -114,8 +116,9 @@ If you have both a `.pdkignore` and a `.gitignore` file, the `jig build` command
 Symlinks in modules are unsupported.
 If your module contains symlinks, either remove them or ignore them before you build your module.
 
-{% include alert.html type="warning" content="If you try to build a module package that contains symlinks, you will receive an warning informing you to remove them.
-They will not be included in the module package." %}
+If you try to build a module package that contains symlinks, you will receive an warning informing you to remove them.
+They will not be included in the module package.
+{: .warning }
 
 
 ### Adding module metadata in `metadata.json`
@@ -128,10 +131,11 @@ Check it and make any necessary edits.
 If you assembled your module manually, you must make sure that you have a `metadata.json` file in your module's main directory.
 For details on writing or editing the `metadata.json` file, see the related topic about module metadata.
 
-{% include alert.html type="warning" content="If you maintain very old modules, you might find the metadata stored in a `Modulefile`.
+If you maintain very old modules, you might find the metadata stored in a `Modulefile`.
 Move any metadata contained in the `Modulefile` to `metadata.json`.
 Modulefiles were deprecated in Puppet 3 and removed in Puppet 4.
-They are now treated like any other text file in the root directory of the module." %}
+They are now treated like any other text file in the root directory of the module.
+{: .warning }
 
 Related topics:
 


### PR DESCRIPTION
I discovered a simpler callout syntax. This just uses Kramdown style
block attributes to add a class to a block item (like a paragraph).

The drawback is that you cannot specify a custom title, so when we want
to do that we continue using the full form.

https://jekyll-vitepress.dev/callouts-labels-buttons/#callouts

Signed-off-by: Ben Ford <binford2k@overlookinfratech.com>

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
