### PR TITLE
Document the URI data type

### DIFF
--- a/_data/nav/openvox_8x.yml
+++ b/_data/nav/openvox_8x.yml
@@ -191,6 +191,8 @@
     link: "lang_data_hash.html"
   - text: Regular expressions
     link: "lang_data_regexp.html"
+  - text: URI
+    link: "lang_data_uri.html"
   - text: Sensitive
     link: "lang_data_sensitive.html"
   - text: Undef

--- a/docs/_openvox_8x/lang_data.md
+++ b/docs/_openvox_8x/lang_data.md
@@ -23,6 +23,7 @@ Strings are the most common and useful data type, but you'll also have to work w
 * [Arrays](./lang_data_array.html)
 * [Hashes](./lang_data_hash.html)
 * [Regular Expressions](./lang_data_regexp.html)
+* [URI](./lang_data_uri.html)
 * [Sensitive](./lang_data_sensitive.html)
 * [Undef](./lang_data_undef.html)
 * [Resource References](./lang_data_resource_reference.html)

--- a/docs/_openvox_8x/lang_data_type.md
+++ b/docs/_openvox_8x/lang_data_type.md
@@ -16,6 +16,7 @@ title: "Language: Data types: Data type syntax"
 [array]: ./lang_data_array.html
 [hash]: ./lang_data_hash.html
 [regexp]: ./lang_data_regexp.html
+[uri]: ./lang_data_uri.html
 [undef]: ./lang_data_undef.html
 [default]: ./lang_data_default.html
 [resource_reference]: ./lang_data_resource_reference.html
@@ -148,6 +149,7 @@ These are the "real" data types, which make up the most common values you'll int
 * [`Array`][array]
 * [`Hash`][hash]
 * [`Regexp`][regexp]
+* [`URI`][uri]
 * [`Undef`][undef]
 * [`Default`][default]
 

--- a/docs/_openvox_8x/lang_data_uri.md
+++ b/docs/_openvox_8x/lang_data_uri.md
@@ -1,0 +1,267 @@
+---
+layout: default
+title: "Language: Data types: URI"
+---
+
+[abstract types]: lang_data_abstract.html
+[data type]: lang_data_type.html
+[enum]: lang_data_abstract.html#enum
+[notundef]: lang_data_abstract.html#notundef
+[new function]: function.html#new
+[pattern]: lang_data_abstract.html#pattern
+[strings]: lang_data_string.html
+
+A `URI` value is a parsed uniform resource identifier. It differs from a string that happens to contain a
+URL: a `URI` value knows its own parts, so you can read the scheme, host, or path individually instead of
+picking them apart with a regular expression. When you use `URI` as a data type, you can also constrain
+those parts.
+
+A string is never automatically a URI. It becomes a `URI` value only when you construct one:
+
+```puppet
+notice('https://example.com' =~ URI) # false
+notice(URI('https://example.com') =~ URI) # true
+```
+
+## Syntax
+
+Construct a URI from a string with either the short form `URI(...)` or `URI.new(...)`. Both call the
+[`new` function][new function]:
+
+```puppet
+$docs = URI('https://docs.openvoxproject.org/openvox/latest/')
+$same = URI.new('https://docs.openvoxproject.org/openvox/latest/')
+```
+
+The string can be a full URI, a relative reference such as `/reports/latest`, or an opaque URI such as
+`mailto:ops@example.com`.
+
+### Creating a URI from its parts
+
+You can also pass a hash of parts, which is useful when you assemble a URI from data:
+
+```puppet
+$endpoint = URI({
+  scheme => 'https',
+  host   => 'docs.example.com',
+  path   => '/openvox',
+})
+
+notice($endpoint) # https://docs.example.com/openvox
+```
+
+Every key is optional. `port` takes a non-negative integer; the rest take non-empty strings. The scheme determines how
+OpenVox assembles the result, so `scheme => 'https'` produces an HTTPS URI rather than a generic one.
+
+## Accessing the parts
+
+A `URI` value exposes its parts as members, which you read with dot notation:
+
+| Member     | Description |
+| ---------- | ----------- |
+| `scheme`   | The scheme, such as `https` or `mailto`. |
+| `userinfo` | The user information preceding `@` in the authority, such as `ann:secret`. |
+| `host`     | The host name. |
+| `port`     | The port, as an `Integer`. |
+| `path`     | The path. |
+| `query`    | The query string, without the leading `?`. |
+| `fragment` | The fragment, without the leading `#`. |
+| `opaque`   | The body of an opaque URI, such as the address in a `mailto:` URI. |
+
+For example:
+
+```puppet
+$u = URI('https://ann:secret@example.com:8080/data?fmt=json#top')
+
+notice($u.scheme)   # https
+notice($u.host)     # example.com
+notice($u.port)     # 8080
+notice($u.path)     # /data
+notice($u.query)    # fmt=json
+notice($u.fragment) # top
+```
+
+Parts that the URI does not have are usually `undef`, so a `mailto:` URI has no host and a relative
+reference has no scheme:
+
+```puppet
+notice(URI('mailto:ops@example.com').host =~ Undef) # true
+notice(URI('/just/a/path').scheme =~ Undef) # true
+```
+
+Two parts do not follow that rule. Check them before you write an `Undef` constraint:
+
+- `port` falls back to the registered default port for the scheme when the URI does not state one, so an
+  `https` URI reports `443` and an `http` URI reports `80`. Only `ftp`, `http`, `https`, `ldap`, `ldaps`,
+  `ws`, and `wss` have a registered default. For any other scheme, and for a URI with no scheme at all,
+  `port` is `undef`.
+- `path` is an empty string rather than `undef` when a hierarchical URI omits it. It is `undef` only for
+  an opaque URI such as `mailto:`.
+
+```puppet
+notice(URI('https://example.com').port) # 443
+notice(URI('https://example.com').path =~ Undef) # false, path is ''
+notice(URI('ssh://example.com').port =~ Undef) # true, no default
+notice(URI('/just/a/path').port =~ Undef) # true, no scheme
+```
+
+`port` is an `Integer`, not a string, so you can compare it numerically without converting it first.
+{: .tip }
+
+## Combining URIs
+
+Use the `+` operator to resolve one URI against another. The right operand can be a `URI` or a string,
+and OpenVox applies the usual URI resolution rules: a relative reference resolves against the base, while
+an absolute path or a full URI replaces the corresponding parts.
+
+```puppet
+$base = URI('https://example.com/docs/')
+
+notice($base + 'latest.html') # https://example.com/docs/latest.html
+notice($base + '/other')      # https://example.com/other
+notice($base + URI('/openvox')) # https://example.com/openvox
+```
+
+A trailing slash on the base changes the result, because a base path without one ends in a file rather
+than a directory:
+
+```puppet
+$dir  = URI('https://example.com/docs/')
+$file = URI('https://example.com/docs')
+
+notice($dir + 'latest.html')  # https://example.com/docs/latest.html
+notice($file + 'latest.html') # https://example.com/latest.html
+```
+
+Building URIs this way is safer than string concatenation, which cannot know whether the result needs a
+separator.
+
+## Converting URIs to strings
+
+Interpolate a URI or pass it to `String` to get its string form back:
+
+```puppet
+$u = URI('https://example.com/a')
+
+notice("${u}")      # https://example.com/a
+notice(String($u))  # https://example.com/a
+```
+
+For more about converting between types, see [strings][strings] and the [`new` function][new function].
+
+## The `URI` data type
+
+The [data type][data type] of URI values is `URI`.
+
+By default, `URI` matches any URI value. You can use parameters to restrict which values it matches.
+
+### Parameters
+
+The full signature for `URI` is:
+
+```puppet
+URI[<SPECIFIC URI OR HASH OF CONSTRAINTS>]
+```
+
+This parameter is optional.
+
+| Position | Parameter   | Data Type          | Default Value | Description |
+| -------- | ----------- | ------------------ | ------------- | ----------- |
+| 1        | Constraints | `String` or `Hash` | none          | If specified, restricts the type to URIs whose parts match the given constraints. |
+
+Given a string, `URI` constrains the parts that the string contains. This is not an exact match: parts the
+string leaves out stay unconstrained, so a URI carrying extra parts still matches.
+
+```puppet
+$type = URI['https://example.com/a']
+
+notice(URI('https://example.com/a') =~ $type)     # true
+notice(URI('https://example.com/a?x=1') =~ $type) # true
+notice(URI('https://example.com/b') =~ $type)     # false
+```
+
+Given a hash, `URI` constrains individual parts. The rules differ between the parts that hold strings and
+`port`, which holds an `Integer`:
+
+- The string parts (`scheme`, `userinfo`, `host`, `path`, `query`, `fragment`, and `opaque`) accept a
+  string, a regular expression, an abstract data type such as [`Enum`][enum] or [`Pattern`][pattern], or
+  [`NotUndef`][notundef] and `Undef` to require that the part is present or absent.
+- `port` accepts a non-negative integer, an `Integer` range, `NotUndef`, or `Undef`. Giving it a string
+  or a regular expression is an error, and `Enum` or `Pattern` never match, because the port is an
+  `Integer` rather than a string.
+
+```puppet
+$u = URI('https://example.com:8443/a')
+
+notice($u =~ URI[{scheme => 'https'}]) # true
+notice($u =~ URI[{scheme => Enum['http', 'https']}]) # true
+notice($u =~ URI[{host => /example/}]) # true
+notice($u =~ URI[{host => NotUndef}]) # true
+notice($u =~ URI[{port => Integer[8000, 9000]}]) # true
+notice($u =~ URI[{port => 443}]) # false
+```
+
+The hash form is also how you require a part to be absent, which the string form cannot express:
+
+```puppet
+$strict = URI[{
+  scheme => 'https',
+  host   => 'example.com',
+  path   => '/a',
+  query  => Undef,
+}]
+
+notice(URI('https://example.com/a') =~ $strict)     # true
+notice(URI('https://example.com/a?x=1') =~ $strict) # false
+```
+
+Requiring a part rejects URIs of the wrong shape. An opaque URI has no host, so it fails a `NotUndef`
+host constraint:
+
+```puppet
+$has_host = URI[{host => NotUndef}]
+
+notice(URI('mailto:ops@example.com') =~ $has_host) # false
+```
+
+This makes `URI` useful in class and defined type parameters, where it rejects malformed input before your
+code runs:
+
+```puppet
+class profile::reporting (
+  URI[{scheme => Enum['https'], host => NotUndef}] $endpoint,
+) {
+  $host = $endpoint.host
+  notice("sending reports to ${host}")
+}
+```
+
+### Examples
+
+- `URI` --- matches any URI value.
+- `URI['https://example.com/a']` --- matches URIs whose scheme, host, and path match those of
+  `https://example.com/a`, regardless of any query or fragment.
+- `URI[{scheme => 'https'}]` --- matches any HTTPS URI.
+- `URI[{host => NotUndef}]` --- matches any URI that has a host, rejecting opaque URIs such as
+  `mailto:`.
+- `URI[{port => Integer[8000, 9000]}]` --- matches any URI whose port falls in that range.
+
+### Related data types
+
+`URI` is part of `RichData`, but it is not `Data` and not `Scalar`:
+
+```puppet
+$u = URI('https://example.com')
+
+notice($u =~ RichData) # true
+notice($u =~ Data)     # false
+notice($u =~ Scalar)   # false
+```
+
+That matters when a parameter or function expects `Data`, which covers only the JSON-compatible types.
+
+You can also use [abstract types][abstract types] to match values that might be a URI. For example,
+`Optional[URI]` matches a URI or `undef`, and `Variant[URI, String]` matches a URI or a plain string.
+
+The Puppet language specification describes the `URI` type in
+[types, values, and variables](https://github.com/OpenVoxProject/puppet-specifications/blob/main/language/types_values_variables.md).


### PR DESCRIPTION
## What

The `URI` type has never been documented in this collection. Our language docs were imported from Puppet 5.5, which had no page for it, and upstream still doesn't have one — `help.puppet.com` lists URI in its data type table without a link, unlike nearly every other type. The language specification was the only substantive source anywhere. This was raised by Yury Bushmelev on Slack.

`lang_data_uri` covers:

- **Construction** from a string (`URI(...)` / `URI.new(...)`) or a hash of parts.
- **Member access** — all eight parts via dot notation, with the cases where a missing part is not `undef`.
- **Combining URIs** with the `+` operator, including the trailing-slash trap.
- **Converting to strings.**
- **The `URI` data type** — the string and hash parameter forms, following the structure the other `lang_data` pages use (Syntax → topic sections → the data type with Parameters, Examples, Related data types).

Also adds the page to the nav, the type list in `lang_data`, and the core data types list in `lang_data_type`.

## Verification

Every example is executed and compared against its documented output — **37 documented outputs, 0 mismatches** — rather than reasoned from source. That surfaced three places where the specification or intuition is wrong for OpenVox 8:

- **`port` is an `Integer`, not a string.** The specification says the port is "returned as a string despite internal integer representation". In OpenVox 8.28 arithmetic works on it directly and `=~ Integer` is true.
- **`port` falls back to the scheme's registered default**, so `https://example.com` reports `443`. Only `ftp`, `http`, `https`, `ldap`, `ldaps`, `ws`, and `wss` have one — `ssh://` and unknown schemes give `undef` despite having a scheme.
- **`URI['<string>']` is not an exact match.** It constrains only the parts the string contains, so `https://example.com/a?x=1` matches `URI['https://example.com/a']`. The hash form with `Undef` is the way to require a part is absent.

`port` also accepts an `Integer` range (enforced), while a string or regexp on it is an error, and `Enum`/`Pattern` are accepted but can never match — so the string parts and `port` are documented as separate rules.

## Rendering

Checked in a real browser at 1280px, 768px, and 390px:

- No code block overflows its container (the first draft had 6 of 16 overflowing, up to 947px against a 624px container, while every sibling page had none).
- The page never scrolls horizontally at any width.
- Zero Rouge syntax-highlighter error tokens. Interpolations avoid `${expr}` forms, which the Puppet lexer renders with a red `$`.

Part of #407
