### PR TITLE
Document JSON support in Bolt CLI --targets option

### DIFF
--- a/docs/_openbolt_5x/running_bolt_commands.md
+++ b/docs/_openbolt_5x/running_bolt_commands.md
@@ -175,10 +175,16 @@ Invoke-BoltCommand -Command 'pwd' -Targets '@targets.txt'
 
 > **Note:** In PowerShell, always wrap the file name in single quotes.
 
+The file can also contain a JSON array of target names or a Bolt result
+object with an `items` array where each item has a `target` key.
+
 ### Read targets from stdin
 
 To read a list of targets from stdin, pipe the results from another command to
-Bolt and pass a single dash (`-`) to the `targets` option.
+Bolt and pass a single dash (`-`) to the `targets` option. Stdin accepts
+plain text target lists as well as JSON input. JSON input can be a JSON array
+of target names or a Bolt result object with an `items` array where each item
+has a `target` key.
 
 _\*nix shell command:_
 
@@ -186,7 +192,15 @@ _\*nix shell command:_
 cat targets.txt | bolt command run 'pwd' --targets -
 ```
 
-Reading from stdin is not supported by the PowerShell module.
+Pipe JSON output from a Bolt plan to run a command on the resulting targets:
+
+_\*nix shell command:_
+
+```console
+bolt plan run myplan --format=json | bolt command run 'pwd' -t-
+```
+
+> **Note:** Reading from stdin is not supported by the PowerShell module.
 
 ### Specify targets from the previous command
 


### PR DESCRIPTION
### Short description

This PR documents the change introduced in OpenVoxProject/openbolt#281.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
