### PR TITLE
Document the remaining undocumented data types

### DIFF
--- a/docs/_openvox_8x/lang_data_abstract.md
+++ b/docs/_openvox_8x/lang_data_abstract.md
@@ -12,6 +12,13 @@ title: "Language: Data types: Abstract data types"
 [hashes]: ./lang_data_hash.html
 [hash_missing_key_access]: ./lang_data_hash.html#accessing-values
 [numbers]: ./lang_data_number.html
+[semver]: ./lang_data_semver.html
+[uri]: ./lang_data_uri.html
+[time]: ./lang_data_time.html
+[binary]: ./lang_data_binary.html
+[error]: ./lang_data_error.html
+[sensitive]: ./lang_data_sensitive.html
+[typecasting]: ./lang_typecasting.html
 
 As described in [the Data Type Syntax][types] page, each of Puppet's main [data types][] has a corresponding value that _represents_ that data type, which can be used to match values of that type in several contexts. (For example, `String` or `Array`.)
 
@@ -257,26 +264,66 @@ The `Scalar` data type matches _all_ values of the following concrete data types
 * [Strings][]
 * [Booleans][]
 * [Regular expressions][]
+* [`SemVer` and `SemVerRange`][semver]
+* [`Timestamp` and `Timespan`][time]
 
 Note that it doesn't match `undef`, `default`, resource references, arrays, or hashes.
 
 It takes no parameters.
 
-`Scalar` is equivalent to `Variant[Integer, Float, String, Boolean, Regexp]`.
+### `ScalarData`
+
+The `ScalarData` data type matches the subset of `Scalar` that can be represented directly in JSON:
+
+* [Numbers][] (both integers and floats)
+* [Strings][]
+* [Booleans][]
+
+It doesn't match regular expressions, `SemVer`, `SemVerRange`, `Timestamp`, or `Timespan`, all of which
+`Scalar` does match. Like `Scalar`, it doesn't match `undef` or `default`.
+
+It takes no parameters.
+
+`ScalarData` is to `Scalar` what `Data` is to `RichData`: the JSON-compatible subset.
 
 ### `Data`
 
-The `Data` data type matches any value that would match `Scalar`, but it also matches:
+The `Data` data type matches any value that would match `ScalarData`, but it also matches:
 
 * `undef`
 * [Arrays][] that only contain values that would also match `Data`
-* [Hashes][] whose keys would match `Scalar` and whose values would also match `Data`
+* [Hashes][] whose keys are [strings][] and whose values would also match `Data`
 
-Note that it doesn't match `default` or resource references.
+Note that it is built on `ScalarData` rather than `Scalar`, so the members of `Scalar` that have no JSON
+equivalent are excluded: a regular expression matches `Scalar` but not `Data`. It also doesn't match
+`default` or resource references.
 
 It takes no parameters.
 
 `Data` is especially useful because it represents the subset of types that can be directly represented in almost all serialization formats (e.g. JSON).
+
+### `RichData`
+
+The `RichData` data type matches any value that would match `Data`, and also matches the types that have no
+direct JSON equivalent:
+
+* [Regular expressions][]
+* [`URI`][uri]
+* [`Binary`][binary]
+* [`Timestamp` and `Timespan`][time]
+* [`SemVer` and `SemVerRange`][semver]
+* [`Error`][error]
+* [`Sensitive`][sensitive]
+* Data types themselves, such as `Integer`
+* Resource and class references
+* `default`
+* [Arrays][] and [hashes][] containing any of the above
+
+It takes no parameters.
+
+`RichData` is what a parameter or function should accept when it needs to handle any ordinary Puppet value.
+Use `Data` instead when the value has to survive being serialized to JSON, and note that this is the
+distinction that makes `Error('boom') =~ Data` false while `Error('boom') =~ RichData` is true.
 
 ### `Collection`
 
@@ -285,6 +332,40 @@ The `Collection` type matches _any_ array or hash, regardless of what kinds of v
 Note that this means it only partially overlaps with `Data` --- there are values (like an array of resource references) that match `Collection` but will not match `Data`.
 
 `Collection` is equivalent to `Variant[Array[Any], Hash[Any, Any]]`.
+
+### `Iterable`
+
+The `Iterable` data type matches any value that an iterative function such as `each` or `map` can walk over.
+That includes arrays, hashes, strings, integers, and the `Iterator` values described below:
+
+```puppet
+notice([1, 2] =~ Iterable)  # true
+notice({'a' => 1} =~ Iterable) # true
+notice('abc' =~ Iterable)   # true
+notice(5 =~ Iterable)       # true
+notice(undef =~ Iterable)   # false
+```
+
+An optional parameter constrains what the value iterates over, so `Iterable[Integer]` matches only things
+that yield integers:
+
+```puppet
+notice(5 =~ Iterable[Integer]) # true
+```
+
+### `Iterator`
+
+The `Iterator` data type matches the lazy sequences produced by the chained forms of some iterative
+functions, such as `reverse_each` and `step` called without a block. Every `Iterator` is also `Iterable`,
+but ordinary arrays and hashes are not `Iterator`:
+
+```puppet
+notice([1, 2].reverse_each =~ Iterator) # true
+notice([1, 2] =~ Iterator)              # false
+```
+
+Like `Iterable`, it accepts an optional parameter for the type it yields. You rarely write `Iterator`
+yourself; it matters mainly when a function returns one and you want to constrain what it produces.
 
 ### `Catalogentry`
 
@@ -358,3 +439,46 @@ function example(Variant[Integer, Init[Integer]] $x) {
    $int_value = Integer($x)  # Safe conversion
 }
 ```
+
+See [typecasting][] for the conversions `Init` tests against.
+
+### `Runtime`
+
+The `Runtime` data type matches values that belong to the implementation language underneath Puppet rather
+than to the Puppet language itself. It takes the runtime name and the type name within it:
+
+```puppet
+Runtime['ruby', 'Symbol']
+```
+
+You cannot create such a value in a manifest. The type exists so that Ruby functions and types can describe
+arguments that are Ruby objects with no Puppet equivalent, and so those arguments can be type-checked.
+
+### `Object`
+
+The `Object` data type is the parent of types created with the Pcore object model, which is how modules
+define types that have named attributes and their own methods. An object type is declared by passing a hash
+that names it and lists its attributes:
+
+```puppet
+$greeter = Object[{name => 'Greeter', attributes => {greeting => String}}]
+$g = $greeter.new('hello')
+
+notice($g.greeting)    # hello
+notice($g =~ $greeter) # true
+```
+
+In practice you rarely write this form inline. Modules declare object types in their `types` directory, one
+type per file.
+
+### `TypeSet`
+
+The `TypeSet` data type groups several object types together under one name and version, so a module can
+publish a related family of types rather than a loose collection. A type set records a name, a version, and
+the types it contains.
+
+A module publishes one by declaring it in `types/init_typeset.pp`, which OpenVox loads as the type set named
+after the module. Type sets are not written inline in a manifest.
+
+The type parser accepts any capitalization, so `Typeset` also works, but `TypeSet` is the spelling OpenVox
+itself uses when it renders the type.

--- a/docs/_openvox_8x/lang_data_boolean.md
+++ b/docs/_openvox_8x/lang_data_boolean.md
@@ -33,8 +33,26 @@ If you want to convert other values to booleans with more permissive rules (`0` 
 
 The [data type][] of boolean values is `Boolean`.
 
-It matches only the values `true` or `false`, and accepts no parameters.
+On its own it matches only the values `true` or `false`.
 
+### Parameters
+
+`Boolean` takes an optional parameter that narrows it to one of the two values:
+
+```puppet
+notice(true =~ Boolean[true])   # true
+notice(false =~ Boolean[true])  # false
+notice(false =~ Boolean[false]) # true
+```
+
+This is useful when a parameter must be one specific value rather than either, such as a flag that may only
+ever be switched on:
+
+```puppet
+class example (
+  Boolean[true] $must_be_enabled = true,
+) { }
+```
 
 ### Related data types
 

--- a/docs/_openvox_8x/lang_data_type.md
+++ b/docs/_openvox_8x/lang_data_type.md
@@ -36,6 +36,16 @@ title: "Language: Data types: Data type syntax"
 [catalogentry]: ./lang_data_abstract.html#catalogentry
 [any]: ./lang_data_abstract.html#any
 [callable]: ./lang_data_abstract.html#callable
+[sensitive]: ./lang_data_sensitive.html
+[notundef]: ./lang_data_abstract.html#notundef
+[init]: ./lang_data_abstract.html#init
+[scalardata]: ./lang_data_abstract.html#scalardata
+[richdata]: ./lang_data_abstract.html#richdata
+[iterable]: ./lang_data_abstract.html#iterable
+[iterator]: ./lang_data_abstract.html#iterator
+[runtime]: ./lang_data_abstract.html#runtime
+[object]: ./lang_data_abstract.html#object
+[typeset]: ./lang_data_abstract.html#typeset
 
 Each value in the Puppet language has a data type, like "string." There is also a set of values _whose data type is "data type."_
 
@@ -158,6 +168,7 @@ These are the "real" data types, which make up the most common values you'll int
 * [`Timestamp` and `Timespan`][time]
 * [`SemVer` and `SemVerRange`][semver]
 * [`Error`][error]
+* [`Sensitive`][sensitive]
 * [`Undef`][undef]
 * [`Default`][default]
 
@@ -173,18 +184,27 @@ Resource references and class references are implemented as data types, although
 Abstract data types let you do more sophisticated or permissive type checking.
 
 * [`Scalar`][Scalar]
+* [`ScalarData`][ScalarData]
 * [`Collection`][Collection]
 * [`Variant`][Variant]
 * [`Data`][Data]
+* [`RichData`][RichData]
 * [`Pattern`][Pattern]
 * [`Enum`][Enum]
 * [`Tuple`][Tuple]
 * [`Struct`][Struct]
 * [`Optional`][Optional]
+* [`NotUndef`][NotUndef]
 * [`Catalogentry`][Catalogentry]
 * [`Type`][inpage_type]
 * [`Any`][Any]
 * [`Callable`][Callable]
+* [`Init`][Init]
+* [`Iterable`][Iterable]
+* [`Iterator`][Iterator]
+* [`Runtime`][Runtime]
+* [`Object`][Object]
+* [`TypeSet`][TypeSet]
 
 ## The `Type` data type
 


### PR DESCRIPTION
Closes out the smaller gaps in #407, the ones left over after the six missing data type pages.

### Types that had no documentation anywhere

Added to `lang_data_abstract.md`, each placed with the types it belongs beside rather than in a list at the end:

- `ScalarData` and `RichData` sit next to `Scalar` and `Data`, since the distinction between them is the JSON-compatible subset in both cases
- `Iterable` and `Iterator` are kept adjacent so the subtype relationship between them is visible
- `Runtime`, `Object`, and `TypeSet` go under unusual types, alongside `Callable` and `Init`

`TypeSet` is the spelling OpenVox renders when it prints the type, though the parser accepts any capitalization. The page says so, since upstream docs render it "Typeset". It also names `types/init_typeset.pp` as where a module publishes one, rather than implying a type set is assembled automatically from the `types` directory.

### Index entries

`lang_data_type.md` listed neither the types above nor three that were already documented. Added `Sensitive` to core data types, and `NotUndef`, `Init`, and the seven new types to abstract data types.

### `Boolean` parameters

`lang_data_boolean.md` said `Boolean` "accepts no parameters". That is incorrect: `Boolean[true]` and `Boolean[false]` narrow it to one of the two values. Replaced with a parameters section showing the matches and a class parameter that may only ever be `true`.

### Corrections worth a closer look

Writing the parent type sections turned up three factual errors in the existing text. All three are corrected here, and all three were confirmed by running the cases rather than by reading.

**1. `Scalar` was described as equivalent to `Variant[Integer, Float, String, Boolean, Regexp]`.** It also matches `SemVer`, `SemVerRange`, `Timestamp`, and `Timespan`:

```puppet
$v = Variant[Integer, Float, String, Boolean, Regexp]
notice(SemVer('1.2.3') =~ Scalar)   # true
notice(SemVer('1.2.3') =~ $v)       # false
notice(Timestamp(0) =~ Scalar)      # true
notice(Timestamp(0) =~ $v)          # false
```

`lang_data_semver.md` already contradicted this. I removed the equivalence claim rather than restating it with a longer `Variant`, since the lattice has grown since the 5.5 import and a fixed list will drift again.

**2. `Data` was described as matching any value that would match `Scalar`.** It is built on `ScalarData`, so a regular expression matches `Scalar` but not `Data`:

```puppet
notice(/re/ =~ Scalar) # true
notice(/re/ =~ Data)   # false
```

**3. `Data`'s hashes were described as taking keys that match `Scalar`.** Only string keys are accepted:

```puppet
notice({'s' => 1} =~ Data) # true
notice({1 => 'a'} =~ Data) # false
notice({1 => 'a'} =~ RichData) # true
```

Separately, the `RichData` list omitted several types it matches while `Data` does not: `URI`, regular expressions, and resource and class references. Found by sweeping every candidate type for membership in both rather than spot-checking.

A note for review: Puppet's `<=` on types is not purely extensional, so subtype comparisons alone are misleading here. `Numeric <= Variant[Integer, Float]` is `false` while the reverse is `true`. Every conclusion above rests on value membership tests, not on `<=`.

## Verification

- Every example was run against OpenVox 8.28.1 with `puppet apply`, re-checked in the exact form it appears on the page.
- All 14 candidate types swept for `RichData` and `Data` membership to confirm both lists are complete.
- `Boolean[true]` confirmed to actually enforce, not just match: a class parameter declared `Boolean[true]` with a `false` default is a compile error.
- The `types/init_typeset.pp` claim checked against the OpenVox loader source rather than assumed.
- `markdownlint-cli2` reports no issues on all three files.
- `bundle exec jekyll build` is clean and all nine new anchors resolve in the built HTML.
- Rebased onto `master` now that #424 has merged: `rake test:links` passes across 455 files, including the `lang_typecasting.html` link from the `Init` section.

Content is original prose in the existing `lang_data_*` house style.

Closes #407 — this is the last of the gaps it tracks: the six missing pages are all merged, and the three smaller items are what this PR covers.


