### PR TITLE
Known Issue about resolv and IPv6 in Server 8.15.0

### DIFF
--- a/docs/_openvox-server_8x/release_notes.markdown
+++ b/docs/_openvox-server_8x/release_notes.markdown
@@ -34,6 +34,62 @@ All bug fixes, new features and other changes are provided on the [project's Git
 | [CVE-2026-54517](https://nvd.nist.gov/vuln/detail/CVE-2026-54517) |       5.3      | `pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.5` |
 | [CVE-2026-54514](https://nvd.nist.gov/vuln/detail/CVE-2026-54514) |       5.3      | `pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.21.5` |
 
+### Known Issues in 8.15.0
+
+#### `resolv` times out when `/etc/resolv.conf` contains multiple IPv6 nameservers
+
+The JRuby 9.4.15.0 upgrade included in this release updated the Ruby `resolv`
+library to a newer version. This newer `resolv` version introduced a mis-match
+where queries to IPv6 DNS servers are sent using compressed addresses (e.g.
+`2001:db8::1`), while responses arrive from un-compressed addresses (e.g.
+`2001:db8:0:0:0:0:0:1`). This mis-match means that queries to IPv6 servers
+are never seen as "answered" and the library returns an empty `[]` response
+after waiting for 160 seconds.
+
+This issue only occurs when `/etc/resolv.conf` is configured exclusively with
+two or more IPv6 nameservers. For example:
+
+```console
+# cat /etc/resolv.conf
+# Google Public DNS (IPv6)
+nameserver 2001:4860:4860::8888
+nameserver 2001:4860:4860::8844
+```
+
+This issue will affect modules that use the `Resolv` library to look up
+DNS records, notably: `puppet-dnsquery`.
+
+The following command can be used to test if an OpenVox Server is affected
+by the issue:
+
+```bash
+/opt/puppetlabs/bin/puppetserver ruby -rtimeout -rresolv -e 'Timeout.timeout(10) { puts Resolv::DNS.new.getaddresses("voxpupuli.org") }'
+```
+
+The command will take several seconds to run, as a JVM is launched, but should
+print a list of DNS addresses to STDOUT:
+
+```console
+104.21.84.238
+172.67.198.227
+2606:4700:3035::ac43:c6e3
+2606:4700:3035::6815:54ee
+```
+
+The command will print a `Timeout::Error` if the issue is present:
+
+```bash
+Timeout::Error: execution expired
+  timeout at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/timeout.rb:199
+   <main> at -e:1
+```
+
+See [OpenVoxProject/openvox-server#535][openvox-server-535] for more details
+and subscribe for updates on a fix. Recommended workaround is to downgrade the
+`openvox-server` package to version 8.14.1.
+
+[openvox-server-535]: https://github.com/OpenVoxProject/openvox-server/issues/535
+
 ## OpenVox Server 8.14.1
 
 Released June 24, 2026.
@@ -74,7 +130,7 @@ All bug fixes, new features and other changes are provided on the [project's Git
 | :----------------------------------------------------------------------- | :------------: | :--------------------------------------------------------- |
 | [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) |       N/A      | `pkg:maven/com.fasterxml.jackson.core/jackson-core@2.21.3` |
 
-### Known Issues
+### Known Issues in 8.13.0
 
 #### `jruby-openssl` 0.15.4 Fails to Parse EC Keys
 


### PR DESCRIPTION
### Short description

This commit adds a Known Issue to the OpenVox Server 8.15.0 release notes about the `resolv` library timing out when querying IPv6 DNS servers after the upgrade to JRuby 9.4.15.0.

See: OpenVoxProject/openvox-server#535

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
