### PR TITLE
add known issues for 8.15.1

### DIFF
--- a/docs/_openvox-server_8x/release_notes.markdown
+++ b/docs/_openvox-server_8x/release_notes.markdown
@@ -12,6 +12,14 @@ This is a bug-fix release of OpenVox Server.
 
 All bug fixes, new features and other changes are provided on the [project's GitHub release page](https://github.com/OpenVoxProject/openvox-server/releases/tag/8.15.1).
 
+### Known Issues in 8.15.1
+
+#### Carried over from previous release
+
+The issue with `resolv` timeouts when using multiple IPv6 nameservers is also present
+in this release. See [OpenVox Server 8.15.0 Known Issues](#known-issues-in-8150)
+for details and a workaround.
+
 ## OpenVox Server 8.15.0
 
 {% include alert.html type="note" title="Unreleased" content="Packages for version 8.15.0 were not released due to broken FIPS builds." %}
@@ -39,7 +47,7 @@ All bug fixes, new features and other changes are provided on the [project's Git
 #### `resolv` times out when `/etc/resolv.conf` contains multiple IPv6 nameservers
 
 The JRuby 9.4.15.0 upgrade included in this release updated the Ruby `resolv`
-library to a newer version. This newer `resolv` version introduced a mis-match
+library to a newer version. This newer `resolv` version introduced a mismatch
 where queries to IPv6 DNS servers are sent using compressed addresses (e.g.
 `2001:db8::1`), while responses arrive from un-compressed addresses (e.g.
 `2001:db8:0:0:0:0:0:1`). This mis-match means that queries to IPv6 servers


### PR DESCRIPTION
### Short description
This commit adds a Known Issue to the OpenVox Server 8.15.1 release notes about the `resolv` library timing out when querying IPv6 DNS servers after the upgrade to JRuby 9.4.15.0.

See: OpenVoxProject/openvox-server#535

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
