### PR TITLE
Fix added missing quote to openvox setup docs

### DIFF
--- a/docs/_ecosystem_8x/getting_started/agent-server.md
+++ b/docs/_ecosystem_8x/getting_started/agent-server.md
@@ -160,7 +160,7 @@ node 'agent1.example.com' {
 
 node default {
   notify { 'welcome_message':
-    message => This node is managed by an OpenVox server, but has no configuration defined.',
+    message => 'This node is managed by an OpenVox server, but has no configuration defined.',
   }
 }
 ```


### PR DESCRIPTION
Tiny fix that adds missing quote.
This prevents the following error:

```
root@puppet-client:~# puppet agent -t -v
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: Requesting catalog from puppet-server:8140 (192.168.122.16)
Notice: Catalog compiled by puppet-server
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not parse for environment production: Syntax error at 'node' (file: /etc/puppetlabs/code/environments/production/manifests/site.pp, line: 17, column: 21) on node puppet-client
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
